### PR TITLE
Speed up packfile reading

### DIFF
--- a/formats/packfile/common.go
+++ b/formats/packfile/common.go
@@ -1,6 +1,7 @@
 package packfile
 
 import (
+	"bufio"
 	"fmt"
 	"io"
 )
@@ -8,6 +9,12 @@ import (
 type trackingReader struct {
 	r        io.Reader
 	position int64
+}
+
+func NewTrackingReader(r io.Reader) *trackingReader {
+	return &trackingReader{
+		r: bufio.NewReader(r),
+	}
 }
 
 func (t *trackingReader) Read(p []byte) (n int, err error) {

--- a/formats/packfile/reader.go
+++ b/formats/packfile/reader.go
@@ -59,7 +59,7 @@ func NewReader(r io.Reader) *Reader {
 	return &Reader{
 		MaxObjectsLimit: DefaultMaxObjectsLimit,
 
-		r:       &trackingReader{r: r},
+		r:       NewTrackingReader(r),
 		offsets: make(map[int64]core.Hash, 0),
 	}
 }


### PR DESCRIPTION
By adding a bufio to the trackingReader, otherwise most of the time
is spent in syscalls for small reads to the packfile.