### PR TITLE
Iterable ObjectStorage interface for use in Repository struct

### DIFF
--- a/commit_test.go
+++ b/commit_test.go
@@ -170,8 +170,8 @@ func (s *SuiteCommit) TestFile(c *C) {
 func makeObjectSlice(hashes []string, storage core.ObjectStorage) []core.Object {
 	series := make([]core.Object, 0, len(hashes))
 	for _, member := range hashes {
-		obj, ok := storage.Get(core.NewHash(member))
-		if ok {
+		obj, err := storage.Get(core.NewHash(member))
+		if err == nil {
 			series = append(series, obj)
 		}
 	}

--- a/commit_test.go
+++ b/commit_test.go
@@ -40,11 +40,14 @@ func (s *SuiteCommit) SetUpSuite(c *C) {
 	}
 }
 
+// FIXME: Test the new CommitIter
+/*
 func (s *SuiteCommit) TestIterClose(c *C) {
 	i := &iter{ch: make(chan core.Object, 1)}
 	i.Close()
 	i.Close()
 }
+*/
 
 var fileTests = []struct {
 	repo     string // the repo name as in localRepos

--- a/commit_test.go
+++ b/commit_test.go
@@ -1,6 +1,7 @@
 package git
 
 import (
+	"io"
 	"os"
 
 	"gopkg.in/src-d/go-git.v2/core"
@@ -40,14 +41,74 @@ func (s *SuiteCommit) SetUpSuite(c *C) {
 	}
 }
 
-// FIXME: Test the new CommitIter
-/*
-func (s *SuiteCommit) TestIterClose(c *C) {
-	i := &iter{ch: make(chan core.Object, 1)}
-	i.Close()
-	i.Close()
+var iterTests = []struct {
+	repo    string   // the repo name in the test suite's map of fixtures
+	commits []string // the commit hashes to iterate over in the test
+}{
+	{"https://github.com/tyba/git-fixture.git", []string{
+		"6ecf0ef2c2dffb796033e5a02219af86ec6584e5",
+		"918c48b83bd081e863dbe1b80f8998f058cd8294",
+		"af2d6a6954d532f8ffb47615169c8fdf9d383a1a",
+		"1669dce138d9b841a518c64b10914d88f5e488ea",
+		"35e85108805c84807bc66a02d91535e1e24b38b9",
+		"b029517f6300c2da0f4b651b8642506cd6aaf45d",
+		"a5b8b09e2f8fcb0bb99d3ccb0958157b40890d69",
+		"b029517f6300c2da0f4b651b8642506cd6aaf45d", // Intentional duplicate
+		"b8e471f58bcbca63b07bda20e428190409c2db47",
+		"b029517f6300c2da0f4b651b8642506cd6aaf45d"}}, // Intentional duplicate
 }
-*/
+
+func (s *SuiteCommit) TestIterSlice(c *C) {
+	for i, t := range iterTests {
+		r := s.repos[t.repo]
+		iter := NewCommitIter(r, core.NewObjectSliceIter(makeObjectSlice(t.commits, r.Storage)))
+		s.checkIter(c, r, i, iter, t.commits)
+	}
+}
+
+func (s *SuiteCommit) TestIterLookup(c *C) {
+	for i, t := range iterTests {
+		r := s.repos[t.repo]
+		iter := NewCommitIter(r, core.NewObjectLookupIter(r.Storage, makeHashSlice(t.commits)))
+		s.checkIter(c, r, i, iter, t.commits)
+	}
+}
+
+func (s *SuiteCommit) checkIter(c *C, r *Repository, subtest int, iter *CommitIter, commits []string) {
+	for k := 0; k < len(commits); k++ {
+		commit, err := iter.Next()
+		c.Assert(err, IsNil, Commentf("subtest %d, iter %d, err=%v", subtest, k, err))
+		c.Assert(commit.Hash.String(), Equals, commits[k], Commentf("subtest %d, iter %d, hash=%v, expected=%s", subtest, k, commit.Hash.String(), commits[k]))
+	}
+	_, err := iter.Next()
+	c.Assert(err, Equals, io.EOF)
+}
+
+func (s *SuiteCommit) TestIterSliceClose(c *C) {
+	for i, t := range iterTests {
+		r := s.repos[t.repo]
+		iter := NewCommitIter(r, core.NewObjectSliceIter(makeObjectSlice(t.commits, r.Storage)))
+		s.checkIterClose(c, i, iter)
+	}
+}
+
+func (s *SuiteCommit) TestIterLookupClose(c *C) {
+	for i, t := range iterTests {
+		r := s.repos[t.repo]
+		iter := NewCommitIter(r, core.NewObjectLookupIter(r.Storage, makeHashSlice(t.commits)))
+		s.checkIterClose(c, i, iter)
+	}
+}
+
+func (s *SuiteCommit) checkIterClose(c *C, subtest int, iter *CommitIter) {
+	iter.Close()
+	_, err := iter.Next()
+	c.Assert(err, Equals, io.EOF, Commentf("subtest %d, close 1, err=%v", subtest, err))
+
+	iter.Close()
+	_, err = iter.Next()
+	c.Assert(err, Equals, io.EOF, Commentf("subtest %d, close 2, err=%v", subtest, err))
+}
 
 var fileTests = []struct {
 	repo     string // the repo name as in localRepos
@@ -104,4 +165,23 @@ func (s *SuiteCommit) TestFile(c *C) {
 			c.Assert(file.Hash.String(), Equals, t.blobHash, Commentf("subtest %d, commit=%s, path=%s", i, t.commit, t.path))
 		}
 	}
+}
+
+func makeObjectSlice(hashes []string, storage core.ObjectStorage) []core.Object {
+	series := make([]core.Object, 0, len(hashes))
+	for _, member := range hashes {
+		obj, ok := storage.Get(core.NewHash(member))
+		if ok {
+			series = append(series, obj)
+		}
+	}
+	return series
+}
+
+func makeHashSlice(hashes []string) []core.Hash {
+	series := make([]core.Hash, 0, len(hashes))
+	for _, member := range hashes {
+		series = append(series, core.NewHash(member))
+	}
+	return series
 }

--- a/core/object.go
+++ b/core/object.go
@@ -2,7 +2,12 @@ package core
 
 import (
 	"bytes"
+	"errors"
 	"io"
+)
+
+var (
+	ObjectNotFoundErr = errors.New("object not found")
 )
 
 // Object is a generic representation of any git object
@@ -82,8 +87,9 @@ func NewObjectLookupIter(storage ObjectStorage, series []Hash) *ObjectLookupIter
 }
 
 // Next returns the next object from the iterator. If the iterator has reached
-// the end it will return io.EOF as an error. If the object is retreieved
-// successfully error will be nil.
+// the end it will return io.EOF as an error. If the object can't be found in
+// the object storage, it will return ObjectNotFoundErr as an error. If the
+// object is retreieved successfully error will be nil.
 func (iter *ObjectLookupIter) Next() (Object, error) {
 	if iter.pos >= len(iter.series) {
 		return nil, io.EOF
@@ -93,7 +99,7 @@ func (iter *ObjectLookupIter) Next() (Object, error) {
 	if !ok {
 		// FIXME: Consider making ObjectStorage.Get return an actual error that we
 		//        could pass back here.
-		return nil, io.EOF
+		return nil, ObjectNotFoundErr
 	}
 	iter.pos++
 	return obj, nil

--- a/core/object.go
+++ b/core/object.go
@@ -21,7 +21,7 @@ type ObjectStorage interface {
 	New() Object
 	Set(Object) Hash
 	Get(Hash) (Object, bool)
-	IterType(ObjectType) ObjectIter
+	Iter(ObjectType) ObjectIter
 }
 
 // ObjectType internal object type's
@@ -59,8 +59,13 @@ type ObjectIter interface {
 	Close()
 }
 
-// ObjectLookupIter yields a series of objects by retrieving each one from
-// object storage.
+// ObjectLookupIter implements ObjectIter. It iterates over a series of object
+// hashes and yields their associated objects by retrieving each one from
+// object storage. The retrievals are lazy and only occur when the iterator
+// moves forward with a call to Next().
+//
+// The ObjectLookupIter must be closed with a call to Close() when it is no
+// longer needed.
 type ObjectLookupIter struct {
 	storage ObjectStorage
 	series  []Hash
@@ -99,7 +104,11 @@ func (iter *ObjectLookupIter) Close() {
 	iter.pos = len(iter.series)
 }
 
-// ObjectSliceIter yields a series of objects from a slice of objects.
+// ObjectSliceIter implements ObjectIter. It iterates over a series of objects
+// stored in a slice and yields each one in turn when Next() is called.
+//
+// The ObjectSliceIter must be closed with a call to Close() when it is no
+// longer needed.
 type ObjectSliceIter struct {
 	series []Object
 	pos    int
@@ -189,7 +198,7 @@ func (o *RAWObjectStorage) Get(h Hash) (Object, bool) {
 	return obj, ok
 }
 
-func (o *RAWObjectStorage) IterType(t ObjectType) ObjectIter {
+func (o *RAWObjectStorage) Iter(t ObjectType) ObjectIter {
 	var series []Object
 	switch t {
 	case CommitObject:

--- a/core/object.go
+++ b/core/object.go
@@ -21,7 +21,7 @@ type ObjectStorage interface {
 	New() Object
 	Set(Object) Hash
 	Get(Hash) (Object, bool)
-	Iter(ObjectType) ObjectIter
+	IterType(ObjectType) ObjectIter
 }
 
 // ObjectType internal object type's
@@ -189,7 +189,7 @@ func (o *RAWObjectStorage) Get(h Hash) (Object, bool) {
 	return obj, ok
 }
 
-func (o *RAWObjectStorage) Iter(t ObjectType) ObjectIter {
+func (o *RAWObjectStorage) IterType(t ObjectType) ObjectIter {
 	var series []Object
 	switch t {
 	case CommitObject:

--- a/formats/packfile/reader_test.go
+++ b/formats/packfile/reader_test.go
@@ -102,8 +102,8 @@ func (s *ReaderSuite) testReadPackfileGitFixture(c *C, file string, f Format) {
 func AssertObjects(c *C, s *core.RAWObjectStorage, expects []string) {
 	c.Assert(len(expects), Equals, len(s.Objects))
 	for _, expected := range expects {
-		obtained, ok := s.Get(core.NewHash(expected))
-		c.Assert(ok, Equals, true)
+		obtained, err := s.Get(core.NewHash(expected))
+		c.Assert(err, IsNil)
 		c.Assert(obtained.Hash().String(), Equals, expected)
 	}
 }

--- a/repository.go
+++ b/repository.go
@@ -89,9 +89,12 @@ func (r *Repository) Pull(remoteName, branch string) (err error) {
 
 // Commit return the commit with the given hash
 func (r *Repository) Commit(h core.Hash) (*Commit, error) {
-	obj, ok := r.Storage.Get(h)
-	if !ok {
-		return nil, ObjectNotFoundErr
+	obj, err := r.Storage.Get(h)
+	if err != nil {
+		if err == core.ObjectNotFoundErr {
+			return nil, ObjectNotFoundErr
+		}
+		return nil, err
 	}
 
 	commit := &Commit{r: r}
@@ -105,9 +108,12 @@ func (r *Repository) Commits() *CommitIter {
 
 // Tree return the tree with the given hash
 func (r *Repository) Tree(h core.Hash) (*Tree, error) {
-	obj, ok := r.Storage.Get(h)
-	if !ok {
-		return nil, ObjectNotFoundErr
+	obj, err := r.Storage.Get(h)
+	if err != nil {
+		if err == core.ObjectNotFoundErr {
+			return nil, ObjectNotFoundErr
+		}
+		return nil, err
 	}
 
 	tree := &Tree{r: r}

--- a/repository.go
+++ b/repository.go
@@ -19,7 +19,7 @@ const (
 
 type Repository struct {
 	Remotes map[string]*Remote
-	Storage *core.RAWObjectStorage
+	Storage core.ObjectStorage
 	URL     string
 }
 
@@ -100,15 +100,7 @@ func (r *Repository) Commit(h core.Hash) (*Commit, error) {
 
 // Commits decode the objects into commits
 func (r *Repository) Commits() *CommitIter {
-	i := NewCommitIter(r)
-	go func() {
-		defer i.Close()
-		for _, obj := range r.Storage.Commits {
-			i.Add(obj)
-		}
-	}()
-
-	return i
+	return NewCommitIter(r, r.Storage.Iter(core.CommitObject))
 }
 
 // Tree return the tree with the given hash

--- a/repository.go
+++ b/repository.go
@@ -100,7 +100,7 @@ func (r *Repository) Commit(h core.Hash) (*Commit, error) {
 
 // Commits decode the objects into commits
 func (r *Repository) Commits() *CommitIter {
-	return NewCommitIter(r, r.Storage.IterType(core.CommitObject))
+	return NewCommitIter(r, r.Storage.Iter(core.CommitObject))
 }
 
 // Tree return the tree with the given hash

--- a/repository.go
+++ b/repository.go
@@ -100,7 +100,7 @@ func (r *Repository) Commit(h core.Hash) (*Commit, error) {
 
 // Commits decode the objects into commits
 func (r *Repository) Commits() *CommitIter {
-	return NewCommitIter(r, r.Storage.Iter(core.CommitObject))
+	return NewCommitIter(r, r.Storage.IterType(core.CommitObject))
 }
 
 // Tree return the tree with the given hash

--- a/tree.go
+++ b/tree.go
@@ -187,19 +187,20 @@ func (t *Tree) Decode(o core.Object) error {
 }
 
 type TreeIter struct {
-	iter
+	core.ObjectIter
+	r *Repository
 }
 
-func NewTreeIter(r *Repository) *TreeIter {
-	return &TreeIter{newIter(r)}
+func NewTreeIter(r *Repository, iter core.ObjectIter) *TreeIter {
+	return &TreeIter{iter, r}
 }
 
-func (i *TreeIter) Next() (*Tree, error) {
-	obj := <-i.ch
-	if obj == nil {
-		return nil, io.EOF
+func (iter *TreeIter) Next() (*Tree, error) {
+	obj, err := iter.ObjectIter.Next()
+	if err != nil {
+		return nil, err
 	}
 
-	tree := &Tree{r: i.r}
+	tree := &Tree{r: iter.r}
 	return tree, tree.Decode(obj)
 }


### PR DESCRIPTION
The current implementation of the Repository struct includes a [pointer to core.RAWObjectStorage](https://github.com/src-d/go-git/blob/e9164d853bed12ed9f6787a608db32504c894a64/repository.go#L22). This seems inappropriate because it prevents the development of alternative implementations of [ObjectStorage](https://github.com/src-d/go-git/blob/e9164d853bed12ed9f6787a608db32504c894a64/core/object.go#L20). I presume that the direct reference was included because it provided convenient and fast access to the commit objects.

This pull request proposes the addition of one function to the ObjectStorage interface: [IterType](https://github.com/scjalliance/go-git/blob/4172d931089d9851614217df7c8f57693587399e/core/object.go#L24). This function returns an iterator of objects matching the given object type. The Repository is modified to make use of this new function, and RAWObjectStorage is modified to provide it.

The return value of IterType is a new interface called [ObjectIter](https://github.com/scjalliance/go-git/blob/4172d931089d9851614217df7c8f57693587399e/core/object.go#L57). Two implementations of ObjectIter are provided:

* ObjectLookupIter, which iterates over a slice of object hashes and looks up the given objects as needed. This is used to iterate through parent commits, for example.
* ObjectSliceIter, which iterates over a slice of objects.

Additional implementations could easily be added.

Both CommitIter and TreeIter are modified to make use of the new ObjectIter interface, as is Commit.Parents(). Note that this does away with the previous channel-based iterators.

The proposed [implementation of RAWObjectStorage.IterType](https://github.com/scjalliance/go-git/blob/4172d931089d9851614217df7c8f57693587399e/core/object.go#L192) simply flattens the map of the requested type into a slice on the fly. This is probably fine for small to medium repositories, but *might* cause trouble for large repositories or if it's called frequently. Further optimization should be done as warranted.

Note that this pull request **modifies several public types**. As such it should probably be considered breaking for v2; it may be more appropriate to pull this instead into a v3 branch. I expect that other breaking changes will be needed to meet the needs of #19, and I suspect that all such work should be carried out in a branch until it's ready to be rolled out formally as v3. Feedback on this is most welcome.