### PR TITLE
File paths will now be consistent across platforms

### DIFF
--- a/tree.go
+++ b/tree.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	"io"
 	"os"
-	"path/filepath"
+	"path"
 	"strconv"
 	"strings"
 
@@ -138,14 +138,14 @@ func (t *Tree) walkEntries(base string, ch chan *File) {
 		if obj.Type() == core.TreeObject {
 			tree := &Tree{r: t.r}
 			tree.Decode(obj)
-			tree.walkEntries(filepath.Join(base, entry.Name), ch)
+			tree.walkEntries(path.Join(base, entry.Name), ch)
 			continue
 		}
 
 		blob := &Blob{}
 		blob.Decode(obj)
 
-		ch <- &File{Name: filepath.Join(base, entry.Name), Reader: blob.Reader(), Hash: entry.Hash}
+		ch <- &File{Name: path.Join(base, entry.Name), Reader: blob.Reader(), Hash: entry.Hash}
 	}
 }
 


### PR DESCRIPTION
Previously go-git used filepath.Join when walking tree structures and constructing paths, but its results are platform-dependent as it will return different results on different systems. For example, it will use backslashes as a path separator on Windows. As a result the SuiteTree.TestFiles test was failing on Windows because the returned paths didn't match what was expected.

filepath.Join has been changed to path.Join, which will return consistent results for all platforms. This change makes it so that go-git will always return paths with forward-slash delimiters.

Users of the library should convert the resulting file paths into platform-compatible paths when necessary.