### PR TITLE
Added Object interface for Commit, Tree, Blob and Tag

### DIFF
--- a/commit.go
+++ b/commit.go
@@ -43,13 +43,28 @@ func (c *Commit) NumParents() int {
 }
 
 // File returns the file with the specified "path" in the commit and a
-// nil error if the file exists. If the file does not exists, it returns
+// nil error if the file exists. If the file does not exist, it returns
 // a nil file and the ErrFileNotFound error.
 func (c *Commit) File(path string) (file *File, err error) {
 	return c.Tree().File(path)
 }
 
-// Decode transform an core.Object into a Blob struct
+// ID returns the object ID of the commit. The returned value will always match
+// the current value of Commit.Hash.
+//
+// ID is present to fufill the Object interface.
+func (c *Commit) ID() core.Hash {
+	return c.Hash
+}
+
+// Type returns the type of object. It always returns core.CommitObject.
+//
+// Type is present to fufill the Object interface.
+func (c *Commit) Type() core.ObjectType {
+	return core.CommitObject
+}
+
+// Decode transforms a core.Object into a Commit struct.
 func (c *Commit) Decode(o core.Object) (err error) {
 	if o.Type() != core.CommitObject {
 		return ErrUnsupportedObject
@@ -107,15 +122,22 @@ func (c *Commit) String() string {
 	)
 }
 
+// CommitIter provides an iterator for a set of commits.
 type CommitIter struct {
 	core.ObjectIter
 	r *Repository
 }
 
+// NewCommitIter returns a CommitIter for the given repository and underlying
+// object iterator.
+//
+// The returned CommitIter will automatically skip over non-commit objects.
 func NewCommitIter(r *Repository, iter core.ObjectIter) *CommitIter {
 	return &CommitIter{iter, r}
 }
 
+// Next moves the iterator to the next commit and returns a pointer to it. If it
+// has reached the end of the set it will return io.EOF.
 func (iter *CommitIter) Next() (*Commit, error) {
 	obj, err := iter.ObjectIter.Next()
 	if err != nil {

--- a/commit_test.go
+++ b/commit_test.go
@@ -2,10 +2,8 @@ package git
 
 import (
 	"io"
-	"os"
 
 	"gopkg.in/src-d/go-git.v3/core"
-	"gopkg.in/src-d/go-git.v3/formats/packfile"
 
 	. "gopkg.in/check.v1"
 )
@@ -18,27 +16,10 @@ var _ = Suite(&SuiteCommit{})
 
 // create the repositories of the fixtures
 func (s *SuiteCommit) SetUpSuite(c *C) {
-	fixtureRepos := [...]struct {
-		url      string
-		packfile string
-	}{
+	commitFixtures := []packedFixture{
 		{"https://github.com/tyba/git-fixture.git", "formats/packfile/fixtures/git-fixture.ofs-delta"},
 	}
-	s.repos = make(map[string]*Repository, 0)
-	for _, fixRepo := range fixtureRepos {
-		s.repos[fixRepo.url] = NewPlainRepository()
-
-		d, err := os.Open(fixRepo.packfile)
-		c.Assert(err, IsNil)
-
-		r := packfile.NewReader(d)
-		r.Format = packfile.OFSDeltaFormat // TODO: how to know the format of a pack file ahead of time?
-
-		_, err = r.Read(s.repos[fixRepo.url].Storage)
-		c.Assert(err, IsNil)
-
-		c.Assert(d.Close(), IsNil)
-	}
+	s.repos = unpackFixtures(c, commitFixtures)
 }
 
 var commitIterTests = []struct {

--- a/file.go
+++ b/file.go
@@ -3,8 +3,6 @@ package git
 import (
 	"bytes"
 	"strings"
-
-	"gopkg.in/src-d/go-git.v3/core"
 )
 
 // File represents git file objects.
@@ -64,15 +62,9 @@ func (iter *FileIter) Next() (*File, error) {
 			return nil, err
 		}
 
-		if obj.Type() != core.BlobObject {
-			// Skip non-blob objects
-			continue
+		if blob, ok := obj.(*Blob); ok {
+			return newFile(name, blob), nil
 		}
-
-		blob := &Blob{}
-		blob.Decode(obj)
-
-		return newFile(name, blob), nil
 	}
 }
 

--- a/objects_test.go
+++ b/objects_test.go
@@ -29,6 +29,7 @@ func (s *ObjectsSuite) TestNewCommit(c *C) {
 	commit, err := s.r.Commit(hash)
 	c.Assert(err, IsNil)
 
+	c.Assert(commit.Hash, Equals, commit.ID())
 	c.Assert(commit.Hash.String(), Equals, "a5b8b09e2f8fcb0bb99d3ccb0958157b40890d69")
 	c.Assert(commit.Tree().Hash.String(), Equals, "c2d30fa8ef288618f65f6eed6e168e0d514886f4")
 

--- a/tree.go
+++ b/tree.go
@@ -127,6 +127,19 @@ func (t *Tree) Files() *FileIter {
 	return NewFileIter(t.r, t)
 }
 
+// ID returns the object ID of the tree. The returned value will always match
+// the current value of Tree.Hash.
+//
+// ID is present to fufill the Object interface.
+func (t *Tree) ID() core.Hash {
+	return t.Hash
+}
+
+// Type returns the type of object. It always returns core.TreeObject.
+func (t *Tree) Type() core.ObjectType {
+	return core.TreeObject
+}
+
 // Decode transform an core.Object into a Tree struct
 func (t *Tree) Decode(o core.Object) (err error) {
 	if o.Type() != core.TreeObject {
@@ -229,12 +242,9 @@ func (iter *TreeIter) Next() (*Tree, error) {
 			return nil, err
 		}
 
-		if obj.Type() != core.TreeObject {
-			// Skip non-tree objects
-			continue
+		if tree, ok := obj.(*Tree); ok {
+			return tree, nil
 		}
-
-		return iter.w.Tree(), nil
 	}
 }
 

--- a/tree_walker_test.go
+++ b/tree_walker_test.go
@@ -6,10 +6,81 @@ import (
 	"strconv"
 
 	"gopkg.in/src-d/go-git.v3/core"
-	"gopkg.in/src-d/go-git.v3/formats/packfile"
 
 	. "gopkg.in/check.v1"
 )
+
+type expectedTreeWalkerEntry struct {
+	Kind core.ObjectType
+	Mode string
+	Name string
+	Hash string
+}
+
+var treeWalkerFixtures = []packedFixture{
+	{"https://github.com/alcortesm/binary-relations.git", "formats/packfile/fixtures/alcortesm-binary-relations.pack"},
+	{"https://github.com/Tribler/dispersy.git", "formats/packfile/fixtures/tribler-dispersy.pack"},
+}
+
+var treeWalkerTests = []struct {
+	repo   string                    // the repo name as in localRepos
+	commit string                    // the commit to search for the file
+	objs   []expectedTreeWalkerEntry // the expected objects in the commit
+}{
+	// https://api.github.com/repos/alcortesm/binary-relations/git/trees/b373f85fa2594d7dcd9989f4a5858a81647fb8ea
+	{"https://github.com/alcortesm/binary-relations.git", "b373f85fa2594d7dcd9989f4a5858a81647fb8ea", []expectedTreeWalkerEntry{
+		{core.BlobObject, "100644", ".gitignore", "7f41905b4d77ab4a9a2d334fcd0fb5db6e8e2183"},
+		{core.BlobObject, "100644", "Makefile", "d441e4e769b53cbd4b1215a1387f8c3108bac97d"},
+		{core.BlobObject, "100644", "binary-relations.tex", "cb50b067cc8cd9f639611d41416575c991ad8e97"},
+		{core.TreeObject, "040000", "imgs-gen", "b33007b7e83a738576c3f44369fe2f674bb23d5d"},
+		{core.TreeObject, "040000", "imgs-gen/simple-graph", "056633542b8ee990d6c89b7a812209dba13d6766"},
+		{core.BlobObject, "100644", "imgs-gen/simple-graph/Makefile", "49560402c1707f29c159ad14f369027250fb154a"},
+		{core.BlobObject, "100644", "imgs-gen/simple-graph/fig.fig", "2c414eb36f0c2e9a2f9c6382d85e63355752170c"},
+		{core.TreeObject, "040000", "src", "ec9d27c4df99caec3a817e9c018812a6c56c1b00"},
+		{core.TreeObject, "040000", "src/map-slice", "00cefb8e77f7a8c61b99dd2491ff48a3b0b16679"},
+		{core.BlobObject, "100644", "src/map-slice/map-slice.go", "12431e98381dd5097e1a19fe53429c72ef1f328e"},
+		{core.TreeObject, "040000", "src/simple-arrays", "9a3781b7fd9d2851e2a4488c035ed9ac905aec79"},
+		{core.BlobObject, "100644", "src/simple-arrays/simple-arrays.go", "104fbb4b0520c192f2e207a2dfd39162f6cdabf7"},
+	}},
+	// https://api.github.com/repos/Tribler/dispersy/git/trees/f5a1fca709f760bf75a7adaa480bf0f0e1a547ee
+	{"https://github.com/Tribler/dispersy.git", "f5a1fca709f760bf75a7adaa480bf0f0e1a547ee", []expectedTreeWalkerEntry{
+		{core.BlobObject, "100644", "__init__.py", "e69de29bb2d1d6434b8b29ae775ad8c2e48c5391"},
+		{core.BlobObject, "100644", "authentication.py", "ca2fb017dce4506c4144ba81d3cbb70563487718"},
+		{core.BlobObject, "100644", "bloomfilter.py", "944e8ccc76779aad923f88f4a73b0d4e8999b6ea"},
+		{core.BlobObject, "100644", "bootstrap.py", "379a4400b992310f54ea56a4691760bdea8b1592"},
+		{core.BlobObject, "100644", "cache.py", "744d48dce50703e7d4ff14531ab2ab77e6b54685"},
+		{core.BlobObject, "100644", "callback.py", "f3a380cbe9eb1c02fb305f2bd2fc0fcfb103892f"},
+		{core.BlobObject, "100644", "candidate.py", "87309a51d3681bf6c46b22ce044dad41c97d32d2"},
+		{core.BlobObject, "100644", "community.py", "38226ffc2139a2349edaf016747d02b199508d41"},
+		{core.BlobObject, "100644", "conversion.py", "4e2fcefba40d99c2a6237768ed0fbb8e2e770c83"},
+		{core.BlobObject, "100644", "crypto.py", "8a6bb00df982fa806ce18838673ab1ef3fd52fed"},
+		{core.BlobObject, "100644", "database.py", "bb484bfd31a92f7775dbd3acf8740abf00bb3d74"},
+		{core.BlobObject, "100644", "debug.py", "3743f20d321f7b2b6d3b47211f93317818c3673e"},
+		{core.BlobObject, "100644", "debugcommunity.py", "1598ec5a773cc561430c5bb9b87157ef7d3e1c7c"},
+		{core.BlobObject, "100644", "decorator.py", "a1e913e674aec5402cc7b4e9fc0801e8155d2cec"},
+		{core.BlobObject, "100644", "destination.py", "d5c02588117d260e728d5c64aba885522ba508c5"},
+		{core.BlobObject, "100644", "dispersy.py", "63a08602e2ac8294b20543f0c89c75c740bf6c1c"},
+		{core.BlobObject, "100644", "dispersydatabase.py", "76dd222444c308c470efabde7ed511825004b4d3"},
+		{core.BlobObject, "100644", "distribution.py", "55a11beca7c09013f5b8ff46baa85b15948c756a"},
+		{core.BlobObject, "100644", "dprint.py", "fd6a8608d62bf415a65e78c9e1ca8df97513e598"},
+		{core.BlobObject, "100644", "encoding.py", "f29b0ebf65f06a0aa7b2ff1aea364f7889c58d56"},
+		{core.BlobObject, "100644", "endpoint.py", "5aa76efd3501de522dbdf2e6374440cf64131423"},
+		{core.BlobObject, "100644", "member.py", "c114c73f710b4c291305e353b4aa0106fafabd52"},
+		{core.BlobObject, "100644", "message.py", "e55bfe0efa851c4e94264dc745141f7f65b1d239"},
+		{core.BlobObject, "100644", "meta.py", "0f62db0fb93326daad6b4925a7d12155a1687f67"},
+		{core.BlobObject, "100644", "payload.py", "0aef13194c51dab3624665340b33dd4040516c86"},
+		{core.BlobObject, "100644", "requestcache.py", "7772c7d81b4b205970cac1a3cdabc2c2deb48b12"},
+		{core.BlobObject, "100644", "resolution.py", "525d6ec81c1fb098d2fe12ae0d5b10a368bfcace"},
+		{core.BlobObject, "100644", "script.py", "ef64e12cc1a4c0b3a5d42ff1b33adef202f30da3"},
+		{core.BlobObject, "100644", "singleton.py", "34662093edf45bbffa91125c13735e37410a185b"},
+		{core.BlobObject, "100644", "timeline.py", "826bb5e1802fb5eaf3144a9a195a994920101880"},
+		{core.TreeObject, "040000", "tool", "da97281af01b5b2dad1de6c84c5acb44da60ef7a"},
+		{core.BlobObject, "100644", "tool/__init__.py", "e69de29bb2d1d6434b8b29ae775ad8c2e48c5391"},
+		{core.BlobObject, "100644", "tool/callbackscript.py", "eb9f8184ef08d9e031936e61bfa86fb9b45b965c"},
+		{core.BlobObject, "100644", "tool/scenarioscript.py", "245c41af66aab8f0a6fd00259b30a47f4d6c00dd"},
+	}},
+	{"https://github.com/Tribler/dispersy.git", "9d38ff85ca03adcf68dc14f5b68b8994f15229f4", []expectedTreeWalkerEntry(nil)},
+}
 
 type SuiteTreeWalker struct {
 	repos map[string]*Repository
@@ -19,97 +90,11 @@ var _ = Suite(&SuiteTreeWalker{})
 
 // create the repositories of the fixtures
 func (s *SuiteTreeWalker) SetUpSuite(c *C) {
-	fixtureRepos := [...]struct {
-		url      string
-		packfile string
-	}{
-		{"https://github.com/alcortesm/binary-relations.git", "formats/packfile/fixtures/alcortesm-binary-relations.pack"},
-		{"https://github.com/Tribler/dispersy.git", "formats/packfile/fixtures/tribler-dispersy.pack"},
-	}
-	s.repos = make(map[string]*Repository, 0)
-	for _, fixRepo := range fixtureRepos {
-		s.repos[fixRepo.url] = NewPlainRepository()
-
-		d, err := os.Open(fixRepo.packfile)
-		c.Assert(err, IsNil)
-
-		r := packfile.NewReader(d)
-		r.Format = packfile.OFSDeltaFormat // TODO: how to know the format of a pack file ahead of time?
-
-		_, err = r.Read(s.repos[fixRepo.url].Storage)
-		c.Assert(err, IsNil)
-
-		c.Assert(d.Close(), IsNil)
-	}
-}
-
-type treeWalkerExpectedEntry struct {
-	Kind core.ObjectType
-	Mode string
-	Name string
-	Hash string
+	s.repos = unpackFixtures(c, treeWalkerFixtures)
 }
 
 func (s *SuiteTreeWalker) TestNext(c *C) {
-	for i, t := range []struct {
-		repo   string                    // the repo name as in localRepos
-		commit string                    // the commit to search for the file
-		objs   []treeWalkerExpectedEntry // the expected objects in the commit
-	}{
-		// https://api.github.com/repos/alcortesm/binary-relations/git/trees/b373f85fa2594d7dcd9989f4a5858a81647fb8ea
-		{"https://github.com/alcortesm/binary-relations.git", "b373f85fa2594d7dcd9989f4a5858a81647fb8ea", []treeWalkerExpectedEntry{
-			{core.BlobObject, "100644", ".gitignore", "7f41905b4d77ab4a9a2d334fcd0fb5db6e8e2183"},
-			{core.BlobObject, "100644", "Makefile", "d441e4e769b53cbd4b1215a1387f8c3108bac97d"},
-			{core.BlobObject, "100644", "binary-relations.tex", "cb50b067cc8cd9f639611d41416575c991ad8e97"},
-			{core.TreeObject, "040000", "imgs-gen", "b33007b7e83a738576c3f44369fe2f674bb23d5d"},
-			{core.TreeObject, "040000", "imgs-gen/simple-graph", "056633542b8ee990d6c89b7a812209dba13d6766"},
-			{core.BlobObject, "100644", "imgs-gen/simple-graph/Makefile", "49560402c1707f29c159ad14f369027250fb154a"},
-			{core.BlobObject, "100644", "imgs-gen/simple-graph/fig.fig", "2c414eb36f0c2e9a2f9c6382d85e63355752170c"},
-			{core.TreeObject, "040000", "src", "ec9d27c4df99caec3a817e9c018812a6c56c1b00"},
-			{core.TreeObject, "040000", "src/map-slice", "00cefb8e77f7a8c61b99dd2491ff48a3b0b16679"},
-			{core.BlobObject, "100644", "src/map-slice/map-slice.go", "12431e98381dd5097e1a19fe53429c72ef1f328e"},
-			{core.TreeObject, "040000", "src/simple-arrays", "9a3781b7fd9d2851e2a4488c035ed9ac905aec79"},
-			{core.BlobObject, "100644", "src/simple-arrays/simple-arrays.go", "104fbb4b0520c192f2e207a2dfd39162f6cdabf7"},
-		}},
-		// https://api.github.com/repos/Tribler/dispersy/git/trees/f5a1fca709f760bf75a7adaa480bf0f0e1a547ee
-		{"https://github.com/Tribler/dispersy.git", "f5a1fca709f760bf75a7adaa480bf0f0e1a547ee", []treeWalkerExpectedEntry{
-			{core.BlobObject, "100644", "__init__.py", "e69de29bb2d1d6434b8b29ae775ad8c2e48c5391"},
-			{core.BlobObject, "100644", "authentication.py", "ca2fb017dce4506c4144ba81d3cbb70563487718"},
-			{core.BlobObject, "100644", "bloomfilter.py", "944e8ccc76779aad923f88f4a73b0d4e8999b6ea"},
-			{core.BlobObject, "100644", "bootstrap.py", "379a4400b992310f54ea56a4691760bdea8b1592"},
-			{core.BlobObject, "100644", "cache.py", "744d48dce50703e7d4ff14531ab2ab77e6b54685"},
-			{core.BlobObject, "100644", "callback.py", "f3a380cbe9eb1c02fb305f2bd2fc0fcfb103892f"},
-			{core.BlobObject, "100644", "candidate.py", "87309a51d3681bf6c46b22ce044dad41c97d32d2"},
-			{core.BlobObject, "100644", "community.py", "38226ffc2139a2349edaf016747d02b199508d41"},
-			{core.BlobObject, "100644", "conversion.py", "4e2fcefba40d99c2a6237768ed0fbb8e2e770c83"},
-			{core.BlobObject, "100644", "crypto.py", "8a6bb00df982fa806ce18838673ab1ef3fd52fed"},
-			{core.BlobObject, "100644", "database.py", "bb484bfd31a92f7775dbd3acf8740abf00bb3d74"},
-			{core.BlobObject, "100644", "debug.py", "3743f20d321f7b2b6d3b47211f93317818c3673e"},
-			{core.BlobObject, "100644", "debugcommunity.py", "1598ec5a773cc561430c5bb9b87157ef7d3e1c7c"},
-			{core.BlobObject, "100644", "decorator.py", "a1e913e674aec5402cc7b4e9fc0801e8155d2cec"},
-			{core.BlobObject, "100644", "destination.py", "d5c02588117d260e728d5c64aba885522ba508c5"},
-			{core.BlobObject, "100644", "dispersy.py", "63a08602e2ac8294b20543f0c89c75c740bf6c1c"},
-			{core.BlobObject, "100644", "dispersydatabase.py", "76dd222444c308c470efabde7ed511825004b4d3"},
-			{core.BlobObject, "100644", "distribution.py", "55a11beca7c09013f5b8ff46baa85b15948c756a"},
-			{core.BlobObject, "100644", "dprint.py", "fd6a8608d62bf415a65e78c9e1ca8df97513e598"},
-			{core.BlobObject, "100644", "encoding.py", "f29b0ebf65f06a0aa7b2ff1aea364f7889c58d56"},
-			{core.BlobObject, "100644", "endpoint.py", "5aa76efd3501de522dbdf2e6374440cf64131423"},
-			{core.BlobObject, "100644", "member.py", "c114c73f710b4c291305e353b4aa0106fafabd52"},
-			{core.BlobObject, "100644", "message.py", "e55bfe0efa851c4e94264dc745141f7f65b1d239"},
-			{core.BlobObject, "100644", "meta.py", "0f62db0fb93326daad6b4925a7d12155a1687f67"},
-			{core.BlobObject, "100644", "payload.py", "0aef13194c51dab3624665340b33dd4040516c86"},
-			{core.BlobObject, "100644", "requestcache.py", "7772c7d81b4b205970cac1a3cdabc2c2deb48b12"},
-			{core.BlobObject, "100644", "resolution.py", "525d6ec81c1fb098d2fe12ae0d5b10a368bfcace"},
-			{core.BlobObject, "100644", "script.py", "ef64e12cc1a4c0b3a5d42ff1b33adef202f30da3"},
-			{core.BlobObject, "100644", "singleton.py", "34662093edf45bbffa91125c13735e37410a185b"},
-			{core.BlobObject, "100644", "timeline.py", "826bb5e1802fb5eaf3144a9a195a994920101880"},
-			{core.TreeObject, "040000", "tool", "da97281af01b5b2dad1de6c84c5acb44da60ef7a"},
-			{core.BlobObject, "100644", "tool/__init__.py", "e69de29bb2d1d6434b8b29ae775ad8c2e48c5391"},
-			{core.BlobObject, "100644", "tool/callbackscript.py", "eb9f8184ef08d9e031936e61bfa86fb9b45b965c"},
-			{core.BlobObject, "100644", "tool/scenarioscript.py", "245c41af66aab8f0a6fd00259b30a47f4d6c00dd"},
-		}},
-		{"https://github.com/Tribler/dispersy.git", "9d38ff85ca03adcf68dc14f5b68b8994f15229f4", []treeWalkerExpectedEntry(nil)},
-	} {
+	for i, t := range treeWalkerTests {
 		r := s.repos[t.repo]
 		commit, err := r.Commit(core.NewHash(t.commit))
 		c.Assert(err, IsNil, Commentf("subtest %d: %v (%s)", i, err, t.commit))
@@ -126,7 +111,7 @@ func (s *SuiteTreeWalker) TestNext(c *C) {
 			c.Assert(entry.Mode, Equals, os.FileMode(mode), Commentf("subtest %d, iter %d, entry.Mode=%v expected=%v", i, k, entry.Mode, mode))
 			c.Assert(obj.Type(), Equals, info.Kind, Commentf("subtest %d, iter %d, obj.Type()=%v expected=%v", i, k, obj.Type(), info.Kind))
 			c.Assert(entry.Hash.String(), Equals, info.Hash, Commentf("subtest %d, iter %d, entry.Hash=%v, expected=%s", i, k, entry.Hash, info.Hash))
-			c.Assert(obj.Hash().String(), Equals, info.Hash, Commentf("subtest %d, iter %d, obj.Hash()=%v, expected=%s", i, k, obj.Hash(), info.Hash))
+			c.Assert(obj.ID().String(), Equals, info.Hash, Commentf("subtest %d, iter %d, obj.ID()=%v, expected=%s", i, k, obj.ID(), info.Hash))
 		}
 		_, _, _, err = walker.Next()
 		c.Assert(err, Equals, io.EOF)


### PR DESCRIPTION
* New Object interface is distinct from core.Object
* New Object interface is used in places where returned object could be of any type
* Object is implemented by Commit, Tree, Blob, File and Tag
* Added Repository.Object function for retrieving objects of any type
* Tag.Object now returns Object instead of core.Object
* Tag target hash is now publicly accessible
* Renamed Tag.Type field to Tag.TargetType, making it distinct from Tag.Type function
* Fixed infinite recursive loop in TagIter.Close
* TreeWalker.Next now returns Object instead of core.Object
* Removed some duplicate test setup code