### PR TITLE
Fix panic in the basic example code

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,10 @@ if err != nil {
 	panic(err)
 }
 
+if err := r.Remotes[git.DefaultRemoteName].Connect(); err != nil {
+	panic(err)
+}
+
 if err := r.PullDefault(); err != nil {
 	panic(err)
 }

--- a/examples/basic/main.go
+++ b/examples/basic/main.go
@@ -15,6 +15,10 @@ func main() {
 		panic(err)
 	}
 
+	if err := r.Remotes[git.DefaultRemoteName].Connect(); err != nil {
+		panic(err)
+	}
+
 	if err := r.PullDefault(); err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
The `remote.upInfo` for origin isn't set before it used in PullDefault.
Calling `Connect` on the remote before calling `PullDefault` fixes the problem.
Relates to Issue #45 

This is not required if you accept #47 