### PR TITLE
Fix PullDefault to not cause panics.

### DIFF
--- a/repository.go
+++ b/repository.go
@@ -67,6 +67,10 @@ func (r *Repository) Pull(remoteName, branch string) (err error) {
 		return err
 	}
 
+	if branch == "" {
+		branch = remote.DefaultBranch()
+	}
+
 	ref, err := remote.Ref(branch)
 	if err != nil {
 		return err
@@ -93,12 +97,7 @@ func (r *Repository) Pull(remoteName, branch string) (err error) {
 
 // PullDefault like Pull but retrieve the default branch from the default remote
 func (r *Repository) PullDefault() (err error) {
-	remote, ok := r.Remotes[DefaultRemoteName]
-	if !ok {
-		return fmt.Errorf("unable to find default remote %q", DefaultRemoteName)
-	}
-
-	return r.Pull(DefaultRemoteName, remote.DefaultBranch())
+	return r.Pull(DefaultRemoteName, "")
 }
 
 // Commit return the commit with the given hash


### PR DESCRIPTION
The `remote.upInfo` is not set until `Connect()` is called.
However, `repository.PullDefault()` requires that it exists when
it calls `remote.DefaultBranch()`. This can be solved by pushing
the default branch discovery into `repository.Pull()`.

The empty string "" is not a valid branch name, so by allowing
the empty string to mean 'default branch' in the `Pull()` function
we can allow `PullDefault()` to not need a `remote.Connect()` call
before calling `repository.Pull()`

Relates to issue #45 