### PR TITLE
Repository head

### DIFF
--- a/repository.go
+++ b/repository.go
@@ -226,6 +226,10 @@ func (r *Repository) Head(remote string) (core.Hash, error) {
 		return r.localHead()
 	}
 
+	return r.remoteHead(remote)
+}
+
+func (r *Repository) remoteHead(remote string) (core.Hash, error) {
 	rem, ok := r.Remotes[remote]
 	if !ok {
 		return core.ZeroHash, fmt.Errorf("unable to find remote %q", remote)
@@ -235,5 +239,11 @@ func (r *Repository) Head(remote string) (core.Hash, error) {
 }
 
 func (r *Repository) localHead() (core.Hash, error) {
-	return core.ZeroHash, nil
+	storage, ok := r.Storage.(*seekable.ObjectStorage)
+	if !ok {
+		return core.ZeroHash,
+			fmt.Errorf("cannot retrieve local head: no local data found")
+	}
+
+	return storage.Head()
 }

--- a/repository.go
+++ b/repository.go
@@ -218,3 +218,10 @@ func (r *Repository) Object(h core.Hash) (Object, error) {
 		return nil, core.ErrInvalidType
 	}
 }
+
+// Head returns the hash of the HEAD of the repository.  If there is no
+// HEAD, it then returns the hash of the HEAD of the default remote.  If
+// there is no default remote, it returns an error.
+func (r *Repository) Head() (core.Hash, error) {
+	return core.ZeroHash, nil
+}

--- a/repository.go
+++ b/repository.go
@@ -219,9 +219,21 @@ func (r *Repository) Object(h core.Hash) (Object, error) {
 	}
 }
 
-// Head returns the hash of the HEAD of the repository.  If there is no
-// HEAD, it then returns the hash of the HEAD of the default remote.  If
-// there is no default remote, it returns an error.
-func (r *Repository) Head() (core.Hash, error) {
+// Head returns the hash of the HEAD of the repository or the head of a
+// remote, if one is passed.
+func (r *Repository) Head(remote string) (core.Hash, error) {
+	if remote == "" {
+		return r.localHead()
+	}
+
+	rem, ok := r.Remotes[remote]
+	if !ok {
+		return core.ZeroHash, fmt.Errorf("unable to find remote %q", remote)
+	}
+
+	return rem.Head()
+}
+
+func (r *Repository) localHead() (core.Hash, error) {
 	return core.ZeroHash, nil
 }

--- a/repository_test.go
+++ b/repository_test.go
@@ -260,4 +260,8 @@ func (s *SuiteRepository) TestHeadFromRemoteError(c *C) {
 	remote := "not found"
 	_, err = r.Head(remote)
 	c.Assert(err, ErrorMatches, fmt.Sprintf("unable to find remote %q", remote))
+
+	remote = ""
+	_, err = r.Head(remote)
+	c.Assert(err, ErrorMatches, "cannot retrieve local head: no local data found")
 }

--- a/repository_test.go
+++ b/repository_test.go
@@ -13,19 +13,26 @@ import (
 	. "gopkg.in/check.v1"
 )
 
-var dirFixtures = [...]struct {
+var dirFixturesInit = [...]struct {
 	name string
 	tgz  string
+	head string
 }{
 	{
 		name: "binrels",
 		tgz:  "storage/seekable/internal/gitdir/fixtures/alcortesm-binary-relations.tgz",
+		head: "c44b5176e99085c8fe36fa27b045590a7b9d34c9",
 	},
 }
 
+type dirFixture struct {
+	path string
+	head core.Hash
+}
+
 type SuiteRepository struct {
-	repos           map[string]*Repository
-	dirFixturePaths map[string]string
+	repos       map[string]*Repository
+	dirFixtures map[string]dirFixture
 }
 
 var _ = Suite(&SuiteRepository{})
@@ -33,22 +40,25 @@ var _ = Suite(&SuiteRepository{})
 func (s *SuiteRepository) SetUpSuite(c *C) {
 	s.repos = unpackFixtures(c, tagFixtures, treeWalkerFixtures)
 
-	s.dirFixturePaths = make(map[string]string, len(dirFixtures))
-	for _, fix := range dirFixtures {
+	s.dirFixtures = make(map[string]dirFixture, len(dirFixturesInit))
+	for _, fix := range dirFixturesInit {
 		com := Commentf("fixture name = %s\n", fix.name)
 
 		path, err := tgz.Extract(fix.tgz)
 		c.Assert(err, IsNil, com)
 
-		s.dirFixturePaths[fix.name] = path
+		s.dirFixtures[fix.name] = dirFixture{
+			path: path,
+			head: core.NewHash(fix.head),
+		}
 	}
 }
 
 func (s *SuiteRepository) TearDownSuite(c *C) {
-	for name, path := range s.dirFixturePaths {
-		err := os.RemoveAll(path)
+	for name, fix := range s.dirFixtures {
+		err := os.RemoveAll(fix.path)
 		c.Assert(err, IsNil, Commentf("cannot delete tmp dir for fixture %s: %s\n",
-			name, path))
+			name, fix.path))
 	}
 }
 
@@ -66,9 +76,9 @@ func (s *SuiteRepository) TestNewRepositoryWithAuth(c *C) {
 }
 
 func (s *SuiteRepository) TestNewRepositoryFromFS(c *C) {
-	for name, path := range s.dirFixturePaths {
+	for name, fix := range s.dirFixtures {
 		fs := fs.NewOS()
-		gitPath := fs.Join(path, ".git/")
+		gitPath := fs.Join(fix.path, ".git/")
 		com := Commentf("dir fixture %q → %q\n", name, gitPath)
 		repo, err := NewRepositoryFromFS(fs, gitPath)
 		c.Assert(err, IsNil, com)
@@ -204,4 +214,35 @@ func (s *SuiteRepository) TestCommitIterClosePanic(c *C) {
 	commits, err := r.Commits()
 	c.Assert(err, IsNil)
 	commits.Close()
+}
+
+func (s *SuiteRepository) TestHeadFromFs(c *C) {
+	for name, fix := range s.dirFixtures {
+		fs := fs.NewOS()
+		gitPath := fs.Join(fix.path, ".git/")
+		com := Commentf("dir fixture %q → %q\n", name, gitPath)
+		repo, err := NewRepositoryFromFS(fs, gitPath)
+		c.Assert(err, IsNil, com)
+
+		head, err := repo.Head()
+		c.Assert(err, IsNil)
+
+		c.Assert(head, Equals, fix.head)
+	}
+}
+
+func (s *SuiteRepository) TestHeadFromRemote(c *C) {
+	r, err := NewRepository(RepositoryFixture, nil)
+	c.Assert(err, IsNil)
+
+	upSrv := &MockGitUploadPackService{}
+	r.Remotes["origin"].upSrv = upSrv
+	info, err := upSrv.Info()
+	c.Assert(err, IsNil)
+	expected := info.Head
+
+	obtained, err := r.Head()
+	c.Assert(err, IsNil)
+
+	c.Assert(obtained, Equals, expected)
 }

--- a/repository_test.go
+++ b/repository_test.go
@@ -224,7 +224,7 @@ func (s *SuiteRepository) TestHeadFromFs(c *C) {
 		repo, err := NewRepositoryFromFS(fs, gitPath)
 		c.Assert(err, IsNil, com)
 
-		head, err := repo.Head()
+		head, err := repo.Head("")
 		c.Assert(err, IsNil)
 
 		c.Assert(head, Equals, fix.head)
@@ -236,13 +236,28 @@ func (s *SuiteRepository) TestHeadFromRemote(c *C) {
 	c.Assert(err, IsNil)
 
 	upSrv := &MockGitUploadPackService{}
-	r.Remotes["origin"].upSrv = upSrv
+	r.Remotes[DefaultRemoteName].upSrv = upSrv
+	err = r.Remotes[DefaultRemoteName].Connect()
+	c.Assert(err, IsNil)
+
 	info, err := upSrv.Info()
 	c.Assert(err, IsNil)
 	expected := info.Head
 
-	obtained, err := r.Head()
+	obtained, err := r.Head(DefaultRemoteName)
 	c.Assert(err, IsNil)
 
 	c.Assert(obtained, Equals, expected)
+}
+
+func (s *SuiteRepository) TestHeadFromRemoteError(c *C) {
+	r, err := NewRepository(RepositoryFixture, nil)
+	c.Assert(err, IsNil)
+
+	upSrv := &MockGitUploadPackService{}
+	r.Remotes[DefaultRemoteName].upSrv = upSrv
+
+	remote := "not found"
+	_, err = r.Head(remote)
+	c.Assert(err, ErrorMatches, fmt.Sprintf("unable to find remote %q", remote))
 }

--- a/repository_test.go
+++ b/repository_test.go
@@ -250,7 +250,7 @@ func (s *SuiteRepository) TestHeadFromRemote(c *C) {
 	c.Assert(obtained, Equals, expected)
 }
 
-func (s *SuiteRepository) TestHeadFromRemoteError(c *C) {
+func (s *SuiteRepository) TestHeadErrors(c *C) {
 	r, err := NewRepository(RepositoryFixture, nil)
 	c.Assert(err, IsNil)
 

--- a/storage/seekable/internal/gitdir/gitdir.go
+++ b/storage/seekable/internal/gitdir/gitdir.go
@@ -25,6 +25,9 @@ var (
 	// ErrPackfileNotFound is returned by Packfile when the packfile is not found
 	// on the repository.
 	ErrPackfileNotFound = errors.New("packfile not found")
+	// ErrHeadfileNotFound is returned by Headfile when the HEAD file is not found
+	// on the repository.
+	ErrHeadfileNotFound = errors.New("headfile not found")
 )
 
 // The GitDir type represents a local git repository on disk. This
@@ -126,7 +129,7 @@ func (d *GitDir) Packfile() (fs.FS, string, error) {
 	return nil, "", ErrPackfileNotFound
 }
 
-// Packfile returns the path of the idx file (really, it returns the
+// Idxfile returns the path of the idx file (really, it returns the
 // path of the first file in the "objects/pack/" directory with an
 // ".idx" extension.
 func (d *GitDir) Idxfile() (fs.FS, string, error) {

--- a/storage/seekable/internal/gitdir/gitdir.go
+++ b/storage/seekable/internal/gitdir/gitdir.go
@@ -25,9 +25,6 @@ var (
 	// ErrPackfileNotFound is returned by Packfile when the packfile is not found
 	// on the repository.
 	ErrPackfileNotFound = errors.New("packfile not found")
-	// ErrHeadfileNotFound is returned by Headfile when the HEAD file is not found
-	// on the repository.
-	ErrHeadfileNotFound = errors.New("headfile not found")
 )
 
 // The GitDir type represents a local git repository on disk. This


### PR DESCRIPTION
@mcuadros realized we are not providing a way to get the repository HEAD or remote HEADs. This patch fixes this limitation.