### PR TITLE
object: Add Encode method to all objects.

### DIFF
--- a/core/memory.go
+++ b/core/memory.go
@@ -50,6 +50,7 @@ func (o *MemoryObject) Writer() (ObjectWriter, error) {
 
 func (o *MemoryObject) Write(p []byte) (n int, err error) {
 	o.cont = append(o.cont, p...)
+	o.sz = int64(len(o.cont))
 	return len(p), nil
 }
 

--- a/tag.go
+++ b/tag.go
@@ -105,6 +105,31 @@ func (t *Tag) Decode(o core.Object) (err error) {
 	return nil
 }
 
+// Encode transforms a Tag into a core.Object.
+func (t *Tag) Encode(o core.Object) error {
+	o.SetType(core.TagObject)
+	w, err := o.Writer()
+	if err != nil {
+		return err
+	}
+	defer checkClose(w, &err)
+	if _, err = fmt.Fprintf(w,
+		"object %s\ntype %s\ntag %s\ntagger ",
+		t.Target.String(), t.TargetType.Bytes(), t.Name); err != nil {
+		return err
+	}
+	if err = t.Tagger.Encode(w); err != nil {
+		return err
+	}
+	if _, err = fmt.Fprint(w, "\n\n"); err != nil {
+		return err
+	}
+	if _, err = fmt.Fprint(w, t.Message); err != nil {
+		return err
+	}
+	return err
+}
+
 // Commit returns the commit pointed to by the tag. If the tag points to a
 // different type of object ErrUnsupportedObject will be returned.
 func (t *Tag) Commit() (*Commit, error) {

--- a/tree_test.go
+++ b/tree_test.go
@@ -2,6 +2,7 @@ package git
 
 import (
 	"io"
+	"os"
 
 	"gopkg.in/src-d/go-git.v4/core"
 
@@ -1252,6 +1253,28 @@ func (s *SuiteTree) TestTreeDecodeReadBug(c *C) {
 	err := obtained.Decode(obj)
 	c.Assert(err, IsNil)
 	c.Assert(EntriesEquals(obtained.Entries, expected.Entries), Equals, true)
+}
+
+func (s *SuiteTree) TestTreeDecodeEncodeIdempotent(c *C) {
+	trees := []*Tree{
+		&Tree{
+			Entries: []TreeEntry{
+				TreeEntry{"foo", os.FileMode(0), core.NewHash("b029517f6300c2da0f4b651b8642506cd6aaf45d")},
+				TreeEntry{"bar", os.FileMode(0), core.NewHash("c029517f6300c2da0f4b651b8642506cd6aaf45d")},
+				TreeEntry{"baz", os.FileMode(0), core.NewHash("d029517f6300c2da0f4b651b8642506cd6aaf45d")},
+			},
+		},
+	}
+	for _, tree := range trees {
+		obj := &core.MemoryObject{}
+		err := tree.Encode(obj)
+		c.Assert(err, IsNil)
+		newTree := &Tree{}
+		err = newTree.Decode(obj)
+		c.Assert(err, IsNil)
+		tree.Hash = obj.Hash()
+		c.Assert(newTree, DeepEquals, tree)
+	}
 }
 
 func EntriesEquals(a, b []TreeEntry) bool {


### PR DESCRIPTION
Encode method encodes a typed object (commit, tree,
tag, blob) into raw core.Object representation.

Additionally, Decode does not trim commit message
lines. This is needed for Decode/Encode to be
idempotent.