### PR TITLE
Update CI build status image in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# go-git [![GoDoc](https://godoc.org/gopkg.in/src-d/go-git.v3?status.svg)](https://godoc.org/gopkg.in/src-d/go-git.v3) [![Build Status](https://travis-ci.org/src-d/go-git.svg)](https://travis-ci.org/src-d/go-git) [![codecov.io](https://codecov.io/github/src-d/go-git/coverage.svg)](https://codecov.io/github/src-d/go-git) [![codebeat badge](https://codebeat.co/badges/b6cb2f73-9e54-483d-89f9-4b95a911f40c)](https://codebeat.co/projects/github-com-src-d-go-git)
+# go-git [![GoDoc](https://godoc.org/gopkg.in/src-d/go-git.v3?status.svg)](https://godoc.org/gopkg.in/src-d/go-git.v3) [![Build Status](https://travis-ci.org/src-d/go-git.svg?branch=master)](https://travis-ci.org/src-d/go-git) [![codecov.io](https://codecov.io/github/src-d/go-git/coverage.svg)](https://codecov.io/github/src-d/go-git) [![codebeat badge](https://codebeat.co/badges/b6cb2f73-9e54-483d-89f9-4b95a911f40c)](https://codebeat.co/projects/github-com-src-d-go-git)
 
 A low level and highly extensible git client library for **reading** repositories from git servers.  It is written in Go from scratch, without any C dependencies.
 


### PR DESCRIPTION
A minor drive-by commit, forces CI indicator on the main page to point only to _master_ builds. Otherwise failing CI can make wrong first impression.
 
Before:
![screen shot 2016-09-07 at 13 07 41](https://cloud.githubusercontent.com/assets/5582506/18299464/23856eb2-74fc-11e6-91bc-571ea68e02fc.png)

After:
![screen shot 2016-09-07 at 13 06 40](https://cloud.githubusercontent.com/assets/5582506/18299468/31d02548-74fc-11e6-9566-4a15bd185302.png)
