### PR TITLE
utils: fs.TempFile

### DIFF
--- a/storage/filesystem/internal/dotgit/writers.go
+++ b/storage/filesystem/internal/dotgit/writers.go
@@ -1,11 +1,9 @@
 package dotgit
 
 import (
-	"crypto/sha1"
 	"fmt"
 	"io"
 	"sync/atomic"
-	"time"
 
 	"gopkg.in/src-d/go-git.v4/core"
 	"gopkg.in/src-d/go-git.v4/formats/idxfile"
@@ -26,15 +24,12 @@ type PackWriter struct {
 }
 
 func newPackWrite(fs fs.Filesystem) (*PackWriter, error) {
-	seed := sha1.Sum([]byte(time.Now().String()))
-	tmp := fs.Join(objectsPath, packPath, fmt.Sprintf("tmp_pack_%x", seed))
-
-	fw, err := fs.Create(tmp)
+	fw, err := fs.TempFile(fs.Join(objectsPath, packPath), "tmp_pack_")
 	if err != nil {
 		return nil, err
 	}
 
-	fr, err := fs.Open(tmp)
+	fr, err := fs.Open(fw.Filename())
 	if err != nil {
 		return nil, err
 	}
@@ -228,10 +223,7 @@ type ObjectWriter struct {
 }
 
 func newObjectWriter(fs fs.Filesystem) (*ObjectWriter, error) {
-	seed := sha1.Sum([]byte(time.Now().String()))
-	tmp := fs.Join(objectsPath, fmt.Sprintf("tmp_obj_%x", seed))
-
-	f, err := fs.Create(tmp)
+	f, err := fs.TempFile(fs.Join(objectsPath, packPath), "tmp_obj_")
 	if err != nil {
 		return nil, err
 	}

--- a/utils/fs/fs.go
+++ b/utils/fs/fs.go
@@ -16,9 +16,10 @@ var (
 type Filesystem interface {
 	Create(filename string) (File, error)
 	Open(filename string) (File, error)
-	Rename(from, to string) error
 	Stat(filename string) (FileInfo, error)
 	ReadDir(path string) ([]FileInfo, error)
+	TempFile(dir, prefix string) (File, error)
+	Rename(from, to string) error
 	Join(elem ...string) string
 	Dir(path string) Filesystem
 	Base() string

--- a/utils/fs/fs_test.go
+++ b/utils/fs/fs_test.go
@@ -1,0 +1,121 @@
+package fs
+
+import (
+	"io"
+	"io/ioutil"
+	"testing"
+
+	. "gopkg.in/check.v1"
+)
+
+func Test(t *testing.T) { TestingT(t) }
+
+type FilesystemSuite struct {
+	fs Filesystem
+}
+
+func (s *FilesystemSuite) TestCreate(c *C) {
+	f, err := s.fs.Create("foo")
+	c.Assert(err, IsNil)
+	c.Assert(f.Filename(), Equals, "foo")
+}
+
+func (s *FilesystemSuite) TestCreateDepth(c *C) {
+	f, err := s.fs.Create("bar/foo")
+	c.Assert(err, IsNil)
+	c.Assert(f.Filename(), Equals, "bar/foo")
+}
+
+func (s *FilesystemSuite) TestCreateAndWrite(c *C) {
+	f, err := s.fs.Create("foo")
+	c.Assert(err, IsNil)
+	l, err := f.Write([]byte("foo"))
+	c.Assert(l, Equals, 3)
+	c.Assert(err, IsNil)
+
+	f.Seek(0, io.SeekStart)
+	wrote, err := ioutil.ReadAll(f)
+	c.Assert(err, IsNil)
+	c.Assert(wrote, DeepEquals, []byte("foo"))
+}
+
+func (s *FilesystemSuite) TestCreateClose(c *C) {
+	f, err := s.fs.Create("foo")
+	c.Assert(err, IsNil)
+	c.Assert(f.IsClosed(), Equals, false)
+
+	f.Write([]byte("foo"))
+	c.Assert(f.Close(), IsNil)
+
+	file, err := s.fs.Open(f.Filename())
+	c.Assert(err, IsNil)
+
+	wrote, err := ioutil.ReadAll(file)
+	c.Assert(err, IsNil)
+	c.Assert(wrote, DeepEquals, []byte("foo"))
+
+	c.Assert(f.IsClosed(), Equals, true)
+}
+
+func (s *FilesystemSuite) TestReadDirAndDir(c *C) {
+	files := []string{"foo", "bar", "qux/baz", "qux/qux"}
+	for _, name := range files {
+		f, err := s.fs.Create(name)
+		c.Assert(err, IsNil)
+		c.Assert(f.Close(), IsNil)
+	}
+
+	info, err := s.fs.ReadDir("/")
+	c.Assert(err, IsNil)
+	c.Assert(info, HasLen, 3)
+
+	info, err = s.fs.ReadDir("/qux")
+	c.Assert(err, IsNil)
+	c.Assert(info, HasLen, 2)
+
+	qux := s.fs.Dir("/qux")
+	info, err = qux.ReadDir("/")
+	c.Assert(err, IsNil)
+	c.Assert(info, HasLen, 2)
+}
+
+func (s *FilesystemSuite) TestRename(c *C) {
+	f, err := s.fs.Create("foo")
+	c.Assert(err, IsNil)
+	c.Assert(f.Close(), IsNil)
+
+	err = s.fs.Rename("foo", "bar")
+	c.Assert(err, IsNil)
+
+	foo, err := s.fs.Stat("foo")
+	c.Assert(foo, IsNil)
+	c.Assert(err, NotNil)
+
+	bar, err := s.fs.Stat("bar")
+	c.Assert(bar, NotNil)
+	c.Assert(err, IsNil)
+}
+
+func (s *FilesystemSuite) TestOpenAndStat(c *C) {
+	f, err := s.fs.Create("foo")
+	c.Assert(err, IsNil)
+	c.Assert(f.Close(), IsNil)
+
+	foo, err := s.fs.Open("foo")
+	c.Assert(foo, NotNil)
+	c.Assert(foo.Filename(), Equals, "foo")
+	c.Assert(err, IsNil)
+
+	stat, err := s.fs.Stat("foo")
+	c.Assert(stat, NotNil)
+	c.Assert(err, IsNil)
+	c.Assert(stat.Name(), Equals, "foo")
+}
+
+func (s *FilesystemSuite) TestJoin(c *C) {
+	c.Assert(s.fs.Join("foo", "bar"), Equals, "foo/bar")
+}
+
+func (s *FilesystemSuite) TestBase(c *C) {
+	c.Assert(s.fs.Base(), Not(Equals), "")
+}

--- a/utils/fs/fs_test.go
+++ b/utils/fs/fs_test.go
@@ -37,10 +37,31 @@ func (s *FilesystemSuite) TestCreateAndWrite(c *C) {
 	f, err := s.fs.Create("foo")
 	c.Assert(err, IsNil)
 	l, err := f.Write([]byte("foo"))
-	c.Assert(l, Equals, 3)
 	c.Assert(err, IsNil)
+	c.Assert(l, Equals, 3)
 
 	f.Seek(0, io.SeekStart)
+	wrote, err := ioutil.ReadAll(f)
+	c.Assert(err, IsNil)
+	c.Assert(wrote, DeepEquals, []byte("foo"))
+}
+
+func (s *FilesystemSuite) TestCreateOverwrite(c *C) {
+	for i := 0; i < 2; i++ {
+		f, err := s.fs.Create("foo")
+		c.Assert(err, IsNil)
+
+		l, err := f.Write([]byte("foo"))
+		c.Assert(err, IsNil)
+		c.Assert(l, Equals, 3)
+
+		err = f.Close()
+		c.Assert(err, IsNil)
+	}
+
+	f, err := s.fs.Open("foo")
+	c.Assert(err, IsNil)
+
 	wrote, err := ioutil.ReadAll(f)
 	c.Assert(err, IsNil)
 	c.Assert(wrote, DeepEquals, []byte("foo"))

--- a/utils/fs/fs_test.go
+++ b/utils/fs/fs_test.go
@@ -3,6 +3,7 @@ package fs
 import (
 	"io"
 	"io/ioutil"
+	"strings"
 	"testing"
 
 	. "gopkg.in/check.v1"
@@ -22,6 +23,12 @@ func (s *FilesystemSuite) TestCreate(c *C) {
 
 func (s *FilesystemSuite) TestCreateDepth(c *C) {
 	f, err := s.fs.Create("bar/foo")
+	c.Assert(err, IsNil)
+	c.Assert(f.Filename(), Equals, "bar/foo")
+}
+
+func (s *FilesystemSuite) TestCreateDepthAbsolute(c *C) {
+	f, err := s.fs.Create("/bar/foo")
 	c.Assert(err, IsNil)
 	c.Assert(f.Filename(), Equals, "bar/foo")
 }
@@ -94,6 +101,27 @@ func (s *FilesystemSuite) TestRename(c *C) {
 	bar, err := s.fs.Stat("bar")
 	c.Assert(bar, NotNil)
 	c.Assert(err, IsNil)
+}
+
+func (s *FilesystemSuite) TestTempFile(c *C) {
+	f, err := s.fs.TempFile("", "bar")
+	c.Assert(err, IsNil)
+
+	c.Assert(strings.HasPrefix(f.Filename(), "bar"), Equals, true)
+}
+
+func (s *FilesystemSuite) TestTempFileWithPath(c *C) {
+	f, err := s.fs.TempFile("foo", "bar")
+	c.Assert(err, IsNil)
+
+	c.Assert(strings.HasPrefix(f.Filename(), s.fs.Join("foo", "bar")), Equals, true)
+}
+
+func (s *FilesystemSuite) TestTempFileFullWithPath(c *C) {
+	f, err := s.fs.TempFile("/foo", "bar")
+	c.Assert(err, IsNil)
+
+	c.Assert(strings.HasPrefix(f.Filename(), s.fs.Join("foo", "bar")), Equals, true)
 }
 
 func (s *FilesystemSuite) TestOpenAndStat(c *C) {

--- a/utils/fs/os.go
+++ b/utils/fs/os.go
@@ -9,8 +9,7 @@ import (
 
 // OS a filesystem base on the os filesystem
 type OS struct {
-	base      string
-	tempfiles []string
+	base string
 }
 
 // NewOS returns a new OS filesystem
@@ -107,7 +106,7 @@ func (fs *OS) Stat(filename string) (FileInfo, error) {
 
 func (fs *OS) TempFile(dir, prefix string) (File, error) {
 	fullpath := fs.Join(fs.base, dir)
-	if err := fs.createDir(fullpath + "/"); err != nil {
+	if err := fs.createDir(fullpath + string(os.PathSeparator)); err != nil {
 		return nil, err
 	}
 

--- a/utils/fs/os.go
+++ b/utils/fs/os.go
@@ -7,27 +7,33 @@ import (
 	"path/filepath"
 )
 
-// OSClient a filesystem based on OSClient
+// OS a filesystem base on the os filesystem
 type OS struct {
-	RootDir string
+	base      string
+	tempfiles []string
 }
 
-// NewOSClient returns a new OSClient
-func NewOS(rootDir string) *OS {
+// NewOS returns a new OS filesystem
+func NewOS(baseDir string) *OS {
 	return &OS{
-		RootDir: rootDir,
+		base: baseDir,
 	}
 }
 
 // Create creates a new GlusterFSFile
 func (fs *OS) Create(filename string) (File, error) {
-	fullpath := path.Join(fs.RootDir, filename)
+	fullpath := path.Join(fs.base, filename)
 
 	if err := fs.createDir(fullpath); err != nil {
 		return nil, err
 	}
 
 	f, err := os.Create(fullpath)
+	if err != nil {
+		return nil, err
+	}
+
+	filename, err = filepath.Rel(fs.base, fullpath)
 	if err != nil {
 		return nil, err
 	}
@@ -52,7 +58,7 @@ func (fs *OS) createDir(fullpath string) error {
 // ReadDir returns the filesystem info for all the archives under the specified
 // path.
 func (fs *OS) ReadDir(path string) ([]FileInfo, error) {
-	fullpath := fs.Join(fs.RootDir, path)
+	fullpath := fs.Join(fs.base, path)
 
 	l, err := ioutil.ReadDir(fullpath)
 	if err != nil {
@@ -68,8 +74,8 @@ func (fs *OS) ReadDir(path string) ([]FileInfo, error) {
 }
 
 func (fs *OS) Rename(from, to string) error {
-	from = fs.Join(fs.RootDir, from)
-	to = fs.Join(fs.RootDir, to)
+	from = fs.Join(fs.base, from)
+	to = fs.Join(fs.base, to)
 
 	if err := fs.createDir(to); err != nil {
 		return err
@@ -78,9 +84,10 @@ func (fs *OS) Rename(from, to string) error {
 	return os.Rename(from, to)
 }
 
+// Open opens the named file for reading. If successful, methods on the returned
+// file can be used for reading only.
 func (fs *OS) Open(filename string) (File, error) {
-	fullpath := fs.Join(fs.RootDir, filename)
-
+	fullpath := fs.Join(fs.base, filename)
 	f, err := os.Open(fullpath)
 	if err != nil {
 		return nil, err
@@ -92,9 +99,37 @@ func (fs *OS) Open(filename string) (File, error) {
 	}, nil
 }
 
+// Stat returns the FileInfo structure describing file.
 func (fs *OS) Stat(filename string) (FileInfo, error) {
-	fullpath := fs.Join(fs.RootDir, filename)
+	fullpath := fs.Join(fs.base, filename)
 	return os.Stat(fullpath)
+}
+
+func (fs *OS) TempFile(dir, prefix string) (File, error) {
+	fullpath := fs.Join(fs.base, dir)
+	if err := fs.createDir(fullpath + "/"); err != nil {
+		return nil, err
+	}
+
+	f, err := ioutil.TempFile(fullpath, prefix)
+	if err != nil {
+		return nil, err
+	}
+
+	s, err := f.Stat()
+	if err != nil {
+		return nil, err
+	}
+
+	filename, err := filepath.Rel(fs.base, fs.Join(fullpath, s.Name()))
+	if err != nil {
+		return nil, err
+	}
+
+	return &OSFile{
+		BaseFile: BaseFile{filename: filename},
+		file:     f,
+	}, nil
 }
 
 // Join joins the specified elements using the filesystem separator.
@@ -102,14 +137,18 @@ func (fs *OS) Join(elem ...string) string {
 	return filepath.Join(elem...)
 }
 
+// Dir returns a new Filesystem from the same type of fs using as baseDir the
+// given path
 func (fs *OS) Dir(path string) Filesystem {
-	return NewOS(fs.Join(fs.RootDir, path))
+	return NewOS(fs.Join(fs.base, path))
 }
 
+// Base returns the base path of the filesytem
 func (fs *OS) Base() string {
-	return fs.RootDir
+	return fs.base
 }
 
+// OSFile represents a file in the os filesystem
 type OSFile struct {
 	file *os.File
 	BaseFile

--- a/utils/fs/os_test.go
+++ b/utils/fs/os_test.go
@@ -1,148 +1,24 @@
 package fs
 
 import (
-	"io"
 	"io/ioutil"
 	"os"
-	"testing"
 
 	. "gopkg.in/check.v1"
 )
 
-func Test(t *testing.T) { TestingT(t) }
-
-type OSSuite struct{}
+type OSSuite struct {
+	FilesystemSuite
+	path string
+}
 
 var _ = Suite(&OSSuite{})
 
-func (s *OSSuite) TestCreate(c *C) {
-	path := getTempDir()
-	client := NewOS(path)
-
-	f, err := client.Create("foo")
-	c.Assert(err, IsNil)
-	c.Assert(f.Filename(), Equals, "foo")
+func (s *OSSuite) SetUpTest(c *C) {
+	s.path, _ = ioutil.TempDir(os.TempDir(), "go-git-os-fs-test")
+	s.FilesystemSuite.fs = NewOS(s.path)
 }
-
-func (s *OSSuite) TestCreateDepth(c *C) {
-	path := getTempDir()
-	client := NewOS(path)
-
-	f, err := client.Create("bar/foo")
+func (s *OSSuite) TearDownTest(c *C) {
+	err := os.RemoveAll(s.path)
 	c.Assert(err, IsNil)
-	c.Assert(f.Filename(), Equals, "bar/foo")
-}
-
-func (s *OSSuite) TestCreateAndWrite(c *C) {
-	path := getTempDir()
-	client := NewOS(path)
-
-	f, err := client.Create("foo")
-	c.Assert(err, IsNil)
-	l, err := f.Write([]byte("foo"))
-	c.Assert(l, Equals, 3)
-	c.Assert(err, IsNil)
-
-	f.Seek(0, io.SeekStart)
-	wrote, err := ioutil.ReadAll(f)
-	c.Assert(err, IsNil)
-	c.Assert(wrote, DeepEquals, []byte("foo"))
-}
-
-func (s *OSSuite) TestCreateClose(c *C) {
-	path := getTempDir()
-	client := NewOS(path)
-
-	f, err := client.Create("foo")
-	c.Assert(err, IsNil)
-	c.Assert(f.IsClosed(), Equals, false)
-
-	f.Write([]byte("foo"))
-	c.Assert(f.Close(), IsNil)
-
-	wrote, _ := ioutil.ReadFile(f.(*OSFile).file.Name())
-	c.Assert(wrote, DeepEquals, []byte("foo"))
-
-	c.Assert(f.IsClosed(), Equals, true)
-}
-
-func (s *OSSuite) TestReadDirAndDir(c *C) {
-	path := getTempDir()
-	client := NewOS(path)
-
-	files := []string{"foo", "bar", "qux/baz", "qux/qux"}
-	for _, name := range files {
-		f, err := client.Create(name)
-		c.Assert(err, IsNil)
-		c.Assert(f.Close(), IsNil)
-	}
-
-	info, err := client.ReadDir("/")
-	c.Assert(err, IsNil)
-	c.Assert(info, HasLen, 3)
-
-	info, err = client.ReadDir("/qux")
-	c.Assert(err, IsNil)
-	c.Assert(info, HasLen, 2)
-
-	qux := client.Dir("/qux")
-	info, err = qux.ReadDir("/")
-	c.Assert(err, IsNil)
-	c.Assert(info, HasLen, 2)
-}
-
-func (s *OSSuite) TestRename(c *C) {
-	path := getTempDir()
-	client := NewOS(path)
-
-	f, err := client.Create("foo")
-	c.Assert(err, IsNil)
-	c.Assert(f.Close(), IsNil)
-
-	err = client.Rename("foo", "bar")
-	c.Assert(err, IsNil)
-
-	foo, err := client.Stat("foo")
-	c.Assert(foo, IsNil)
-	c.Assert(err, NotNil)
-
-	bar, err := client.Stat("bar")
-	c.Assert(bar, NotNil)
-	c.Assert(err, IsNil)
-}
-
-func (s *OSSuite) TestOpenAndStat(c *C) {
-	path := getTempDir()
-	client := NewOS(path)
-
-	f, err := client.Create("foo")
-	c.Assert(err, IsNil)
-	c.Assert(f.Close(), IsNil)
-
-	foo, err := client.Open("foo")
-	c.Assert(foo, NotNil)
-	c.Assert(foo.Filename(), Equals, "foo")
-	c.Assert(err, IsNil)
-
-	stat, err := client.Stat("foo")
-	c.Assert(stat, NotNil)
-	c.Assert(err, IsNil)
-	c.Assert(stat.Name(), Equals, "foo")
-}
-
-func (s *OSSuite) TestJoin(c *C) {
-	path := getTempDir()
-	client := NewOS(path)
-	c.Assert(client.Join("foo", "bar"), Equals, "foo/bar")
-}
-
-func (s *OSSuite) TestBase(c *C) {
-	path := getTempDir()
-	client := NewOS(path)
-	c.Assert(client.Base(), Equals, path)
-}
-
-func getTempDir() string {
-	dir, _ := ioutil.TempDir(os.TempDir(), "--OSClientTest--")
-	return dir
 }


### PR DESCRIPTION
- New fs.TempFile method in the fs.Filesystem interface, this abstraction is required to filesystem where the creation of a temporal file should be explicit 
- utils.fs: new TestSuite for test any fs.Filesystem implementation