### PR TITLE
utils/fs/test: add a method to skip tests.

### DIFF
--- a/utils/fs/os/os_test.go
+++ b/utils/fs/os/os_test.go
@@ -22,6 +22,8 @@ var _ = Suite(&OSSuite{})
 func (s *OSSuite) SetUpTest(c *C) {
 	s.path, _ = ioutil.TempDir(stdos.TempDir(), "go-git-os-fs-test")
 	s.FilesystemSuite.Fs = os.NewOS(s.path)
+	s.FilesystemSuite.SetUpTest(c)
+
 }
 func (s *OSSuite) TearDownTest(c *C) {
 	err := stdos.RemoveAll(s.path)

--- a/utils/fs/test/fs_suite.go
+++ b/utils/fs/test/fs_suite.go
@@ -14,6 +14,24 @@ func Test(t *testing.T) { TestingT(t) }
 
 type FilesystemSuite struct {
 	Fs Filesystem
+
+	SkippedTests map[string]string
+}
+
+func (s *FilesystemSuite) SetUpTest(c *C) {
+	if s.SkippedTests == nil {
+		return
+	}
+
+	name := c.TestName()
+	parts := strings.Split(name, ".")
+	name = parts[len(parts)-1]
+	reason, ok := s.SkippedTests[name]
+	if !ok {
+		return
+	}
+
+	c.Skip(reason)
 }
 
 func (s *FilesystemSuite) TestCreate(c *C) {


### PR DESCRIPTION
* Some 3rd party implementations of filesystem need to
  skip some tests from the standard suite because of
  partial compliance.