### PR TITLE
add Blobs, Trees and Objects iters.

### DIFF
--- a/blobs.go
+++ b/blobs.go
@@ -1,0 +1,115 @@
+package git
+
+import (
+	"io"
+
+	"gopkg.in/src-d/go-git.v4/core"
+)
+
+// Blob is used to store file data - it is generally a file.
+type Blob struct {
+	Hash core.Hash
+	Size int64
+
+	obj core.Object
+}
+
+// ID returns the object ID of the blob. The returned value will always match
+// the current value of Blob.Hash.
+//
+// ID is present to fulfill the Object interface.
+func (b *Blob) ID() core.Hash {
+	return b.Hash
+}
+
+// Type returns the type of object. It always returns core.BlobObject.
+//
+// Type is present to fulfill the Object interface.
+func (b *Blob) Type() core.ObjectType {
+	return core.BlobObject
+}
+
+// Decode transforms a core.Object into a Blob struct.
+func (b *Blob) Decode(o core.Object) error {
+	if o.Type() != core.BlobObject {
+		return ErrUnsupportedObject
+	}
+
+	b.Hash = o.Hash()
+	b.Size = o.Size()
+	b.obj = o
+
+	return nil
+}
+
+// Encode transforms a Blob into a core.Object.
+func (b *Blob) Encode(o core.Object) error {
+	w, err := o.Writer()
+	if err != nil {
+		return err
+	}
+	defer checkClose(w, &err)
+	r, err := b.Reader()
+	if err != nil {
+		return err
+	}
+	defer checkClose(r, &err)
+	_, err = io.Copy(w, r)
+	o.SetType(core.BlobObject)
+	return err
+}
+
+// Reader returns a reader allow the access to the content of the blob
+func (b *Blob) Reader() (core.ObjectReader, error) {
+	return b.obj.Reader()
+}
+
+// BlobIter provides an iterator for a set of blobs.
+type BlobIter struct {
+	core.ObjectIter
+	r *Repository
+}
+
+// NewBlobIter returns a CommitIter for the given repository and underlying
+// object iterator.
+//
+// The returned BlobIter will automatically skip over non-blob objects.
+func NewBlobIter(r *Repository, iter core.ObjectIter) *BlobIter {
+	return &BlobIter{iter, r}
+}
+
+// Next moves the iterator to the next blob and returns a pointer to it. If it
+// has reached the end of the set it will return io.EOF.
+func (iter *BlobIter) Next() (*Blob, error) {
+	for {
+		obj, err := iter.ObjectIter.Next()
+		if err != nil {
+			return nil, err
+		}
+
+		if obj.Type() != core.BlobObject {
+			continue
+		}
+
+		blob := &Blob{}
+		return blob, blob.Decode(obj)
+	}
+}
+
+// ForEach call the cb function for each blob contained on this iter until
+// an error happens or the end of the iter is reached. If ErrStop is sent
+// the iteration is stop but no error is returned. The iterator is closed.
+func (iter *BlobIter) ForEach(cb func(*Blob) error) error {
+	return iter.ObjectIter.ForEach(func(obj core.Object) error {
+		if obj.Type() != core.BlobObject {
+			return nil
+		}
+
+		blob := &Blob{}
+		if err := blob.Decode(obj); err != nil {
+			return err
+		}
+
+		return cb(blob)
+	})
+}

--- a/blobs_test.go
+++ b/blobs_test.go
@@ -1,0 +1,94 @@
+package git
+
+import (
+	"io"
+	"io/ioutil"
+
+	"gopkg.in/src-d/go-git.v4/core"
+
+	. "gopkg.in/check.v1"
+)
+
+type BlobsSuite struct {
+	BaseSuite
+}
+
+var _ = Suite(&BlobsSuite{})
+
+func (s *BlobsSuite) TestBlobHash(c *C) {
+	o := &core.MemoryObject{}
+	o.SetType(core.BlobObject)
+	o.SetSize(3)
+
+	writer, err := o.Writer()
+	c.Assert(err, IsNil)
+	defer func() { c.Assert(writer.Close(), IsNil) }()
+
+	writer.Write([]byte{'F', 'O', 'O'})
+
+	blob := &Blob{}
+	c.Assert(blob.Decode(o), IsNil)
+
+	c.Assert(blob.Size, Equals, int64(3))
+	c.Assert(blob.Hash.String(), Equals, "d96c7efbfec2814ae0301ad054dc8d9fc416c9b5")
+
+	reader, err := blob.Reader()
+	c.Assert(err, IsNil)
+	defer func() { c.Assert(reader.Close(), IsNil) }()
+
+	data, err := ioutil.ReadAll(reader)
+	c.Assert(err, IsNil)
+	c.Assert(string(data), Equals, "FOO")
+}
+
+func (s *BlobsSuite) TestBlobDecodeEncodeIdempotent(c *C) {
+	var objects []*core.MemoryObject
+	for _, str := range []string{"foo", "foo\n"} {
+		obj := &core.MemoryObject{}
+		obj.Write([]byte(str))
+		obj.SetType(core.BlobObject)
+		obj.Hash()
+		objects = append(objects, obj)
+	}
+	for _, object := range objects {
+		blob := &Blob{}
+		err := blob.Decode(object)
+		c.Assert(err, IsNil)
+		newObject := &core.MemoryObject{}
+		err = blob.Encode(newObject)
+		c.Assert(err, IsNil)
+		newObject.Hash() // Ensure Hash is pre-computed before deep comparison
+		c.Assert(newObject, DeepEquals, object)
+	}
+}
+
+func (s *BlobsSuite) TestBlobIter(c *C) {
+	iter, err := s.Repository.Blobs()
+	c.Assert(err, IsNil)
+
+	blobs := []*Blob{}
+	iter.ForEach(func(b *Blob) error {
+		blobs = append(blobs, b)
+		return nil
+	})
+
+	c.Assert(len(blobs) > 0, Equals, true)
+	iter.Close()
+
+	iter, err = s.Repository.Blobs()
+	c.Assert(err, IsNil)
+
+	i := 0
+	for {
+		b, err := iter.Next()
+		if err == io.EOF {
+			break
+		}
+
+		c.Assert(err, IsNil)
+		c.Assert(b, DeepEquals, blobs[i])
+		i += 1
+	}
+
+	iter.Close()
+}

--- a/file.go
+++ b/file.go
@@ -55,11 +55,11 @@ func (f *File) Lines() ([]string, error) {
 
 type FileIter struct {
 	r *Repository
-	w TreeIter
+	w TreeWalker
 }
 
 func NewFileIter(r *Repository, t *Tree) *FileIter {
-	return &FileIter{r: r, w: *NewTreeIter(r, t, true)}
+	return &FileIter{r: r, w: *NewTreeWalker(r, t, true)}
 }
 
 func (iter *FileIter) Next() (*File, error) {

--- a/repository.go
+++ b/repository.go
@@ -259,6 +259,16 @@ func (r *Repository) Tree(h core.Hash) (*Tree, error) {
 	return tree.(*Tree), nil
 }
 
+// Trees decodes the objects into trees
+func (r *Repository) Trees() (*TreeIter, error) {
+	iter, err := r.s.ObjectStorage().Iter(core.TreeObject)
+	if err != nil {
+		return nil, err
+	}
+
+	return NewTreeIter(r, iter), nil
+}
+
 // Blob returns the blob with the given hash
 func (r *Repository) Blob(h core.Hash) (*Blob, error) {
 	blob, err := r.Object(core.BlobObject, h)
@@ -267,6 +277,16 @@ func (r *Repository) Blob(h core.Hash) (*Blob, error) {
 	}
 
 	return blob.(*Blob), nil
+}
+
+// Blobs decodes the objects into blobs
+func (r *Repository) Blobs() (*BlobIter, error) {
+	iter, err := r.s.ObjectStorage().Iter(core.BlobObject)
+	if err != nil {
+		return nil, err
+	}
+
+	return NewBlobIter(r, iter), nil
 }
 
 // Tag returns a tag with the given hash.
@@ -316,6 +336,17 @@ func (r *Repository) Object(t core.ObjectType, h core.Hash) (Object, error) {
 	default:
 		return nil, core.ErrInvalidType
 	}
+}
+
+// Objects returns an ObjectIter that can step through all of the annotated tags
+// in the repository.
+func (r *Repository) Objects() (*ObjectIter, error) {
+	iter, err := r.s.ObjectStorage().Iter(core.AnyObject)
+	if err != nil {
+		return nil, err
+	}
+
+	return NewObjectIter(r, iter), nil
 }
 
 // Head returns the reference where HEAD is pointing

--- a/tree_diff.go
+++ b/tree_diff.go
@@ -140,7 +140,7 @@ func newWithEmpty(a, b *Tree) (Changes, error) {
 		tree = a
 	}
 
-	w := NewTreeIter(tree.r, tree, true)
+	w := NewTreeWalker(tree.r, tree, true)
 	defer w.Close()
 
 	for {


### PR DESCRIPTION
* Now every object type as an iterator in Repository.
* old TreeIter is TreeWalker again, TreeIter now matches
  the same behaviour as other iterators.