### PR TITLE
utils/fs: Fix O_CREATE flag check in OpenFile

### DIFF
--- a/utils/fs/os/os.go
+++ b/utils/fs/os/os.go
@@ -32,7 +32,7 @@ func (fs *OS) Create(filename string) (fs.File, error) {
 func (fs *OS) OpenFile(filename string, flag int, perm os.FileMode) (fs.File, error) {
 	fullpath := path.Join(fs.base, filename)
 
-	if flag|os.O_CREATE != 0 {
+	if flag&os.O_CREATE != 0 {
 		if err := fs.createDir(fullpath); err != nil {
 			return nil, err
 		}

--- a/utils/fs/os/os_test.go
+++ b/utils/fs/os/os_test.go
@@ -3,6 +3,7 @@ package os_test
 import (
 	"io/ioutil"
 	stdos "os"
+	"path/filepath"
 	"testing"
 
 	. "gopkg.in/check.v1"
@@ -26,4 +27,11 @@ func (s *OSSuite) SetUpTest(c *C) {
 func (s *OSSuite) TearDownTest(c *C) {
 	err := stdos.RemoveAll(s.path)
 	c.Assert(err, IsNil)
+}
+
+func (s *OSSuite) TestOpenDoesNotCreateDir(c *C) {
+	_, err := s.Fs.Open("dir/non-existant")
+	c.Assert(err, NotNil)
+	_, err = stdos.Stat(filepath.Join(s.path, "dir"))
+	c.Assert(stdos.IsNotExist(err), Equals, true)
 }


### PR DESCRIPTION
Flag checking is using a `|` instead of `&` against `os.O_CREATE`.