### PR TITLE
utils/fs: add ReadAt to memory file and tests.

### DIFF
--- a/utils/fs/memory/memory.go
+++ b/utils/fs/memory/memory.go
@@ -189,6 +189,16 @@ func newFile(base, fullpath string, flag int) *file {
 }
 
 func (f *file) Read(b []byte) (int, error) {
+	n, err := f.ReadAt(b, f.position)
+	if err != nil {
+		return 0, err
+	}
+
+	f.position += int64(n)
+	return n, err
+}
+
+func (f *file) ReadAt(b []byte, off int64) (int, error) {
 	if f.IsClosed() {
 		return 0, fs.ErrClosed
 	}
@@ -197,7 +207,7 @@ func (f *file) Read(b []byte) (int, error) {
 		return 0, errors.New("read not supported")
 	}
 
-	n, err := f.content.ReadAt(b, f.position)
+	n, err := f.content.ReadAt(b, off)
 	f.position += int64(n)
 
 	return n, err

--- a/utils/fs/os/os.go
+++ b/utils/fs/os/os.go
@@ -178,6 +178,6 @@ func (f *osFile) Close() error {
 	return f.file.Close()
 }
 
-func (f *osFile) ReadAt(p []byte, off int64) (n int, err error) {
+func (f *osFile) ReadAt(p []byte, off int64) (int, error) {
 	return f.file.ReadAt(p, off)
 }


### PR DESCRIPTION
* memory files now implement io.ReaderAt.
* tests now check ReadAt behaviour.