### PR TITLE
Fix nil tx bug

### DIFF
--- a/plumbing/format/packfile/decoder.go
+++ b/plumbing/format/packfile/decoder.go
@@ -121,7 +121,7 @@ func (d *Decoder) readObjectsWithObjectStorer(count int) error {
 }
 
 func (d *Decoder) readObjectsWithObjectStorerTx(count int) error {
-	tx := d.o.(storer.Transactioner).Begin()
+	d.tx = d.o.(storer.Transactioner).Begin()
 
 	for i := 0; i < count; i++ {
 		obj, err := d.ReadObject()
@@ -129,7 +129,7 @@ func (d *Decoder) readObjectsWithObjectStorerTx(count int) error {
 			return err
 		}
 
-		if _, err := tx.SetObject(obj); err != nil {
+		if _, err := d.tx.SetObject(obj); err != nil {
 			if rerr := d.tx.Rollback(); rerr != nil {
 				return ErrRollback.AddDetails(
 					"error: %s, during tx.Set error: %s", rerr, err,
@@ -141,7 +141,7 @@ func (d *Decoder) readObjectsWithObjectStorerTx(count int) error {
 
 	}
 
-	return tx.Commit()
+	return d.tx.Commit()
 }
 
 // ReadObject reads a object from the stream and return it


### PR DESCRIPTION
Commit https://github.com/src-d/go-git/commit/5a72b12c035ef65a3f2335474fe7e66a3c135ace introduced a bug that makes go-git panic when cloning repositories from non-seekable packfiles (from ssh or http connections for example). A simple way to reproduce the bug is:

```go
package main

import (
	"log"

	git "gopkg.in/src-d/go-git.v4"
)

func main() {
	r := git.NewMemoryRepository()

	opts := &git.CloneOptions{
		URL: "git@github.com:src-d/git-fixture.git",
	}

	if err := r.Clone(opts); err != nil {
		log.Fatal(err)
	}
}
```

The bug has not been detected by our tests because some of the functionality being added by the commit was not being tested.

This fix has two commits: one that adds a test for the offending functionality and another to fix the bug.