### PR TITLE
fix nil pointer dereference while reading tags

### DIFF
--- a/plumbing/format/packfile/decoder.go
+++ b/plumbing/format/packfile/decoder.go
@@ -276,9 +276,11 @@ func (d *Decoder) recallByHash(h plumbing.Hash) (plumbing.Object, error) {
 		}
 	}
 
-	obj, err := d.tx.Object(plumbing.AnyObject, h)
-	if err != plumbing.ErrObjectNotFound {
-		return obj, err
+	if d.tx != nil {
+		obj, err := d.tx.Object(plumbing.AnyObject, h)
+		if err != plumbing.ErrObjectNotFound {
+			return obj, err
+		}
 	}
 
 	return nil, plumbing.ErrObjectNotFound


### PR DESCRIPTION
I've a private repo which trigger panic while scanning repo for tags using this code:
```go
if tagIter, err := repo.Tags(); err == nil {
	for tag, err := tagIter.Next(); err == nil; tag, err = tagIter.Next() {} // this line triggers panic
}
```
Usually this repo didn't trigger the panic, but it was cloned by our CI with depth limit. Because of this depth limit our application fails to find version tags in the repo, so I've run `git fetch --unshallow` first, and then run our application again - and this result in the panic.

I've no idea is proposed fix is correct - I don't know that's in the `d.tx` and not sure is `return nil, plumbing.ErrObjectNotFound` right thing to do if `d.tx==nil`, but this fix an issue for me and at a glance looks like code which search for tags works ok with this fix.

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x28 pc=0x615063]

goroutine 1 [running]:
panic(0x8166c0, 0xc42000c140)
	/usr/lib/go/src/runtime/panic.go:500 +0x1a1
gopkg.in/src-d/go-git.v4/plumbing/format/packfile.(*Decoder).recallByHash(0xc4202c80c0, 0x94381b747ef6cb70, 0x66250b3b002b5acb, 0x5d14cea, 0xc4d7b2be59, 0x0, 0x0, 0xc42017edc0)
	/home/powerman/gocode/src/gopkg.in/src-d/go-git.v4/plumbing/format/packfile/decoder.go:280 +0x43
gopkg.in/src-d/go-git.v4/plumbing/format/packfile.(*Decoder).fillREFDeltaObjectContent(0xc4202c80c0, 0xa825c0, 0xc42017edc0, 0x94381b747ef6cb70, 0x66250b3b002b5acb, 0x7112576305d14cea, 0x9036ceed, 0x7b7380, 0xb5ad6879fa41bc19)
	/home/powerman/gocode/src/gopkg.in/src-d/go-git.v4/plumbing/format/packfile/decoder.go:226 +0xe6
gopkg.in/src-d/go-git.v4/plumbing/format/packfile.(*Decoder).ReadObject(0xc4202c80c0, 0xac32c0, 0x14, 0xb5ad6879fa41bc00, 0x9036ceed71125763)
	/home/powerman/gocode/src/gopkg.in/src-d/go-git.v4/plumbing/format/packfile/decoder.go:162 +0x465
gopkg.in/src-d/go-git.v4/storage/filesystem.(*packfileIter).Next(0xc4202c6600, 0xc420179502, 0xc4203c22ec, 0xac3f60, 0x0)
	/home/powerman/gocode/src/gopkg.in/src-d/go-git.v4/storage/filesystem/object.go:300 +0x41
gopkg.in/src-d/go-git.v4/storage/filesystem.(*packfileIter).Next(0xc4202c6600, 0xc420179502, 0xc4203c234c, 0xac3f60, 0x0)
	/home/powerman/gocode/src/gopkg.in/src-d/go-git.v4/storage/filesystem/object.go:311 +0x140
gopkg.in/src-d/go-git.v4/storage/filesystem.(*packfileIter).Next(0xc4202c6600, 0xc420179502, 0xc4203c23ac, 0xac3f60, 0x0)
	/home/powerman/gocode/src/gopkg.in/src-d/go-git.v4/storage/filesystem/object.go:311 +0x140
gopkg.in/src-d/go-git.v4/storage/filesystem.(*packfileIter).Next(0xc4202c6600, 0xc420179502, 0xc4203c240c, 0xac3f60, 0x0)
	/home/powerman/gocode/src/gopkg.in/src-d/go-git.v4/storage/filesystem/object.go:311 +0x140
gopkg.in/src-d/go-git.v4/storage/filesystem.(*packfileIter).Next(0xc4202c6600, 0xc420179501, 0xc4203c246c, 0xac3f60, 0x0)
	/home/powerman/gocode/src/gopkg.in/src-d/go-git.v4/storage/filesystem/object.go:311 +0x140
gopkg.in/src-d/go-git.v4/storage/filesystem.(*packfileIter).Next(0xc4202c6600, 0xc420179501, 0xc4203c24cc, 0xac3f60, 0x0)
	/home/powerman/gocode/src/gopkg.in/src-d/go-git.v4/storage/filesystem/object.go:311 +0x140
gopkg.in/src-d/go-git.v4/storage/filesystem.(*packfileIter).Next(0xc4202c6600, 0xc420179501, 0xc4203c252c, 0xac3f60, 0x0)
	/home/powerman/gocode/src/gopkg.in/src-d/go-git.v4/storage/filesystem/object.go:311 +0x140
gopkg.in/src-d/go-git.v4/storage/filesystem.(*packfileIter).Next(0xc4202c6600, 0xc420179501, 0xc4203c258c, 0xac3f60, 0x0)
	/home/powerman/gocode/src/gopkg.in/src-d/go-git.v4/storage/filesystem/object.go:311 +0x140
gopkg.in/src-d/go-git.v4/storage/filesystem.(*packfileIter).Next(0xc4202c6600, 0xc420179501, 0xc4203c25ec, 0xac3f60, 0x0)
	/home/powerman/gocode/src/gopkg.in/src-d/go-git.v4/storage/filesystem/object.go:311 +0x140
gopkg.in/src-d/go-git.v4/storage/filesystem.(*packfileIter).Next(0xc4202c6600, 0xc420179501, 0xc4203c264c, 0xac3f60, 0x0)
	/home/powerman/gocode/src/gopkg.in/src-d/go-git.v4/storage/filesystem/object.go:311 +0x140
gopkg.in/src-d/go-git.v4/storage/filesystem.(*packfileIter).Next(0xc4202c6600, 0xc420179501, 0xc4203c26ac, 0xac3f60, 0x0)
	/home/powerman/gocode/src/gopkg.in/src-d/go-git.v4/storage/filesystem/object.go:311 +0x140
gopkg.in/src-d/go-git.v4/storage/filesystem.(*packfileIter).Next(0xc4202c6600, 0xc420179501, 0xc4203c270c, 0xac3f60, 0x0)
	/home/powerman/gocode/src/gopkg.in/src-d/go-git.v4/storage/filesystem/object.go:311 +0x140
gopkg.in/src-d/go-git.v4/storage/filesystem.(*packfileIter).Next(0xc4202c6600, 0xc420179501, 0xc4203c276c, 0xac3f60, 0x0)
	/home/powerman/gocode/src/gopkg.in/src-d/go-git.v4/storage/filesystem/object.go:311 +0x140
gopkg.in/src-d/go-git.v4/storage/filesystem.(*packfileIter).Next(0xc4202c6600, 0xc420179501, 0xc4203c27cc, 0xac3f60, 0x0)
	/home/powerman/gocode/src/gopkg.in/src-d/go-git.v4/storage/filesystem/object.go:311 +0x140
gopkg.in/src-d/go-git.v4/storage/filesystem.(*packfileIter).Next(0xc4202c6600, 0xc420179501, 0xc4203c282c, 0xac3f60, 0x0)
	/home/powerman/gocode/src/gopkg.in/src-d/go-git.v4/storage/filesystem/object.go:311 +0x140
gopkg.in/src-d/go-git.v4/storage/filesystem.(*packfileIter).Next(0xc4202c6600, 0xc420179501, 0xc4203c288c, 0xac3f60, 0x0)
	/home/powerman/gocode/src/gopkg.in/src-d/go-git.v4/storage/filesystem/object.go:311 +0x140
gopkg.in/src-d/go-git.v4/storage/filesystem.(*packfileIter).Next(0xc4202c6600, 0xc420179501, 0xc4203c28ec, 0xac3f60, 0x0)
	/home/powerman/gocode/src/gopkg.in/src-d/go-git.v4/storage/filesystem/object.go:311 +0x140
gopkg.in/src-d/go-git.v4/storage/filesystem.(*packfileIter).Next(0xc4202c6600, 0xc420179501, 0xc4203c294c, 0xac3f60, 0x0)
	/home/powerman/gocode/src/gopkg.in/src-d/go-git.v4/storage/filesystem/object.go:311 +0x140
gopkg.in/src-d/go-git.v4/storage/filesystem.(*packfileIter).Next(0xc4202c6600, 0xc420179501, 0xc4203c29ac, 0xac3f60, 0x0)
	/home/powerman/gocode/src/gopkg.in/src-d/go-git.v4/storage/filesystem/object.go:311 +0x140
gopkg.in/src-d/go-git.v4/storage/filesystem.(*packfileIter).Next(0xc4202c6600, 0xc420179501, 0xc4203c2a0c, 0xac3f60, 0x0)
	/home/powerman/gocode/src/gopkg.in/src-d/go-git.v4/storage/filesystem/object.go:311 +0x140
gopkg.in/src-d/go-git.v4/storage/filesystem.(*packfileIter).Next(0xc4202c6600, 0xc420179501, 0xc4203c2a6c, 0xac3f60, 0x0)
	/home/powerman/gocode/src/gopkg.in/src-d/go-git.v4/storage/filesystem/object.go:311 +0x140
gopkg.in/src-d/go-git.v4/storage/filesystem.(*packfileIter).Next(0xc4202c6600, 0xc420179501, 0xc4203c2acc, 0xac3f60, 0x0)
	/home/powerman/gocode/src/gopkg.in/src-d/go-git.v4/storage/filesystem/object.go:311 +0x140
gopkg.in/src-d/go-git.v4/storage/filesystem.(*packfileIter).Next(0xc4202c6600, 0xc420179501, 0xc4203c2b2c, 0xac3f60, 0x0)
	/home/powerman/gocode/src/gopkg.in/src-d/go-git.v4/storage/filesystem/object.go:311 +0x140
gopkg.in/src-d/go-git.v4/storage/filesystem.(*packfileIter).Next(0xc4202c6600, 0xc420179501, 0xc4203c2b8c, 0xac3f60, 0x0)
	/home/powerman/gocode/src/gopkg.in/src-d/go-git.v4/storage/filesystem/object.go:311 +0x140
gopkg.in/src-d/go-git.v4/storage/filesystem.(*packfileIter).Next(0xc4202c6600, 0xc420179501, 0xc4203c2bec, 0xac3f60, 0x0)
	/home/powerman/gocode/src/gopkg.in/src-d/go-git.v4/storage/filesystem/object.go:311 +0x140
gopkg.in/src-d/go-git.v4/storage/filesystem.(*packfileIter).Next(0xc4202c6600, 0xc420179501, 0xc4203c2c4c, 0xac3f60, 0x0)
	/home/powerman/gocode/src/gopkg.in/src-d/go-git.v4/storage/filesystem/object.go:311 +0x140
gopkg.in/src-d/go-git.v4/storage/filesystem.(*packfileIter).Next(0xc4202c6600, 0xc420179501, 0xc4203c2cac, 0xac3f60, 0x0)
	/home/powerman/gocode/src/gopkg.in/src-d/go-git.v4/storage/filesystem/object.go:311 +0x140
gopkg.in/src-d/go-git.v4/storage/filesystem.(*packfileIter).Next(0xc4202c6600, 0xc420179501, 0xc4203c2d0c, 0xac3f60, 0x0)
	/home/powerman/gocode/src/gopkg.in/src-d/go-git.v4/storage/filesystem/object.go:311 +0x140
gopkg.in/src-d/go-git.v4/storage/filesystem.(*packfileIter).Next(0xc4202c6600, 0xc420179501, 0xc4203c2d6c, 0xac3f60, 0x0)
	/home/powerman/gocode/src/gopkg.in/src-d/go-git.v4/storage/filesystem/object.go:311 +0x140
gopkg.in/src-d/go-git.v4/storage/filesystem.(*packfileIter).Next(0xc4202c6600, 0xc420179501, 0xc4203c2dcc, 0xac3f60, 0x0)
	/home/powerman/gocode/src/gopkg.in/src-d/go-git.v4/storage/filesystem/object.go:311 +0x140
gopkg.in/src-d/go-git.v4/storage/filesystem.(*packfileIter).Next(0xc4202c6600, 0xc420179501, 0xc4203c2e2c, 0xac3f60, 0x0)
	/home/powerman/gocode/src/gopkg.in/src-d/go-git.v4/storage/filesystem/object.go:311 +0x140
gopkg.in/src-d/go-git.v4/storage/filesystem.(*packfileIter).Next(0xc4202c6600, 0xc420179501, 0xc4203c2e8c, 0xac3f60, 0x0)
	/home/powerman/gocode/src/gopkg.in/src-d/go-git.v4/storage/filesystem/object.go:311 +0x140
gopkg.in/src-d/go-git.v4/storage/filesystem.(*packfileIter).Next(0xc4202c6600, 0xc420179501, 0xc4203c2eec, 0xac3f60, 0x0)
	/home/powerman/gocode/src/gopkg.in/src-d/go-git.v4/storage/filesystem/object.go:311 +0x140
gopkg.in/src-d/go-git.v4/storage/filesystem.(*packfileIter).Next(0xc4202c6600, 0xc420179501, 0xc4203c2f4c, 0xac3f60, 0x0)
	/home/powerman/gocode/src/gopkg.in/src-d/go-git.v4/storage/filesystem/object.go:311 +0x140
gopkg.in/src-d/go-git.v4/storage/filesystem.(*packfileIter).Next(0xc4202c6600, 0xc420179501, 0xc4203c2fac, 0xac3f60, 0x0)
	/home/powerman/gocode/src/gopkg.in/src-d/go-git.v4/storage/filesystem/object.go:311 +0x140
gopkg.in/src-d/go-git.v4/storage/filesystem.(*packfileIter).Next(0xc4202c6600, 0xc420179501, 0xc4203c300c, 0xac3f60, 0x0)
	/home/powerman/gocode/src/gopkg.in/src-d/go-git.v4/storage/filesystem/object.go:311 +0x140
gopkg.in/src-d/go-git.v4/storage/filesystem.(*packfileIter).Next(0xc4202c6600, 0xc420179501, 0xc4203c306c, 0xac3f60, 0x0)
	/home/powerman/gocode/src/gopkg.in/src-d/go-git.v4/storage/filesystem/object.go:311 +0x140
gopkg.in/src-d/go-git.v4/storage/filesystem.(*packfileIter).Next(0xc4202c6600, 0xc420179501, 0xc4203c30cc, 0xac3f60, 0x0)
	/home/powerman/gocode/src/gopkg.in/src-d/go-git.v4/storage/filesystem/object.go:311 +0x140
gopkg.in/src-d/go-git.v4/storage/filesystem.(*packfileIter).Next(0xc4202c6600, 0xc420179501, 0xc4203c312c, 0xac3f60, 0x0)
	/home/powerman/gocode/src/gopkg.in/src-d/go-git.v4/storage/filesystem/object.go:311 +0x140
gopkg.in/src-d/go-git.v4/storage/filesystem.(*packfileIter).Next(0xc4202c6600, 0xc420179501, 0xc4203c318c, 0xac3f60, 0x0)
	/home/powerman/gocode/src/gopkg.in/src-d/go-git.v4/storage/filesystem/object.go:311 +0x140
gopkg.in/src-d/go-git.v4/storage/filesystem.(*packfileIter).Next(0xc4202c6600, 0xc420179501, 0xc4203c31ec, 0xac3f60, 0x0)
	/home/powerman/gocode/src/gopkg.in/src-d/go-git.v4/storage/filesystem/object.go:311 +0x140
gopkg.in/src-d/go-git.v4/storage/filesystem.(*packfileIter).Next(0xc4202c6600, 0xc420179501, 0xc4203c324c, 0xac3f60, 0x0)
	/home/powerman/gocode/src/gopkg.in/src-d/go-git.v4/storage/filesystem/object.go:311 +0x140
gopkg.in/src-d/go-git.v4/storage/filesystem.(*packfileIter).Next(0xc4202c6600, 0xc420179501, 0xc4203c32ac, 0xac3f60, 0x0)
	/home/powerman/gocode/src/gopkg.in/src-d/go-git.v4/storage/filesystem/object.go:311 +0x140
gopkg.in/src-d/go-git.v4/storage/filesystem.(*packfileIter).Next(0xc4202c6600, 0xc420179501, 0xc4203c330c, 0xac3f60, 0x0)
	/home/powerman/gocode/src/gopkg.in/src-d/go-git.v4/storage/filesystem/object.go:311 +0x140
gopkg.in/src-d/go-git.v4/storage/filesystem.(*packfileIter).Next(0xc4202c6600, 0xc420179501, 0xc4203c336c, 0xac3f60, 0x0)
	/home/powerman/gocode/src/gopkg.in/src-d/go-git.v4/storage/filesystem/object.go:311 +0x140
gopkg.in/src-d/go-git.v4/storage/filesystem.(*packfileIter).Next(0xc4202c6600, 0xc420179501, 0xc4203c33cc, 0xac3f60, 0x0)
	/home/powerman/gocode/src/gopkg.in/src-d/go-git.v4/storage/filesystem/object.go:311 +0x140
gopkg.in/src-d/go-git.v4/storage/filesystem.(*packfileIter).Next(0xc4202c6600, 0xc420179501, 0xc4203c342c, 0xac3f60, 0x0)
	/home/powerman/gocode/src/gopkg.in/src-d/go-git.v4/storage/filesystem/object.go:311 +0x140
gopkg.in/src-d/go-git.v4/storage/filesystem.(*packfileIter).Next(0xc4202c6600, 0xc420179501, 0xc4203c348c, 0xac3f60, 0x0)
	/home/powerman/gocode/src/gopkg.in/src-d/go-git.v4/storage/filesystem/object.go:311 +0x140
gopkg.in/src-d/go-git.v4/storage/filesystem.(*packfileIter).Next(0xc4202c6600, 0xc420179501, 0xc4203c34ec, 0xac3f60, 0x0)
	/home/powerman/gocode/src/gopkg.in/src-d/go-git.v4/storage/filesystem/object.go:311 +0x140
gopkg.in/src-d/go-git.v4/storage/filesystem.(*packfileIter).Next(0xc4202c6600, 0xc420179501, 0xc4203c354c, 0xac3f60, 0x0)
	/home/powerman/gocode/src/gopkg.in/src-d/go-git.v4/storage/filesystem/object.go:311 +0x140
gopkg.in/src-d/go-git.v4/storage/filesystem.(*packfileIter).Next(0xc4202c6600, 0xc420179501, 0xc4203c35ac, 0xac3f60, 0x0)
	/home/powerman/gocode/src/gopkg.in/src-d/go-git.v4/storage/filesystem/object.go:311 +0x140
gopkg.in/src-d/go-git.v4/storage/filesystem.(*packfileIter).Next(0xc4202c6600, 0xc420179501, 0xc4203c360c, 0xac3f60, 0x0)
	/home/powerman/gocode/src/gopkg.in/src-d/go-git.v4/storage/filesystem/object.go:311 +0x140
gopkg.in/src-d/go-git.v4/storage/filesystem.(*packfileIter).Next(0xc4202c6600, 0xc420179501, 0xc4203c366c, 0xac3f60, 0x0)
	/home/powerman/gocode/src/gopkg.in/src-d/go-git.v4/storage/filesystem/object.go:311 +0x140
gopkg.in/src-d/go-git.v4/storage/filesystem.(*packfileIter).Next(0xc4202c6600, 0xc420179501, 0xc4203c36cc, 0xac3f60, 0x0)
	/home/powerman/gocode/src/gopkg.in/src-d/go-git.v4/storage/filesystem/object.go:311 +0x140
gopkg.in/src-d/go-git.v4/storage/filesystem.(*packfileIter).Next(0xc4202c6600, 0xc420179501, 0xc4203c372c, 0xac3f60, 0x0)
	/home/powerman/gocode/src/gopkg.in/src-d/go-git.v4/storage/filesystem/object.go:311 +0x140
gopkg.in/src-d/go-git.v4/storage/filesystem.(*packfileIter).Next(0xc4202c6600, 0xc420179501, 0xc4203c378c, 0xac3f60, 0x0)
	/home/powerman/gocode/src/gopkg.in/src-d/go-git.v4/storage/filesystem/object.go:311 +0x140
gopkg.in/src-d/go-git.v4/storage/filesystem.(*packfileIter).Next(0xc4202c6600, 0xc420179501, 0xc4203c37ec, 0xac3f60, 0x0)
	/home/powerman/gocode/src/gopkg.in/src-d/go-git.v4/storage/filesystem/object.go:311 +0x140
gopkg.in/src-d/go-git.v4/storage/filesystem.(*packfileIter).Next(0xc4202c6600, 0xc420179501, 0xc4203c384c, 0xac3f60, 0x0)
	/home/powerman/gocode/src/gopkg.in/src-d/go-git.v4/storage/filesystem/object.go:311 +0x140
gopkg.in/src-d/go-git.v4/storage/filesystem.(*packfileIter).Next(0xc4202c6600, 0xc420179501, 0xc4203c38ac, 0xac3f60, 0x0)
	/home/powerman/gocode/src/gopkg.in/src-d/go-git.v4/storage/filesystem/object.go:311 +0x140
gopkg.in/src-d/go-git.v4/storage/filesystem.(*packfileIter).Next(0xc4202c6600, 0xc420179501, 0xc4203c390c, 0xac3f60, 0x0)
	/home/powerman/gocode/src/gopkg.in/src-d/go-git.v4/storage/filesystem/object.go:311 +0x140
gopkg.in/src-d/go-git.v4/storage/filesystem.(*packfileIter).Next(0xc4202c6600, 0xc420179501, 0xc4203c396c, 0xac3f60, 0x0)
	/home/powerman/gocode/src/gopkg.in/src-d/go-git.v4/storage/filesystem/object.go:311 +0x140
gopkg.in/src-d/go-git.v4/storage/filesystem.(*packfileIter).Next(0xc4202c6600, 0x0, 0xcace677eedabaa33, 0x0, 0xc420563a28)
	/home/powerman/gocode/src/gopkg.in/src-d/go-git.v4/storage/filesystem/object.go:311 +0x140
gopkg.in/src-d/go-git.v4/plumbing/storer.(*MultiObjectIter).Next(0xc4202ba4c0, 0x0, 0xc420563de8, 0x0, 0x0)
	/home/powerman/gocode/src/gopkg.in/src-d/go-git.v4/plumbing/storer/object.go:190 +0x47
gopkg.in/src-d/go-git%2ev4.(*TagIter).Next(0xc4202ba4e0, 0xc420563c18, 0xc420192b21, 0xc420192ac8)
	/home/powerman/gocode/src/gopkg.in/src-d/go-git.v4/tag.go:202 +0x37
main.main()
	/home/powerman/gocode/src/github.com/inCaller/srv-common/cmd/inCaller-gen-version/main.go:106 +0x91f
```