### PR TITLE
plumbing/transport: add common tests and fixes.

### DIFF
--- a/plumbing/format/packp/advrefs/decoder.go
+++ b/plumbing/format/packp/advrefs/decoder.go
@@ -86,6 +86,12 @@ func decodePrefix(d *Decoder) decoderStateFn {
 		return nil
 	}
 
+	// If the repository is empty, we receive a flush here (SSH).
+	if isFlush(d.line) {
+		d.err = ErrEmpty
+		return nil
+	}
+
 	if isPrefix(d.line) {
 		tmp := make([]byte, len(d.line))
 		copy(tmp, d.line)
@@ -117,6 +123,12 @@ func isFlush(payload []byte) bool {
 // list-of-refs is comming, and the hash will be followed by the first
 // advertised ref.
 func decodeFirstHash(p *Decoder) decoderStateFn {
+	// If the repository is empty, we receive a flush here (HTTP).
+	if isFlush(p.line) {
+		p.err = ErrEmpty
+		return nil
+	}
+
 	if len(p.line) < hashSize {
 		p.error("cannot read hash, pkt-line too short")
 		return nil

--- a/plumbing/format/packp/advrefs/decoder_test.go
+++ b/plumbing/format/packp/advrefs/decoder_test.go
@@ -26,6 +26,32 @@ func (s *SuiteDecoder) TestEmpty(c *C) {
 	c.Assert(err, Equals, advrefs.ErrEmpty)
 }
 
+func (s *SuiteDecoder) TestEmptyFlush(c *C) {
+	ar := advrefs.New()
+	var buf bytes.Buffer
+	e := pktline.NewEncoder(&buf)
+	e.Flush()
+
+	d := advrefs.NewDecoder(&buf)
+
+	err := d.Decode(ar)
+	c.Assert(err, Equals, advrefs.ErrEmpty)
+}
+
+func (s *SuiteDecoder) TestEmptyPrefixFlush(c *C) {
+	ar := advrefs.New()
+	var buf bytes.Buffer
+	e := pktline.NewEncoder(&buf)
+	e.EncodeString("# service=git-upload-pack")
+	e.Flush()
+	e.Flush()
+
+	d := advrefs.NewDecoder(&buf)
+
+	err := d.Decode(ar)
+	c.Assert(err, Equals, advrefs.ErrEmpty)
+}
+
 func (s *SuiteDecoder) TestShortForHash(c *C) {
 	payloads := []string{
 		"6ecf0ef2c2dffb796",

--- a/plumbing/transport/client/client_test.go
+++ b/plumbing/transport/client/client_test.go
@@ -22,14 +22,14 @@ func (s *ClientSuite) TestNewClientHTTP(c *C) {
 
 	output, err := NewClient(e)
 	c.Assert(err, IsNil)
-	c.Assert(typeAsString(output), Equals, "*http.Client")
+	c.Assert(typeAsString(output), Equals, "*http.client")
 
 	e, err = transport.NewEndpoint("https://github.com/src-d/go-git")
 	c.Assert(err, IsNil)
 
 	output, err = NewClient(e)
 	c.Assert(err, IsNil)
-	c.Assert(typeAsString(output), Equals, "*http.Client")
+	c.Assert(typeAsString(output), Equals, "*http.client")
 }
 
 func (s *ClientSuite) TestNewClientSSH(c *C) {
@@ -38,7 +38,7 @@ func (s *ClientSuite) TestNewClientSSH(c *C) {
 
 	output, err := NewClient(e)
 	c.Assert(err, IsNil)
-	c.Assert(typeAsString(output), Equals, "*ssh.Client")
+	c.Assert(typeAsString(output), Equals, "*ssh.client")
 }
 
 func (s *ClientSuite) TestNewClientUnknown(c *C) {

--- a/plumbing/transport/common.go
+++ b/plumbing/transport/common.go
@@ -24,9 +24,12 @@ import (
 
 var (
 	ErrRepositoryNotFound     = errors.New("repository not found")
+	ErrEmptyRemoteRepository  = errors.New("remote repository is empty")
 	ErrAuthorizationRequired  = errors.New("authorization required")
 	ErrEmptyUploadPackRequest = errors.New("empty git-upload-pack given")
 	ErrInvalidAuthMethod      = errors.New("invalid auth method")
+
+	ErrAdvertistedReferencesAlreadyCalled = errors.New("cannot call AdvertisedReference twice")
 )
 
 const (

--- a/plumbing/transport/fetch_pack.go
+++ b/plumbing/transport/fetch_pack.go
@@ -129,13 +129,13 @@ func (r *UploadPackRequest) Have(h ...plumbing.Hash) {
 }
 
 func (r *UploadPackRequest) IsEmpty() bool {
-	if len(r.Haves) < len(r.Wants) {
-		return false
-	}
+	return isSubset(r.Wants, r.Haves)
+}
 
-	for _, h := range r.Wants {
+func isSubset(needle []plumbing.Hash, haystack []plumbing.Hash) bool {
+	for _, h := range needle {
 		found := false
-		for _, oh := range r.Haves {
+		for _, oh := range haystack {
 			if h == oh {
 				found = true
 				break

--- a/plumbing/transport/fetch_pack.go
+++ b/plumbing/transport/fetch_pack.go
@@ -33,7 +33,7 @@ func (i *UploadPackInfo) Decode(r io.Reader) error {
 	ar := advrefs.New()
 	if err := d.Decode(ar); err != nil {
 		if err == advrefs.ErrEmpty {
-			return plumbing.NewPermanentError(err)
+			return err
 		}
 		return plumbing.NewUnexpectedError(err)
 	}
@@ -126,6 +126,28 @@ func (r *UploadPackRequest) Want(h ...plumbing.Hash) {
 
 func (r *UploadPackRequest) Have(h ...plumbing.Hash) {
 	r.Haves = append(r.Haves, h...)
+}
+
+func (r *UploadPackRequest) IsEmpty() bool {
+	if len(r.Haves) < len(r.Wants) {
+		return false
+	}
+
+	for _, h := range r.Wants {
+		found := false
+		for _, oh := range r.Haves {
+			if h == oh {
+				found = true
+				break
+			}
+		}
+
+		if !found {
+			return false
+		}
+	}
+
+	return true
 }
 
 func (r *UploadPackRequest) String() string {

--- a/plumbing/transport/fetch_pack_test.go
+++ b/plumbing/transport/fetch_pack_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/base64"
 
 	"gopkg.in/src-d/go-git.v4/plumbing"
+	"gopkg.in/src-d/go-git.v4/plumbing/format/packp/advrefs"
 
 	. "gopkg.in/check.v1"
 )
@@ -58,7 +59,7 @@ func (s *UploadPackSuite) TestUploadPackInfoEmpty(c *C) {
 
 	i := NewUploadPackInfo()
 	err := i.Decode(b)
-	c.Assert(err, ErrorMatches, "permanent.*empty.*")
+	c.Assert(err, Equals, advrefs.ErrEmpty)
 }
 
 func (s *UploadPackSuite) TestUploadPackEncode(c *C) {
@@ -93,4 +94,26 @@ func (s *UploadPackSuite) TestUploadPackRequest(c *C) {
 			"0032have 6ecf0ef2c2dffb796033e5a02219af86ec6584e5\n0000"+
 			"0009done\n",
 	)
+}
+
+func (s *UploadPackSuite) TestUploadPackRequest_IsEmpty(c *C) {
+	r := &UploadPackRequest{}
+	r.Want(plumbing.NewHash("d82f291cde9987322c8a0c81a325e1ba6159684c"))
+	r.Want(plumbing.NewHash("2b41ef280fdb67a9b250678686a0c3e03b0a9989"))
+	r.Have(plumbing.NewHash("6ecf0ef2c2dffb796033e5a02219af86ec6584e5"))
+
+	c.Assert(r.IsEmpty(), Equals, false)
+
+	r = &UploadPackRequest{}
+	r.Want(plumbing.NewHash("d82f291cde9987322c8a0c81a325e1ba6159684c"))
+	r.Want(plumbing.NewHash("2b41ef280fdb67a9b250678686a0c3e03b0a9989"))
+	r.Have(plumbing.NewHash("d82f291cde9987322c8a0c81a325e1ba6159684c"))
+
+	c.Assert(r.IsEmpty(), Equals, false)
+
+	r = &UploadPackRequest{}
+	r.Want(plumbing.NewHash("d82f291cde9987322c8a0c81a325e1ba6159684c"))
+	r.Have(plumbing.NewHash("d82f291cde9987322c8a0c81a325e1ba6159684c"))
+
+	c.Assert(r.IsEmpty(), Equals, true)
 }

--- a/plumbing/transport/http/common.go
+++ b/plumbing/transport/http/common.go
@@ -9,33 +9,38 @@ import (
 	"gopkg.in/src-d/go-git.v4/plumbing/transport"
 )
 
-type Client struct {
+type client struct {
 	c *http.Client
 }
 
+// DefaultClient is the default HTTP client, which uses `http.DefaultClient`.
 var DefaultClient = NewClient(nil)
 
 // NewClient creates a new client with a custom net/http client.
 // See `InstallProtocol` to install and override default http client.
 // Unless a properly initialized client is given, it will fall back into
 // `http.DefaultClient`.
+//
+// Note that for HTTP client cannot distinguist between private repositories and
+// unexistent repositories on GitHub. So it returns `ErrAuthorizationRequired`
+// for both.
 func NewClient(c *http.Client) transport.Client {
 	if c == nil {
-		return &Client{http.DefaultClient}
+		return &client{http.DefaultClient}
 	}
 
-	return &Client{
+	return &client{
 		c: c,
 	}
 }
 
-func (c *Client) NewFetchPackSession(ep transport.Endpoint) (
+func (c *client) NewFetchPackSession(ep transport.Endpoint) (
 	transport.FetchPackSession, error) {
 
 	return newFetchPackSession(c.c, ep), nil
 }
 
-func (c *Client) NewSendPackSession(ep transport.Endpoint) (
+func (c *client) NewSendPackSession(ep transport.Endpoint) (
 	transport.SendPackSession, error) {
 
 	return newSendPackSession(c.c, ep), nil

--- a/plumbing/transport/http/common_test.go
+++ b/plumbing/transport/http/common_test.go
@@ -20,16 +20,20 @@ var _ = Suite(&ClientSuite{})
 
 func (s *ClientSuite) SetUpSuite(c *C) {
 	var err error
-	s.Endpoint, err = transport.NewEndpoint("https://github.com/git-fixtures/basic")
+	s.Endpoint, err = transport.NewEndpoint(
+		"https://github.com/git-fixtures/basic",
+	)
 	c.Assert(err, IsNil)
 }
 
 func (s *FetchPackSuite) TestNewClient(c *C) {
-	roundTripper := &http.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: true}}
-	client := &http.Client{Transport: roundTripper}
-	r := NewClient(client).(*Client)
-
-	c.Assert(r.c, Equals, client)
+	roundTripper := &http.Transport{
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+	}
+	cl := &http.Client{Transport: roundTripper}
+	r, ok := NewClient(cl).(*client)
+	c.Assert(ok, Equals, true)
+	c.Assert(r.c, Equals, cl)
 }
 
 func (s *ClientSuite) TestNewBasicAuth(c *C) {
@@ -54,7 +58,8 @@ func (s *ClientSuite) TestNewErrNotFound(c *C) {
 }
 
 func (s *ClientSuite) TestNewHTTPError40x(c *C) {
-	s.testNewHTTPError(c, http.StatusPaymentRequired, "unexpected client error.*")
+	s.testNewHTTPError(c, http.StatusPaymentRequired,
+		"unexpected client error.*")
 }
 
 func (s *ClientSuite) testNewHTTPError(c *C, code int, msg string) {

--- a/plumbing/transport/http/fetch_pack_test.go
+++ b/plumbing/transport/http/fetch_pack_test.go
@@ -1,122 +1,38 @@
 package http
 
 import (
-	"fmt"
-	"io/ioutil"
-
-	"gopkg.in/src-d/go-git.v4/plumbing"
 	"gopkg.in/src-d/go-git.v4/plumbing/transport"
+	"gopkg.in/src-d/go-git.v4/plumbing/transport/test"
 
 	. "gopkg.in/check.v1"
 )
 
 type FetchPackSuite struct {
-	Endpoint transport.Endpoint
+	test.FetchPackSuite
 }
 
 var _ = Suite(&FetchPackSuite{})
 
 func (s *FetchPackSuite) SetUpSuite(c *C) {
-	fmt.Println("SetUpSuite\n")
-	var err error
-	s.Endpoint, err = transport.NewEndpoint("https://github.com/git-fixtures/basic")
+	s.FetchPackSuite.Client = DefaultClient
+
+	ep, err := transport.NewEndpoint("https://github.com/git-fixtures/basic.git")
 	c.Assert(err, IsNil)
+	s.FetchPackSuite.Endpoint = ep
+
+	ep, err = transport.NewEndpoint("https://github.com/git-fixtures/empty.git")
+	c.Assert(err, IsNil)
+	s.FetchPackSuite.EmptyEndpoint = ep
+
+	ep, err = transport.NewEndpoint("https://github.com/git-fixtures/non-existent.git")
+	c.Assert(err, IsNil)
+	s.FetchPackSuite.NonExistentEndpoint = ep
 }
 
-func (s *FetchPackSuite) TestInfoEmpty(c *C) {
-	endpoint, _ := transport.NewEndpoint("https://github.com/git-fixture/empty")
-	r, err := DefaultClient.NewFetchPackSession(endpoint)
-	c.Assert(err, IsNil)
-	info, err := r.AdvertisedReferences()
-	c.Assert(err, Equals, transport.ErrAuthorizationRequired)
-	c.Assert(info, IsNil)
-}
-
-//TODO: Test this error with HTTP BasicAuth too.
 func (s *FetchPackSuite) TestInfoNotExists(c *C) {
-	endpoint, _ := transport.NewEndpoint("https://github.com/git-fixture/not-exists")
-	r, err := DefaultClient.NewFetchPackSession(endpoint)
+	r, err := s.Client.NewFetchPackSession(s.NonExistentEndpoint)
 	c.Assert(err, IsNil)
 	info, err := r.AdvertisedReferences()
 	c.Assert(err, Equals, transport.ErrAuthorizationRequired)
 	c.Assert(info, IsNil)
-}
-
-func (s *FetchPackSuite) TestDefaultBranch(c *C) {
-	r, err := DefaultClient.NewFetchPackSession(s.Endpoint)
-	c.Assert(err, IsNil)
-	info, err := r.AdvertisedReferences()
-	c.Assert(err, IsNil)
-	c.Assert(info.Capabilities.SymbolicReference("HEAD"), Equals, "refs/heads/master")
-}
-
-func (s *FetchPackSuite) TestCapabilities(c *C) {
-	r, err := DefaultClient.NewFetchPackSession(s.Endpoint)
-	c.Assert(err, IsNil)
-	info, err := r.AdvertisedReferences()
-	c.Assert(err, IsNil)
-	c.Assert(info.Capabilities.Get("agent").Values, HasLen, 1)
-}
-
-func (s *FetchPackSuite) TestFullFetchPack(c *C) {
-	r, err := DefaultClient.NewFetchPackSession(s.Endpoint)
-	c.Assert(err, IsNil)
-
-	info, err := r.AdvertisedReferences()
-	c.Assert(err, IsNil)
-	c.Assert(info, NotNil)
-
-	req := &transport.UploadPackRequest{}
-	req.Want(plumbing.NewHash("6ecf0ef2c2dffb796033e5a02219af86ec6584e5"))
-
-	reader, err := r.FetchPack(req)
-	c.Assert(err, IsNil)
-
-	b, err := ioutil.ReadAll(reader)
-	c.Assert(err, IsNil)
-	c.Assert(b, HasLen, 85374)
-}
-
-func (s *FetchPackSuite) TestFetchPack(c *C) {
-	r, err := DefaultClient.NewFetchPackSession(s.Endpoint)
-	c.Assert(err, IsNil)
-
-	req := &transport.UploadPackRequest{}
-	req.Want(plumbing.NewHash("6ecf0ef2c2dffb796033e5a02219af86ec6584e5"))
-
-	reader, err := r.FetchPack(req)
-	c.Assert(err, IsNil)
-
-	b, err := ioutil.ReadAll(reader)
-	c.Assert(err, IsNil)
-	c.Assert(b, HasLen, 85374)
-}
-
-func (s *FetchPackSuite) TestFetchPackNoChanges(c *C) {
-	r, err := DefaultClient.NewFetchPackSession(s.Endpoint)
-	c.Assert(err, IsNil)
-
-	req := &transport.UploadPackRequest{}
-	req.Want(plumbing.NewHash("6ecf0ef2c2dffb796033e5a02219af86ec6584e5"))
-	req.Have(plumbing.NewHash("6ecf0ef2c2dffb796033e5a02219af86ec6584e5"))
-
-	reader, err := r.FetchPack(req)
-	c.Assert(err, Equals, transport.ErrEmptyUploadPackRequest)
-	c.Assert(reader, IsNil)
-}
-
-func (s *FetchPackSuite) TestFetchPackMulti(c *C) {
-	r, err := DefaultClient.NewFetchPackSession(s.Endpoint)
-	c.Assert(err, IsNil)
-
-	req := &transport.UploadPackRequest{}
-	req.Want(plumbing.NewHash("6ecf0ef2c2dffb796033e5a02219af86ec6584e5"))
-	req.Want(plumbing.NewHash("e8d3ffab552895c19b9fcf7aa264d277cde33881"))
-
-	reader, err := r.FetchPack(req)
-	c.Assert(err, IsNil)
-
-	b, err := ioutil.ReadAll(reader)
-	c.Assert(err, IsNil)
-	c.Assert(b, HasLen, 85585)
 }

--- a/plumbing/transport/ssh/common_test.go
+++ b/plumbing/transport/ssh/common_test.go
@@ -7,11 +7,3 @@ import (
 )
 
 func Test(t *testing.T) { TestingT(t) }
-
-type ClientSuite struct{}
-
-var _ = Suite(&ClientSuite{})
-
-func (s *ClientSuite) TestNewClient(c *C) {
-	c.Assert(DefaultClient, DeepEquals, NewClient())
-}

--- a/plumbing/transport/ssh/fetch_pack_test.go
+++ b/plumbing/transport/ssh/fetch_pack_test.go
@@ -1,100 +1,36 @@
 package ssh
 
 import (
-	"io/ioutil"
 	"os"
 
-	"gopkg.in/src-d/go-git.v4/plumbing"
 	"gopkg.in/src-d/go-git.v4/plumbing/transport"
+	"gopkg.in/src-d/go-git.v4/plumbing/transport/test"
 
 	. "gopkg.in/check.v1"
 )
 
 type FetchPackSuite struct {
-	Endpoint transport.Endpoint
+	test.FetchPackSuite
 }
 
 var _ = Suite(&FetchPackSuite{})
 
 func (s *FetchPackSuite) SetUpSuite(c *C) {
-	var err error
-	s.Endpoint, err = transport.NewEndpoint("git@github.com:git-fixtures/basic.git")
-	c.Assert(err, IsNil)
-
 	if os.Getenv("SSH_AUTH_SOCK") == "" {
 		c.Skip("SSH_AUTH_SOCK is not set")
 	}
-}
 
-func (s *FetchPackSuite) TestDefaultBranch(c *C) {
-	r, err := DefaultClient.NewFetchPackSession(s.Endpoint)
+	s.FetchPackSuite.Client = DefaultClient
+
+	ep, err := transport.NewEndpoint("git@github.com:git-fixtures/basic.git")
 	c.Assert(err, IsNil)
-	defer func() { c.Assert(r.Close(), IsNil) }()
+	s.FetchPackSuite.Endpoint = ep
 
-	info, err := r.AdvertisedReferences()
+	ep, err = transport.NewEndpoint("git@github.com:git-fixtures/empty.git")
 	c.Assert(err, IsNil)
-	c.Assert(info.Capabilities.SymbolicReference("HEAD"), Equals, "refs/heads/master")
-}
+	s.FetchPackSuite.EmptyEndpoint = ep
 
-func (s *FetchPackSuite) TestCapabilities(c *C) {
-	r, err := DefaultClient.NewFetchPackSession(s.Endpoint)
+	ep, err = transport.NewEndpoint("git@github.com:git-fixtures/non-existent.git")
 	c.Assert(err, IsNil)
-	defer func() { c.Assert(r.Close(), IsNil) }()
-
-	info, err := r.AdvertisedReferences()
-	c.Assert(err, IsNil)
-	c.Assert(info.Capabilities.Get("agent").Values, HasLen, 1)
-}
-
-func (s *FetchPackSuite) TestFullFetchPack(c *C) {
-	r, err := DefaultClient.NewFetchPackSession(s.Endpoint)
-	c.Assert(err, IsNil)
-	defer func() { c.Assert(r.Close(), IsNil) }()
-
-	_, err = r.AdvertisedReferences()
-	c.Assert(err, IsNil)
-
-	req := &transport.UploadPackRequest{}
-	req.Want(plumbing.NewHash("6ecf0ef2c2dffb796033e5a02219af86ec6584e5"))
-	req.Want(plumbing.NewHash("e8d3ffab552895c19b9fcf7aa264d277cde33881"))
-	reader, err := r.FetchPack(req)
-	c.Assert(err, IsNil)
-
-	defer func() { c.Assert(reader.Close(), IsNil) }()
-
-	b, err := ioutil.ReadAll(reader)
-	c.Assert(err, IsNil)
-	c.Check(len(b), Equals, 85585)
-}
-
-func (s *FetchPackSuite) TestFetchPack(c *C) {
-	r, err := DefaultClient.NewFetchPackSession(s.Endpoint)
-	c.Assert(err, IsNil)
-	defer func() { c.Assert(r.Close(), IsNil) }()
-
-	req := &transport.UploadPackRequest{}
-	req.Want(plumbing.NewHash("6ecf0ef2c2dffb796033e5a02219af86ec6584e5"))
-	req.Want(plumbing.NewHash("e8d3ffab552895c19b9fcf7aa264d277cde33881"))
-	reader, err := r.FetchPack(req)
-	c.Assert(err, IsNil)
-	defer func() { c.Assert(reader.Close(), IsNil) }()
-
-	b, err := ioutil.ReadAll(reader)
-	c.Assert(err, IsNil)
-	c.Check(len(b), Equals, 85585)
-}
-
-func (s *FetchPackSuite) TestFetchError(c *C) {
-	r, err := DefaultClient.NewFetchPackSession(s.Endpoint)
-	c.Assert(err, IsNil)
-	defer func() { c.Assert(r.Close(), IsNil) }()
-
-	req := &transport.UploadPackRequest{}
-	req.Want(plumbing.NewHash("1111111111111111111111111111111111111111"))
-
-	reader, err := r.FetchPack(req)
-	c.Assert(err, IsNil)
-
-	err = reader.Close()
-	c.Assert(err, Not(IsNil))
+	s.FetchPackSuite.NonExistentEndpoint = ep
 }

--- a/plumbing/transport/test/common.go
+++ b/plumbing/transport/test/common.go
@@ -1,0 +1,155 @@
+// Package test implements common test suite for different transport
+// implementations.
+//
+package test
+
+import (
+	"io/ioutil"
+
+	"gopkg.in/src-d/go-git.v4/plumbing"
+	"gopkg.in/src-d/go-git.v4/plumbing/transport"
+
+	. "gopkg.in/check.v1"
+)
+
+type FetchPackSuite struct {
+	Endpoint            transport.Endpoint
+	EmptyEndpoint       transport.Endpoint
+	NonExistentEndpoint transport.Endpoint
+	Client              transport.Client
+}
+
+func (s *FetchPackSuite) TestInfoEmpty(c *C) {
+	r, err := s.Client.NewFetchPackSession(s.EmptyEndpoint)
+	c.Assert(err, IsNil)
+	info, err := r.AdvertisedReferences()
+	c.Assert(err, Equals, transport.ErrEmptyRemoteRepository)
+	c.Assert(info, IsNil)
+}
+
+func (s *FetchPackSuite) TestInfoNotExists(c *C) {
+	r, err := s.Client.NewFetchPackSession(s.NonExistentEndpoint)
+	c.Assert(err, IsNil)
+	info, err := r.AdvertisedReferences()
+	c.Assert(err, Equals, transport.ErrRepositoryNotFound)
+	c.Assert(info, IsNil)
+
+	r, err = s.Client.NewFetchPackSession(s.NonExistentEndpoint)
+	c.Assert(err, IsNil)
+	req := &transport.UploadPackRequest{}
+	req.Want(plumbing.NewHash("6ecf0ef2c2dffb796033e5a02219af86ec6584e5"))
+	reader, err := r.FetchPack(req)
+	c.Assert(err, Equals, transport.ErrRepositoryNotFound)
+	c.Assert(reader, IsNil)
+}
+
+func (s *FetchPackSuite) TestCannotCallAdvertisedReferenceTwice(c *C) {
+	r, err := s.Client.NewFetchPackSession(s.Endpoint)
+	c.Assert(err, IsNil)
+	_, err = r.AdvertisedReferences()
+	c.Assert(err, IsNil)
+	_, err = r.AdvertisedReferences()
+	c.Assert(err, Equals, transport.ErrAdvertistedReferencesAlreadyCalled)
+}
+
+func (s *FetchPackSuite) TestDefaultBranch(c *C) {
+	r, err := s.Client.NewFetchPackSession(s.Endpoint)
+	c.Assert(err, IsNil)
+	defer func() { c.Assert(r.Close(), IsNil) }()
+
+	info, err := r.AdvertisedReferences()
+	c.Assert(err, IsNil)
+	c.Assert(info.Capabilities.SymbolicReference("HEAD"), Equals, "refs/heads/master")
+}
+
+func (s *FetchPackSuite) TestCapabilities(c *C) {
+	r, err := s.Client.NewFetchPackSession(s.Endpoint)
+	c.Assert(err, IsNil)
+	defer func() { c.Assert(r.Close(), IsNil) }()
+
+	info, err := r.AdvertisedReferences()
+	c.Assert(err, IsNil)
+	c.Assert(info.Capabilities.Get("agent").Values, HasLen, 1)
+}
+
+func (s *FetchPackSuite) TestFullFetchPack(c *C) {
+	r, err := s.Client.NewFetchPackSession(s.Endpoint)
+	c.Assert(err, IsNil)
+	defer func() { c.Assert(r.Close(), IsNil) }()
+
+	info, err := r.AdvertisedReferences()
+	c.Assert(err, IsNil)
+	c.Assert(info, NotNil)
+
+	req := &transport.UploadPackRequest{}
+	req.Want(plumbing.NewHash("6ecf0ef2c2dffb796033e5a02219af86ec6584e5"))
+
+	reader, err := r.FetchPack(req)
+	c.Assert(err, IsNil)
+
+	b, err := ioutil.ReadAll(reader)
+	c.Assert(err, IsNil)
+	c.Assert(b, HasLen, 85374)
+}
+
+func (s *FetchPackSuite) TestFetchPack(c *C) {
+	r, err := s.Client.NewFetchPackSession(s.Endpoint)
+	c.Assert(err, IsNil)
+	defer func() { c.Assert(r.Close(), IsNil) }()
+
+	req := &transport.UploadPackRequest{}
+	req.Want(plumbing.NewHash("6ecf0ef2c2dffb796033e5a02219af86ec6584e5"))
+
+	reader, err := r.FetchPack(req)
+	c.Assert(err, IsNil)
+
+	b, err := ioutil.ReadAll(reader)
+	c.Assert(err, IsNil)
+	c.Assert(b, HasLen, 85374)
+}
+
+func (s *FetchPackSuite) TestFetchPackNoChanges(c *C) {
+	r, err := s.Client.NewFetchPackSession(s.Endpoint)
+	c.Assert(err, IsNil)
+	defer func() { c.Assert(r.Close(), IsNil) }()
+
+	req := &transport.UploadPackRequest{}
+	req.Want(plumbing.NewHash("6ecf0ef2c2dffb796033e5a02219af86ec6584e5"))
+	req.Have(plumbing.NewHash("6ecf0ef2c2dffb796033e5a02219af86ec6584e5"))
+
+	reader, err := r.FetchPack(req)
+	c.Assert(err, Equals, transport.ErrEmptyUploadPackRequest)
+	c.Assert(reader, IsNil)
+}
+
+func (s *FetchPackSuite) TestFetchPackMulti(c *C) {
+	r, err := s.Client.NewFetchPackSession(s.Endpoint)
+	c.Assert(err, IsNil)
+	defer func() { c.Assert(r.Close(), IsNil) }()
+
+	req := &transport.UploadPackRequest{}
+	req.Want(plumbing.NewHash("6ecf0ef2c2dffb796033e5a02219af86ec6584e5"))
+	req.Want(plumbing.NewHash("e8d3ffab552895c19b9fcf7aa264d277cde33881"))
+
+	reader, err := r.FetchPack(req)
+	c.Assert(err, IsNil)
+
+	b, err := ioutil.ReadAll(reader)
+	c.Assert(err, IsNil)
+	c.Assert(b, HasLen, 85585)
+}
+
+func (s *FetchPackSuite) TestFetchError(c *C) {
+	r, err := s.Client.NewFetchPackSession(s.Endpoint)
+	c.Assert(err, IsNil)
+
+	req := &transport.UploadPackRequest{}
+	req.Want(plumbing.NewHash("1111111111111111111111111111111111111111"))
+
+	reader, err := r.FetchPack(req)
+	c.Assert(err, Equals, transport.ErrEmptyUploadPackRequest)
+	c.Assert(reader, IsNil)
+
+	//XXX: We do not test Close error, since implementations might return
+	//     different errors if a previous error was found.
+}

--- a/utils/ioutil/common.go
+++ b/utils/ioutil/common.go
@@ -1,0 +1,52 @@
+package ioutil
+
+import (
+	"bufio"
+	"errors"
+	"io"
+)
+
+type readPeeker interface {
+	io.Reader
+	Peek(int) ([]byte, error)
+}
+
+var (
+	ErrEmptyReader = errors.New("reader is empty")
+)
+
+// NonEmptyReader takes a reader and returns it if it is not empty, or
+// `ErrEmptyReader` if it is empty. If there is an error when reading the first
+// byte of the given reader, it will be propagated.
+func NonEmptyReader(r io.Reader) (io.Reader, error) {
+	pr, ok := r.(readPeeker)
+	if !ok {
+		pr = bufio.NewReader(r)
+	}
+
+	_, err := pr.Peek(1)
+	if err == io.EOF {
+		return nil, ErrEmptyReader
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	return pr, nil
+}
+
+type readCloser struct {
+	io.Reader
+	closer io.Closer
+}
+
+func (r *readCloser) Close() error {
+	return r.closer.Close()
+}
+
+// NewReadCloser creates an `io.ReadCloser` with the given `io.Reader` and
+// `io.ReadCloser`.
+func NewReadCloser(r io.Reader, c io.Closer) io.ReadCloser {
+	return &readCloser{Reader: r, closer: c}
+}

--- a/utils/ioutil/common.go
+++ b/utils/ioutil/common.go
@@ -46,7 +46,7 @@ func (r *readCloser) Close() error {
 }
 
 // NewReadCloser creates an `io.ReadCloser` with the given `io.Reader` and
-// `io.ReadCloser`.
+// `io.Closer`.
 func NewReadCloser(r io.Reader, c io.Closer) io.ReadCloser {
 	return &readCloser{Reader: r, closer: c}
 }

--- a/utils/ioutil/common_test.go
+++ b/utils/ioutil/common_test.go
@@ -1,0 +1,55 @@
+package ioutil
+
+import (
+	"bytes"
+	"io/ioutil"
+	"testing"
+
+	. "gopkg.in/check.v1"
+)
+
+func Test(t *testing.T) { TestingT(t) }
+
+type CommonSuite struct{}
+
+var _ = Suite(&CommonSuite{})
+
+type closer struct {
+	called int
+}
+
+func (c *closer) Close() error {
+	c.called++
+	return nil
+}
+
+func (s *CommonSuite) TestNonEmptyReader_Empty(c *C) {
+	var buf bytes.Buffer
+	r, err := NonEmptyReader(&buf)
+	c.Assert(err, Equals, ErrEmptyReader)
+	c.Assert(r, IsNil)
+}
+
+func (s *CommonSuite) TestNonEmptyReader_NonEmpty(c *C) {
+	buf := bytes.NewBuffer([]byte("1"))
+	r, err := NonEmptyReader(buf)
+	c.Assert(err, IsNil)
+	c.Assert(r, NotNil)
+
+	read, err := ioutil.ReadAll(r)
+	c.Assert(err, IsNil)
+	c.Assert(string(read), Equals, "1")
+}
+
+func (s *CommonSuite) TestNewReadCloser(c *C) {
+	buf := bytes.NewBuffer([]byte("1"))
+	closer := &closer{}
+	r := NewReadCloser(buf, closer)
+
+	read, err := ioutil.ReadAll(r)
+	c.Assert(err, IsNil)
+	c.Assert(string(read), Equals, "1")
+
+	c.Assert(r.Close(), IsNil)
+	c.Assert(closer.called, Equals, 1)
+}


### PR DESCRIPTION
* add common test suite for different transport implementations.
* fix different behaviour on error handling for ssh and http.
  fixes issue #123.
* support detecting unexisting repositories with SSH + GitHub/Bitbucket
  (apparently, there is no standard for all SSH servers).
* remove ssh.NewClient (only DefaultClient makes sense at the moment).
* make ssh.Client and http.Client private.
* transport: test actual objects fetched, not just packfile size.
* utils/ioutil: utilities to work with io interfaces.