### PR TITLE
Add revision implementation

### DIFF
--- a/internal/revision/parser.go
+++ b/internal/revision/parser.go
@@ -213,6 +213,18 @@ func (p *parser) validateFullRevision(chunks *[]revisioner) error {
 			}
 
 			return &ErrInvalidRevision{`":" statement is not valid, could be : :/<regexp>`}
+		case colonPath:
+			if i == len(*chunks)-1 && hasReference || len(*chunks) == 1 {
+				return nil
+			}
+
+			return &ErrInvalidRevision{`":" statement is not valid, could be : <revision>:<path>`}
+		case colonStagePath:
+			if len(*chunks) == 1 {
+				return nil
+			}
+
+			return &ErrInvalidRevision{`":" statement is not valid, could be : :<n>:<path>`}
 		}
 	}
 

--- a/internal/revision/parser.go
+++ b/internal/revision/parser.go
@@ -14,6 +14,9 @@ func (e *ErrInvalidRevision) Error() string {
 	return "Revision invalid : " + e.s
 }
 
+// ref represents a reference name
+type ref string
+
 // parser represents a parser.
 type parser struct {
 	s   *scanner
@@ -73,7 +76,7 @@ func (p *parser) parseRevSuffix() ([]string, error) {
 }
 
 // parseRef extract reference name
-func (p *parser) parseRef() (string, error) {
+func (p *parser) parseRef() (ref, error) {
 	var tok token
 	var prevTok token
 	var lit string
@@ -95,7 +98,7 @@ func (p *parser) parseRef() (string, error) {
 		}
 
 		if endOfRef {
-			return buf, nil
+			return ref(buf), nil
 		}
 
 		buf += lit

--- a/internal/revision/parser.go
+++ b/internal/revision/parser.go
@@ -144,7 +144,9 @@ func (p *parser) parseAt() (revisioner, error) {
 	tok, lit = p.scan()
 
 	if tok != obrace {
-		return (revisioner)(struct{}{}), &ErrInvalidRevision{fmt.Sprintf(`"%s" found must be "{" after @`, lit)}
+		p.unscan()
+
+		return ref("HEAD"), nil
 	}
 
 	tok, lit = p.scan()

--- a/internal/revision/parser.go
+++ b/internal/revision/parser.go
@@ -359,13 +359,30 @@ func (p *parser) parseColonDefault() (revisioner, error) {
 	var tok token
 	var lit string
 	var path string
+	var stage int
+	var n = -1
+
+	tok, lit = p.scan()
+	nextTok, _ := p.scan()
+
+	if tok == number && nextTok == colon {
+		n, _ = strconv.Atoi(lit)
+	}
+
+	switch n {
+	case 0, 1, 2, 3:
+		stage = n
+	default:
+		path += lit
+		p.unscan()
+	}
 
 	for {
 		tok, lit = p.scan()
 
 		switch {
 		case tok == eof:
-			return colonPath{path, 0}, nil
+			return colonPath{path, stage}, nil
 		default:
 			path += lit
 		}

--- a/internal/revision/parser.go
+++ b/internal/revision/parser.go
@@ -53,7 +53,7 @@ type atCheckout struct {
 	deep int
 }
 
-// atUpstream represents @{upstream}, @{u
+// atUpstream represents @{upstream}, @{u}
 type atUpstream struct {
 	branchName string
 }

--- a/internal/revision/parser.go
+++ b/internal/revision/parser.go
@@ -145,16 +145,12 @@ func (p *Parser) Parse() ([]Revisioner, error) {
 
 		switch tok {
 		case at:
-			p.unscan()
 			rev, err = p.parseAt()
 		case tilde:
-			p.unscan()
 			rev, err = p.parseTilde()
 		case caret:
-			p.unscan()
 			rev, err = p.parseCaret()
 		case colon:
-			p.unscan()
 			rev, err = p.parseColon()
 		case eof:
 			err = p.validateFullRevision(&revs)
@@ -254,12 +250,6 @@ func (p *Parser) parseAt() (Revisioner, error) {
 
 	tok, lit = p.scan()
 
-	if tok != at {
-		return nil, &ErrInvalidRevision{fmt.Sprintf(`"%s" found must be "@"`, lit)}
-	}
-
-	tok, lit = p.scan()
-
 	if tok != obrace {
 		p.unscan()
 
@@ -319,12 +309,6 @@ func (p *Parser) parseTilde() (Revisioner, error) {
 
 	tok, lit = p.scan()
 
-	if tok != tilde {
-		return nil, &ErrInvalidRevision{fmt.Sprintf(`"%s" found must be "~"`, lit)}
-	}
-
-	tok, lit = p.scan()
-
 	switch {
 	case tok == number:
 		n, _ := strconv.Atoi(lit)
@@ -343,16 +327,8 @@ func (p *Parser) parseCaret() (Revisioner, error) {
 
 	tok, lit = p.scan()
 
-	if tok != caret {
-		return nil, &ErrInvalidRevision{fmt.Sprintf(`"%s" found must be "^"`, lit)}
-	}
-
-	tok, lit = p.scan()
-
 	switch {
 	case tok == obrace:
-		p.unscan()
-
 		r, err := p.parseCaretBraces()
 
 		if err != nil {
@@ -381,12 +357,6 @@ func (p *Parser) parseCaretBraces() (Revisioner, error) {
 	start := true
 	var re string
 	var negate bool
-
-	tok, lit = p.scan()
-
-	if tok != obrace {
-		return []Revisioner{}, &ErrInvalidRevision{fmt.Sprintf(`"%s" found must be "{" after ^`, lit)}
-	}
 
 	for {
 		tok, lit = p.scan()
@@ -429,19 +399,11 @@ func (p *Parser) parseCaretBraces() (Revisioner, error) {
 // parseColon extract : statements
 func (p *Parser) parseColon() (Revisioner, error) {
 	var tok token
-	var lit string
 
-	tok, lit = p.scan()
-
-	if tok != colon {
-		return []Revisioner{}, &ErrInvalidRevision{fmt.Sprintf(`"%s" found must be ":"`, lit)}
-	}
-
-	tok, lit = p.scan()
+	tok, _ = p.scan()
 
 	switch tok {
 	case slash:
-		p.unscan()
 		return p.parseColonSlash()
 	default:
 		p.unscan()
@@ -456,12 +418,6 @@ func (p *Parser) parseColonSlash() (Revisioner, error) {
 	var re string
 	var negate bool
 
-	tok, lit = p.scan()
-
-	if tok != slash {
-		return []Revisioner{}, &ErrInvalidRevision{fmt.Sprintf(`"%s" found must be "/"`, lit)}
-	}
-
 	for {
 		tok, lit = p.scan()
 		nextTok, _ = p.scan()
@@ -475,7 +431,6 @@ func (p *Parser) parseColonSlash() (Revisioner, error) {
 			return nil, &ErrInvalidRevision{fmt.Sprintf(`revision suffix brace component sequences starting with "/!" others than those defined are reserved`)}
 		case tok == eof:
 			p.unscan()
-
 			reg, err := regexp.Compile(re)
 
 			if err != nil {

--- a/internal/revision/parser.go
+++ b/internal/revision/parser.go
@@ -108,13 +108,13 @@ func (p *parser) parse() ([]revisioner, error) {
 		switch tok {
 		case at:
 			p.unscan()
-			rev, err = p.parseAtSuffix()
+			rev, err = p.parseAt()
 		case tilde:
 			p.unscan()
-			rev, err = p.parseTildeSuffix()
+			rev, err = p.parseTilde()
 		case caret:
 			p.unscan()
-			rev, err = p.parseCaretSuffix()
+			rev, err = p.parseCaret()
 		case eof:
 			return revs, nil
 		default:
@@ -130,8 +130,8 @@ func (p *parser) parse() ([]revisioner, error) {
 	}
 }
 
-// parseAtSuffix extract part following @
-func (p *parser) parseAtSuffix() (revisioner, error) {
+// parseAt extract @ statements
+func (p *parser) parseAt() (revisioner, error) {
 	var tok, nextTok token
 	var lit, nextLit string
 
@@ -182,8 +182,8 @@ func (p *parser) parseAtSuffix() (revisioner, error) {
 	return (revisioner)(struct{}{}), &ErrInvalidRevision{fmt.Sprintf(`invalid expression "%s" in @{} structure`, lit)}
 }
 
-// parseTildeSuffix extract part following tilde
-func (p *parser) parseTildeSuffix() (revisioner, error) {
+// parseTilde extract ~ statements
+func (p *parser) parseTilde() (revisioner, error) {
 	var tok token
 	var lit string
 
@@ -212,8 +212,8 @@ func (p *parser) parseTildeSuffix() (revisioner, error) {
 	}
 }
 
-// parseCaretSuffix extract part following caret
-func (p *parser) parseCaretSuffix() (revisioner, error) {
+// parseCaret extract ^ statements
+func (p *parser) parseCaret() (revisioner, error) {
 	var tok token
 	var lit string
 

--- a/internal/revision/parser.go
+++ b/internal/revision/parser.go
@@ -115,7 +115,6 @@ func (p *parser) unscan() { p.buf.n = 1 }
 
 // parse explode a revision string into components
 func (p *parser) parse() ([]revisioner, error) {
-	// var tok token
 	var rev revisioner
 	var revs []revisioner
 	var err error

--- a/internal/revision/parser.go
+++ b/internal/revision/parser.go
@@ -95,6 +95,41 @@ func (p *parser) scan() (tok token, lit string) {
 // unscan pushes the previously read token back onto the buffer.
 func (p *parser) unscan() { p.buf.n = 1 }
 
+// parse explode a revision string into components
+func (p *parser) parse() ([]revisioner, error) {
+	// var tok token
+	var rev revisioner
+	var revs []revisioner
+	var err error
+
+	for {
+		tok, _ := p.scan()
+
+		switch tok {
+		case at:
+			p.unscan()
+			rev, err = p.parseAtSuffix()
+		case tilde:
+			p.unscan()
+			rev, err = p.parseTildeSuffix()
+		case caret:
+			p.unscan()
+			rev, err = p.parseCaretSuffix()
+		case eof:
+			return revs, nil
+		default:
+			p.unscan()
+			rev, err = p.parseRef()
+		}
+
+		if err != nil {
+			return []revisioner{}, nil
+		}
+
+		revs = append(revs, rev)
+	}
+}
+
 // parseAtSuffix extract part following @
 func (p *parser) parseAtSuffix() (revisioner, error) {
 	var tok, nextTok token

--- a/internal/revision/parser.go
+++ b/internal/revision/parser.go
@@ -1,0 +1,37 @@
+package revision
+
+import (
+	"io"
+)
+
+// parser represents a parser.
+type parser struct {
+	s   *scanner
+	buf struct {
+		tok token
+		lit string
+		n   int
+	}
+}
+
+// newParser returns a new instance of parser.
+func newParser(r io.Reader) *parser {
+	return &parser{s: newScanner(r)}
+}
+
+// scan returns the next token from the underlying scanner.
+// If a token has been unscanned then read that instead.
+func (p *parser) scan() (tok token, lit string) {
+	if p.buf.n != 0 {
+		p.buf.n = 0
+		return p.buf.tok, p.buf.lit
+	}
+
+	tok, lit = p.s.scan()
+
+	p.buf.tok, p.buf.lit = tok, lit
+	return
+}
+
+// unscan pushes the previously read token back onto the buffer.
+func (p *parser) unscan() { p.buf.n = 1 }

--- a/internal/revision/parser.go
+++ b/internal/revision/parser.go
@@ -75,8 +75,13 @@ type colonReg struct {
 	negate bool
 }
 
-// colonPath represents :../<path> :./<path> :<path>
+// colonPath represents :./<path> :<path>
 type colonPath struct {
+	path string
+}
+
+// colonStagePath represents :<n>:/<path>
+type colonStagePath struct {
 	path  string
 	stage int
 }
@@ -469,8 +474,10 @@ func (p *parser) parseColonDefault() (revisioner, error) {
 		tok, lit = p.scan()
 
 		switch {
+		case tok == eof && n == -1:
+			return colonPath{path}, nil
 		case tok == eof:
-			return colonPath{path, stage}, nil
+			return colonStagePath{path, stage}, nil
 		default:
 			path += lit
 		}

--- a/internal/revision/parser.go
+++ b/internal/revision/parser.go
@@ -132,7 +132,7 @@ func (p *parser) parse() ([]revisioner, error) {
 		}
 
 		if err != nil {
-			return []revisioner{}, nil
+			return []revisioner{}, err
 		}
 
 		revs = append(revs, rev)

--- a/internal/revision/parser.go
+++ b/internal/revision/parser.go
@@ -1,8 +1,18 @@
 package revision
 
 import (
+	"fmt"
 	"io"
 )
+
+// ErrInvalidRevision is emitted if string doesn't match valid revision
+type ErrInvalidRevision struct {
+	s string
+}
+
+func (e *ErrInvalidRevision) Error() string {
+	return "Revision invalid : " + e.s
+}
 
 // parser represents a parser.
 type parser struct {
@@ -35,3 +45,68 @@ func (p *parser) scan() (tok token, lit string) {
 
 // unscan pushes the previously read token back onto the buffer.
 func (p *parser) unscan() { p.buf.n = 1 }
+
+// parseRef extract reference name
+func (p *parser) parseRef() (string, error) {
+	var tok token
+	var prevTok token
+	var lit string
+	var buf string
+
+	for {
+		tok, lit = p.scan()
+
+		err := p.checkRefFormat(tok, lit, prevTok, buf)
+
+		if err != nil {
+			return "", err
+		}
+
+		switch tok {
+		case eof:
+			return buf, nil
+		}
+
+		buf += lit
+		prevTok = tok
+	}
+}
+
+// checkRefFormat ensure reference name follow rules defined here :
+// https://git-scm.com/docs/git-check-ref-format
+func (p *parser) checkRefFormat(token token, literal string, previousToken token, buffer string) error {
+	switch token {
+	case aslash, space, control, qmark, asterisk, obracket:
+		return &ErrInvalidRevision{fmt.Sprintf(`must not contains "%s"`, literal)}
+	}
+
+	if (token == dot || token == slash) && buffer == "" {
+		return &ErrInvalidRevision{fmt.Sprintf(`must not start with "%s"`, literal)}
+	}
+
+	if previousToken == slash && token == eof {
+		return &ErrInvalidRevision{`must not end with "/"`}
+	}
+
+	if previousToken == dot && token == eof {
+		return &ErrInvalidRevision{`must not end with "."`}
+	}
+
+	if token == dot && previousToken == slash {
+		return &ErrInvalidRevision{`must not contains "/."`}
+	}
+
+	if previousToken == dot && token == dot {
+		return &ErrInvalidRevision{`must not contains ".."`}
+	}
+
+	if previousToken == slash && token == slash {
+		return &ErrInvalidRevision{`must not contains consecutively "/"`}
+	}
+
+	if (token == slash || token == eof) && len(buffer) > 4 && buffer[len(buffer)-5:] == ".lock" {
+		return &ErrInvalidRevision{"cannot end with .lock"}
+	}
+
+	return nil
+}

--- a/internal/revision/parser.go
+++ b/internal/revision/parser.go
@@ -53,6 +53,16 @@ type atSuffixCheckout struct {
 	deep int
 }
 
+// atUpstream represents @{upstream}, @{u
+type atUpstream struct {
+	branchName string
+}
+
+// atPush represents @{push}
+type atPush struct {
+	branchName string
+}
+
 // parser represents a parser.
 type parser struct {
 	s   *scanner
@@ -101,6 +111,10 @@ func (p *parser) parseAtSuffix() (atSuffixer, error) {
 		nextTok, nextLit = p.scan()
 
 		switch {
+		case tok == word && (lit == "u" || lit == "upstream") && nextTok == cbrace:
+			return atUpstream{}, nil
+		case tok == word && lit == "push" && nextTok == cbrace:
+			return atPush{}, nil
 		case tok == number && nextTok == cbrace:
 			n, err := strconv.Atoi(lit)
 

--- a/internal/revision/parser.go
+++ b/internal/revision/parser.go
@@ -319,7 +319,15 @@ func (p *parser) parseColon() (revisioner, error) {
 		return []revisioner{}, &ErrInvalidRevision{fmt.Sprintf(`"%s" found must be ":"`, lit)}
 	}
 
-	return p.parseColonSlash()
+	tok, lit = p.scan()
+
+	switch tok {
+	case slash:
+		p.unscan()
+		return p.parseColonSlash()
+	default:
+		return (revisioner)(struct{}{}), &ErrInvalidRevision{fmt.Sprintf(`"%s" is not a valid revision suffix colon component`, lit)}
+	}
 }
 
 // parseColonSlash extract :/<data> statements

--- a/internal/revision/parser.go
+++ b/internal/revision/parser.go
@@ -283,6 +283,7 @@ func (p *parser) parseRef() (ref, error) {
 		}
 
 		if endOfRef {
+			p.unscan()
 			return ref(buf), nil
 		}
 

--- a/internal/revision/parser.go
+++ b/internal/revision/parser.go
@@ -85,31 +85,20 @@ func (p *parser) checkRefFormat(token token, literal string, previousToken token
 		return &ErrInvalidRevision{fmt.Sprintf(`must not contains "%s"`, literal)}
 	}
 
-	if (token == dot || token == slash) && buffer == "" {
+	switch {
+	case (token == dot || token == slash) && buffer == "":
 		return &ErrInvalidRevision{fmt.Sprintf(`must not start with "%s"`, literal)}
-	}
-
-	if previousToken == slash && endOfRef {
+	case previousToken == slash && endOfRef:
 		return &ErrInvalidRevision{`must not end with "/"`}
-	}
-
-	if previousToken == dot && endOfRef {
+	case previousToken == dot && endOfRef:
 		return &ErrInvalidRevision{`must not end with "."`}
-	}
-
-	if token == dot && previousToken == slash {
+	case token == dot && previousToken == slash:
 		return &ErrInvalidRevision{`must not contains "/."`}
-	}
-
-	if previousToken == dot && token == dot {
+	case previousToken == dot && token == dot:
 		return &ErrInvalidRevision{`must not contains ".."`}
-	}
-
-	if previousToken == slash && token == slash {
+	case previousToken == slash && token == slash:
 		return &ErrInvalidRevision{`must not contains consecutively "/"`}
-	}
-
-	if (token == slash || endOfRef) && len(buffer) > 4 && buffer[len(buffer)-5:] == ".lock" {
+	case (token == slash || endOfRef) && len(buffer) > 4 && buffer[len(buffer)-5:] == ".lock":
 		return &ErrInvalidRevision{"cannot end with .lock"}
 	}
 

--- a/internal/revision/parser.go
+++ b/internal/revision/parser.go
@@ -250,7 +250,7 @@ func (p *Parser) parseAt() (Revisioner, error) {
 	tok, lit = p.scan()
 
 	if tok != at {
-		return (Revisioner)(struct{}{}), &ErrInvalidRevision{fmt.Sprintf(`"%s" found must be "@"`, lit)}
+		return nil, &ErrInvalidRevision{fmt.Sprintf(`"%s" found must be "@"`, lit)}
 	}
 
 	tok, lit = p.scan()
@@ -296,7 +296,7 @@ func (p *Parser) parseAt() (Revisioner, error) {
 				t, err := time.Parse("2006-01-02T15:04:05Z", date)
 
 				if err != nil {
-					return (Revisioner)(struct{}{}), &ErrInvalidRevision{fmt.Sprintf(`wrong date "%s" must fit ISO-8601 format : 2006-01-02T15:04:05Z`, date)}
+					return nil, &ErrInvalidRevision{fmt.Sprintf(`wrong date "%s" must fit ISO-8601 format : 2006-01-02T15:04:05Z`, date)}
 				}
 
 				return AtDate{t}, nil
@@ -315,7 +315,7 @@ func (p *Parser) parseTilde() (Revisioner, error) {
 	tok, lit = p.scan()
 
 	if tok != tilde {
-		return (Revisioner)(struct{}{}), &ErrInvalidRevision{fmt.Sprintf(`"%s" found must be "~"`, lit)}
+		return nil, &ErrInvalidRevision{fmt.Sprintf(`"%s" found must be "~"`, lit)}
 	}
 
 	tok, lit = p.scan()
@@ -339,7 +339,7 @@ func (p *Parser) parseCaret() (Revisioner, error) {
 	tok, lit = p.scan()
 
 	if tok != caret {
-		return (Revisioner)(struct{}{}), &ErrInvalidRevision{fmt.Sprintf(`"%s" found must be "^"`, lit)}
+		return nil, &ErrInvalidRevision{fmt.Sprintf(`"%s" found must be "^"`, lit)}
 	}
 
 	tok, lit = p.scan()
@@ -351,7 +351,7 @@ func (p *Parser) parseCaret() (Revisioner, error) {
 		r, err := p.parseCaretBraces()
 
 		if err != nil {
-			return (Revisioner)(struct{}{}), err
+			return nil, err
 		}
 
 		return r, nil
@@ -359,7 +359,7 @@ func (p *Parser) parseCaret() (Revisioner, error) {
 		n, _ := strconv.Atoi(lit)
 
 		if n > 2 {
-			return (Revisioner)(struct{}{}), &ErrInvalidRevision{fmt.Sprintf(`"%s" found must be 0, 1 or 2 after "^"`, lit)}
+			return nil, &ErrInvalidRevision{fmt.Sprintf(`"%s" found must be 0, 1 or 2 after "^"`, lit)}
 		}
 
 		return CaretPath{n}, nil
@@ -397,11 +397,11 @@ func (p *Parser) parseCaretBraces() (Revisioner, error) {
 		case re == "" && tok == emark && nextTok == minus:
 			negate = true
 		case re == "" && tok == emark:
-			return (Revisioner)(struct{}{}), &ErrInvalidRevision{fmt.Sprintf(`revision suffix brace component sequences starting with "/!" others than those defined are reserved`)}
+			return nil, &ErrInvalidRevision{fmt.Sprintf(`revision suffix brace component sequences starting with "/!" others than those defined are reserved`)}
 		case re == "" && tok == slash:
 			p.unscan()
 		case tok != slash && start:
-			return (Revisioner)(struct{}{}), &ErrInvalidRevision{fmt.Sprintf(`"%s" is not a valid revision suffix brace component`, lit)}
+			return nil, &ErrInvalidRevision{fmt.Sprintf(`"%s" is not a valid revision suffix brace component`, lit)}
 		case tok != cbrace:
 			p.unscan()
 			re += lit
@@ -467,7 +467,7 @@ func (p *Parser) parseColonSlash() (Revisioner, error) {
 		case re == "" && tok == emark && nextTok == minus:
 			negate = true
 		case re == "" && tok == emark:
-			return (Revisioner)(struct{}{}), &ErrInvalidRevision{fmt.Sprintf(`revision suffix brace component sequences starting with "/!" others than those defined are reserved`)}
+			return nil, &ErrInvalidRevision{fmt.Sprintf(`revision suffix brace component sequences starting with "/!" others than those defined are reserved`)}
 		case tok == eof:
 			p.unscan()
 

--- a/internal/revision/parser.go
+++ b/internal/revision/parser.go
@@ -105,7 +105,7 @@ func (p *parser) parseAtSuffix() (atSuffixer, error) {
 			n, err := strconv.Atoi(lit)
 
 			if err != nil {
-				return []atSuffixer{}, err
+				return []atSuffixer{}, &ErrInvalidRevision{fmt.Sprintf(`"%s" is not a number`, lit)}
 			}
 
 			return atSuffixReflog{n}, nil
@@ -113,7 +113,7 @@ func (p *parser) parseAtSuffix() (atSuffixer, error) {
 			n, err := strconv.Atoi(nextLit)
 
 			if err != nil {
-				return []atSuffixer{}, err
+				return []atSuffixer{}, &ErrInvalidRevision{fmt.Sprintf(`"%s" is not a number`, nextLit)}
 			}
 
 			t, _ := p.scan()
@@ -152,7 +152,7 @@ func (p *parser) parseRevSuffix() ([]revSuffixer, error) {
 			n, err := strconv.Atoi(nextLit)
 
 			if err != nil {
-				return []revSuffixer{}, nil
+				return []revSuffixer{}, &ErrInvalidRevision{fmt.Sprintf(`"%s" is not a number`, nextLit)}
 			}
 
 			r := revSuffixPath{lit, n}

--- a/internal/revision/parser.go
+++ b/internal/revision/parser.go
@@ -358,6 +358,10 @@ func (p *Parser) parseCaret() (Revisioner, error) {
 	case tok == number:
 		n, _ := strconv.Atoi(lit)
 
+		if n > 2 {
+			return (Revisioner)(struct{}{}), &ErrInvalidRevision{fmt.Sprintf(`"%s" found must be 0, 1 or 2 after "^"`, lit)}
+		}
+
 		return CaretPath{n}, nil
 	default:
 		p.unscan()

--- a/internal/revision/parser.go
+++ b/internal/revision/parser.go
@@ -231,7 +231,7 @@ func (p *parser) parseCaret() (revisioner, error) {
 	case tok == obrace:
 		p.unscan()
 
-		r, err := p.parseCaretSuffixWithBraces()
+		r, err := p.parseCaretBraces()
 
 		if err != nil {
 			return (revisioner)(struct{}{}), err
@@ -254,9 +254,9 @@ func (p *parser) parseCaret() (revisioner, error) {
 	}
 }
 
-// parseCaretSuffixWithBraces extract suffix between braces following caret
+// parseCaretBraces extract ^{<data>} statements
 // todo : add regexp checker
-func (p *parser) parseCaretSuffixWithBraces() (revisioner, error) {
+func (p *parser) parseCaretBraces() (revisioner, error) {
 	var tok, nextTok token
 	var lit, _ string
 	start := true

--- a/internal/revision/parser.go
+++ b/internal/revision/parser.go
@@ -20,11 +20,15 @@ func (e *ErrInvalidRevision) Error() string {
 	return "Revision invalid : " + e.s
 }
 
-// Revisioner represents a revision component
+// Revisioner represents a revision component.
+// A revision is made of multiple revision components
+// obtained after parsing a revision string,
+// for instance revision "master~" will be converted in
+// two revision components Ref and TildePath
 type Revisioner interface {
 }
 
-// Ref represents a reference name
+// Ref represents a reference name : HEAD, master
 type Ref string
 
 // TildePath represents ~, ~{n}
@@ -112,8 +116,8 @@ func NewParser(r io.Reader) *Parser {
 	return &Parser{s: newScanner(r)}
 }
 
-// scan returns the next token from the underlying scanner.
-// If a token has been unscanned then read that instead.
+// scan returns the next token from the underlying scanner
+// or the last scanned token if an unscan was requested
 func (p *Parser) scan() (tok token, lit string) {
 	if p.buf.n != 0 {
 		p.buf.n = 0

--- a/internal/revision/parser.go
+++ b/internal/revision/parser.go
@@ -173,19 +173,11 @@ func (p *parser) parseAt() (revisioner, error) {
 	case tok == word && lit == "push" && nextTok == cbrace:
 		return atPush{}, nil
 	case tok == number && nextTok == cbrace:
-		n, err := strconv.Atoi(lit)
-
-		if err != nil {
-			return []revisioner{}, &ErrInvalidRevision{fmt.Sprintf(`"%s" is not a number`, lit)}
-		}
+		n, _ := strconv.Atoi(lit)
 
 		return atReflog{n}, nil
 	case tok == minus && nextTok == number:
-		n, err := strconv.Atoi(nextLit)
-
-		if err != nil {
-			return []revisioner{}, &ErrInvalidRevision{fmt.Sprintf(`"%s" is not a number`, nextLit)}
-		}
+		n, _ := strconv.Atoi(nextLit)
 
 		t, _ := p.scan()
 
@@ -214,11 +206,7 @@ func (p *parser) parseTilde() (revisioner, error) {
 
 	switch {
 	case tok == number:
-		n, err := strconv.Atoi(lit)
-
-		if err != nil {
-			return (revisioner)(struct{}{}), &ErrInvalidRevision{fmt.Sprintf(`"%s" is not a number`, lit)}
-		}
+		n, _ := strconv.Atoi(lit)
 
 		return tildePath{n}, nil
 	case tok == tilde || tok == caret || tok == eof:
@@ -254,11 +242,7 @@ func (p *parser) parseCaret() (revisioner, error) {
 
 		return r, nil
 	case tok == number:
-		n, err := strconv.Atoi(lit)
-
-		if err != nil {
-			return []revisioner{}, &ErrInvalidRevision{fmt.Sprintf(`"%s" is not a number`, lit)}
-		}
+		n, _ := strconv.Atoi(lit)
 
 		return caretPath{n}, nil
 	case tok == caret || tok == tilde || tok == eof:

--- a/internal/revision/parser.go
+++ b/internal/revision/parser.go
@@ -302,11 +302,9 @@ func (p *parser) parseTilde() (revisioner, error) {
 		n, _ := strconv.Atoi(lit)
 
 		return tildePath{n}, nil
-	case tok == tilde || tok == caret || tok == eof:
+	default:
 		p.unscan()
 		return tildePath{1}, nil
-	default:
-		return (revisioner)(struct{}{}), &ErrInvalidRevision{fmt.Sprintf(`"%s" is not a valid revision suffix component`, lit)}
 	}
 }
 
@@ -338,11 +336,9 @@ func (p *parser) parseCaret() (revisioner, error) {
 		n, _ := strconv.Atoi(lit)
 
 		return caretPath{n}, nil
-	case tok == caret || tok == tilde || tok == eof:
+	default:
 		p.unscan()
 		return caretPath{1}, nil
-	default:
-		return (revisioner)(struct{}{}), &ErrInvalidRevision{fmt.Sprintf(`"%s" is not a valid revision suffix component`, lit)}
 	}
 }
 

--- a/internal/revision/parser.go
+++ b/internal/revision/parser.go
@@ -3,6 +3,7 @@
 package revision
 
 import (
+	"bytes"
 	"fmt"
 	"io"
 	"regexp"
@@ -99,6 +100,11 @@ type Parser struct {
 		lit string
 		n   int
 	}
+}
+
+// NewParserFromString returns a new instance of parser from a string.
+func NewParserFromString(s string) *Parser {
+	return NewParser(bytes.NewBufferString(s))
 }
 
 // NewParser returns a new instance of parser.

--- a/internal/revision/parser.go
+++ b/internal/revision/parser.go
@@ -166,38 +166,48 @@ func (p *parser) validateFullRevision(chunks *[]revisioner) error {
 			if i == 0 {
 				hasReference = true
 			} else {
-				return &ErrInvalidRevision{"reference must be defined once at the beginning"}
+				return &ErrInvalidRevision{`reference must be defined once at the beginning`}
 			}
 		case atDate:
 			if len(*chunks) == 1 || hasReference && len(*chunks) == 2 {
 				return nil
 			}
 
-			return &ErrInvalidRevision{"@ statement is not valid, could be : <refname>@{<ISO-8601 date>}, @{<ISO-8601 date>}"}
+			return &ErrInvalidRevision{`"@" statement is not valid, could be : <refname>@{<ISO-8601 date>}, @{<ISO-8601 date>}`}
 		case atReflog:
 			if len(*chunks) == 1 || hasReference && len(*chunks) == 2 {
 				return nil
 			}
 
-			return &ErrInvalidRevision{"@ statement is not valid, could be : <refname>@{<n>}, @{<n>}"}
+			return &ErrInvalidRevision{`"@" statement is not valid, could be : <refname>@{<n>}, @{<n>}`}
 		case atCheckout:
 			if len(*chunks) == 1 {
 				return nil
 			}
 
-			return &ErrInvalidRevision{"@ statement is not valid, could be : @{-<n>}"}
+			return &ErrInvalidRevision{`"@" statement is not valid, could be : @{-<n>}`}
 		case atUpstream:
 			if len(*chunks) == 1 || hasReference && len(*chunks) == 2 {
 				return nil
 			}
 
-			return &ErrInvalidRevision{"@ statement is not valid, could be : <refname>@{upstream}, @{upstream}, <refname>@{u}, @{u}"}
+			return &ErrInvalidRevision{`"@" statement is not valid, could be : <refname>@{upstream}, @{upstream}, <refname>@{u}, @{u}`}
 		case atPush:
 			if len(*chunks) == 1 || hasReference && len(*chunks) == 2 {
 				return nil
 			}
 
-			return &ErrInvalidRevision{"@ statement is not valid, could be : <refname>@{push}, @{push}"}
+			return &ErrInvalidRevision{`"@" statement is not valid, could be : <refname>@{push}, @{push}`}
+		case tildePath, caretPath, caretReg:
+			if !hasReference {
+				return &ErrInvalidRevision{`"~" or "^" statement must have a reference defined at the beginning`}
+			}
+		case colonReg:
+			if len(*chunks) == 1 {
+				return nil
+			}
+
+			return &ErrInvalidRevision{`":" statement is not valid, could be : :/<regexp>`}
 		}
 	}
 

--- a/internal/revision/parser_test.go
+++ b/internal/revision/parser_test.go
@@ -2,6 +2,7 @@ package revision
 
 import (
 	"bytes"
+	"time"
 
 	. "gopkg.in/check.v1"
 )
@@ -76,12 +77,15 @@ func (s *ParserSuite) TestUnscan(c *C) {
 }
 
 func (s *ParserSuite) TestParseWithValidExpression(c *C) {
+	tim, _ := time.Parse("2006-01-02T15:04:05Z", "2016-12-16T21:42:47Z")
+
 	datas := map[string]revisioner{
 		"@": []revisioner{ref("HEAD")},
 		"@~3": []revisioner{
 			ref("HEAD"),
 			tildePath{3},
 		},
+		"@{2016-12-16T21:42:47Z}": []revisioner{atDate{tim}},
 		"@{1}":  []revisioner{atReflog{1}},
 		"@{-1}": []revisioner{atCheckout{1}},
 		"master@{upstream}": []revisioner{
@@ -91,6 +95,10 @@ func (s *ParserSuite) TestParseWithValidExpression(c *C) {
 		"master@{push}": []revisioner{
 			ref("master"),
 			atPush{},
+		},
+		"master@{2016-12-16T21:42:47Z}": []revisioner{
+			ref("master"),
+			atDate{tim},
 		},
 		"HEAD^": []revisioner{
 			ref("HEAD"),
@@ -168,6 +176,8 @@ func (s *ParserSuite) TestParseWithUnValidExpression(c *C) {
 }
 
 func (s *ParserSuite) TestParseAtWithValidExpression(c *C) {
+	tim, _ := time.Parse("2006-01-02T15:04:05Z", "2016-12-16T21:42:47Z")
+
 	datas := map[string]revisioner{
 		"@":           ref("HEAD"),
 		"@{1}":        atReflog{1},
@@ -175,6 +185,7 @@ func (s *ParserSuite) TestParseAtWithValidExpression(c *C) {
 		"@{push}":     atPush{},
 		"@{upstream}": atUpstream{},
 		"@{u}":        atUpstream{},
+		"@{2016-12-16T21:42:47Z}": atDate{tim},
 	}
 
 	for d, expected := range datas {
@@ -190,7 +201,7 @@ func (s *ParserSuite) TestParseAtWithValidExpression(c *C) {
 func (s *ParserSuite) TestParseAtWithUnValidExpression(c *C) {
 	datas := map[string]error{
 		"a":       &ErrInvalidRevision{`"a" found must be "@"`},
-		"@{test}": &ErrInvalidRevision{`invalid expression "test" in @{} structure`},
+		"@{test}": &ErrInvalidRevision{`wrong date "test" must fit ISO-8601 format : 2006-01-02T15:04:05Z`},
 		"@{-1":    &ErrInvalidRevision{`missing "}" in @{-n} structure`},
 	}
 

--- a/internal/revision/parser_test.go
+++ b/internal/revision/parser_test.go
@@ -130,6 +130,20 @@ func (s *ParserSuite) TestParse(c *C) {
 	}
 }
 
+func (s *ParserSuite) TestParseWithUnValidExpression(c *C) {
+	datas := map[string]error{
+		"..": &ErrInvalidRevision{`must not start with "."`},
+	}
+
+	for s, e := range datas {
+		parser := newParser(bytes.NewBufferString(s))
+
+		t, err := parser.parse()
+		c.Log(t)
+		c.Assert(err, DeepEquals, e)
+	}
+}
+
 func (s *ParserSuite) TestParseAtWithValidExpression(c *C) {
 	datas := map[string]revisioner{
 		"@":           ref("HEAD"),

--- a/internal/revision/parser_test.go
+++ b/internal/revision/parser_test.go
@@ -71,6 +71,11 @@ func (s *ParserSuite) TestUnscan(c *C) {
 
 func (s *ParserSuite) TestParse(c *C) {
 	datas := map[string]revisioner{
+		"@": []revisioner{ref("HEAD")},
+		"@~3": []revisioner{
+			ref("HEAD"),
+			tildeSuffixPath{3},
+		},
 		"@{1}":  []revisioner{atSuffixReflog{1}},
 		"@{-1}": []revisioner{atSuffixCheckout{1}},
 		"master@{upstream}": []revisioner{
@@ -124,6 +129,7 @@ func (s *ParserSuite) TestParse(c *C) {
 
 func (s *ParserSuite) TestParseAtWithValidExpression(c *C) {
 	datas := map[string]revisioner{
+		"@":           ref("HEAD"),
 		"@{1}":        atSuffixReflog{1},
 		"@{-1}":       atSuffixCheckout{1},
 		"@{push}":     atPush{},
@@ -144,7 +150,6 @@ func (s *ParserSuite) TestParseAtWithValidExpression(c *C) {
 func (s *ParserSuite) TestParseAtWithUnValidExpression(c *C) {
 	datas := map[string]error{
 		"a":       &ErrInvalidRevision{`"a" found must be "@"`},
-		"@test}":  &ErrInvalidRevision{`"test" found must be "{" after @`},
 		"@{test}": &ErrInvalidRevision{`invalid expression "test" in @{} structure`},
 		"@{-1":    &ErrInvalidRevision{`missing "}" in @{-n} structure`},
 	}

--- a/internal/revision/parser_test.go
+++ b/internal/revision/parser_test.go
@@ -68,3 +68,54 @@ func (s *ParserSuite) TestUnscan(c *C) {
 	c.Assert(str, Equals, "Hello")
 	c.Assert(tok, Equals, word)
 }
+
+func (s *ParserSuite) TestParseRefWithValidName(c *C) {
+	datas := []string{
+		"lock",
+		"master",
+		"v1.0.0",
+		"refs/stash",
+		"refs/tags/v1.0.0",
+		"refs/heads/master",
+		"refs/remotes/test",
+		"refs/remotes/origin/HEAD",
+		"refs/remotes/origin/master",
+	}
+
+	for _, d := range datas {
+		parser := newParser(bytes.NewBufferString(d))
+
+		result, err := parser.parseRef()
+
+		c.Assert(err, Equals, nil)
+		c.Assert(result, Equals, d)
+	}
+}
+
+func (s *ParserSuite) TestParseRefWithUnvalidName(c *C) {
+	datas := map[string]error{
+		".master":                     &ErrInvalidRevision{`must not start with "."`},
+		"/master":                     &ErrInvalidRevision{`must not start with "/"`},
+		"master/":                     &ErrInvalidRevision{`must not end with "/"`},
+		"master.":                     &ErrInvalidRevision{`must not end with "."`},
+		"refs/remotes/.origin/HEAD":   &ErrInvalidRevision{`must not contains "/."`},
+		"test..test":                  &ErrInvalidRevision{`must not contains ".."`},
+		"test..":                      &ErrInvalidRevision{`must not contains ".."`},
+		"test test":                   &ErrInvalidRevision{`must not contains " "`},
+		"test*test":                   &ErrInvalidRevision{`must not contains "*"`},
+		"test?test":                   &ErrInvalidRevision{`must not contains "?"`},
+		"test\\test":                  &ErrInvalidRevision{`must not contains "\"`},
+		"test[test":                   &ErrInvalidRevision{`must not contains "["`},
+		"te//st":                      &ErrInvalidRevision{`must not contains consecutively "/"`},
+		"refs/remotes/test.lock/HEAD": &ErrInvalidRevision{`cannot end with .lock`},
+		"test.lock":                   &ErrInvalidRevision{`cannot end with .lock`},
+	}
+
+	for s, e := range datas {
+		parser := newParser(bytes.NewBufferString(s))
+
+		_, err := parser.parseRef()
+
+		c.Assert(err, DeepEquals, e)
+	}
+}

--- a/internal/revision/parser_test.go
+++ b/internal/revision/parser_test.go
@@ -10,6 +10,12 @@ type ParserSuite struct{}
 
 var _ = Suite(&ParserSuite{})
 
+func (s *ParserSuite) TestErrInvalidRevision(c *C) {
+	e := ErrInvalidRevision{"test"}
+
+	c.Assert(e.Error(), Equals, "Revision invalid : test")
+}
+
 func (s *ParserSuite) TestScan(c *C) {
 	parser := newParser(bytes.NewBufferString("Hello world !"))
 

--- a/internal/revision/parser_test.go
+++ b/internal/revision/parser_test.go
@@ -70,11 +70,20 @@ func (s *ParserSuite) TestUnscan(c *C) {
 }
 
 func (s *ParserSuite) TestParseRevSuffixWithValidExpression(c *C) {
-	datas := map[string][]string{
-		"^": []string{"^"},
-		"~": []string{"~"},
-		"~^^1~2~10~^100^~1000": []string{"~", "^", "^1", "~2", "~10", "~", "^100", "^", "~1000"},
-	}
+	datas := map[string][]revSuffixer{
+		"^": []revSuffixer{revSuffixPath{"^", 1}},
+		"~": []revSuffixer{revSuffixPath{"~", 1}},
+		"~^^1~2~10~^100^~1000": []revSuffixer{
+			revSuffixPath{"~", 1},
+			revSuffixPath{"^", 1},
+			revSuffixPath{"^", 1},
+			revSuffixPath{"~", 2},
+			revSuffixPath{"~", 10},
+			revSuffixPath{"~", 1},
+			revSuffixPath{"^", 100},
+			revSuffixPath{"^", 1},
+			revSuffixPath{"~", 1000},
+		}}
 
 	for d, expected := range datas {
 		parser := newParser(bytes.NewBufferString(d))

--- a/internal/revision/parser_test.go
+++ b/internal/revision/parser_test.go
@@ -18,6 +18,12 @@ func (s *ParserSuite) TestErrInvalidRevision(c *C) {
 	c.Assert(e.Error(), Equals, "Revision invalid : test")
 }
 
+func (s *ParserSuite) TestNewParserFromString(c *C) {
+	p := NewParserFromString("test")
+
+	c.Assert(p, FitsTypeOf, &Parser{})
+}
+
 func (s *ParserSuite) TestScan(c *C) {
 	parser := NewParser(bytes.NewBufferString("Hello world !"))
 

--- a/internal/revision/parser_test.go
+++ b/internal/revision/parser_test.go
@@ -140,6 +140,12 @@ func (s *ParserSuite) TestParseWithValidExpression(c *C) {
 			ref("master"),
 			colonPath{"./README"},
 		},
+		"master^1~:./README": []revisioner{
+			ref("master"),
+			caretPath{1},
+			tildePath{1},
+			colonPath{"./README"},
+		},
 		":0:README": []revisioner{
 			colonStagePath{"README", 0},
 		},
@@ -181,6 +187,7 @@ func (s *ParserSuite) TestParseWithUnValidExpression(c *C) {
 		"^{/test}":                        &ErrInvalidRevision{`"~" or "^" statement must have a reference defined at the beginning`},
 		"~1":                              &ErrInvalidRevision{`"~" or "^" statement must have a reference defined at the beginning`},
 		"master:/test":                    &ErrInvalidRevision{`":" statement is not valid, could be : :/<regexp>`},
+		"master:0:README":                 &ErrInvalidRevision{`":" statement is not valid, could be : :<n>:<path>`},
 	}
 
 	for s, e := range datas {

--- a/internal/revision/parser_test.go
+++ b/internal/revision/parser_test.go
@@ -171,12 +171,16 @@ func (s *ParserSuite) TestParseWithUnValidExpression(c *C) {
 	datas := map[string]error{
 		"..":                              &ErrInvalidRevision{`must not start with "."`},
 		"master^1master":                  &ErrInvalidRevision{`reference must be defined once at the beginning`},
-		"master^1@{2016-12-16T21:42:47Z}": &ErrInvalidRevision{`@ statement is not valid, could be : <refname>@{<ISO-8601 date>}, @{<ISO-8601 date>}`},
-		"master^1@{1}":                    &ErrInvalidRevision{`@ statement is not valid, could be : <refname>@{<n>}, @{<n>}`},
-		"master@{-1}":                     &ErrInvalidRevision{`@ statement is not valid, could be : @{-<n>}`},
-		"master^1@{upstream}":             &ErrInvalidRevision{`@ statement is not valid, could be : <refname>@{upstream}, @{upstream}, <refname>@{u}, @{u}`},
-		"master^1@{u}":                    &ErrInvalidRevision{`@ statement is not valid, could be : <refname>@{upstream}, @{upstream}, <refname>@{u}, @{u}`},
-		"master^1@{push}":                 &ErrInvalidRevision{`@ statement is not valid, could be : <refname>@{push}, @{push}`},
+		"master^1@{2016-12-16T21:42:47Z}": &ErrInvalidRevision{`"@" statement is not valid, could be : <refname>@{<ISO-8601 date>}, @{<ISO-8601 date>}`},
+		"master^1@{1}":                    &ErrInvalidRevision{`"@" statement is not valid, could be : <refname>@{<n>}, @{<n>}`},
+		"master@{-1}":                     &ErrInvalidRevision{`"@" statement is not valid, could be : @{-<n>}`},
+		"master^1@{upstream}":             &ErrInvalidRevision{`"@" statement is not valid, could be : <refname>@{upstream}, @{upstream}, <refname>@{u}, @{u}`},
+		"master^1@{u}":                    &ErrInvalidRevision{`"@" statement is not valid, could be : <refname>@{upstream}, @{upstream}, <refname>@{u}, @{u}`},
+		"master^1@{push}":                 &ErrInvalidRevision{`"@" statement is not valid, could be : <refname>@{push}, @{push}`},
+		"^1":                              &ErrInvalidRevision{`"~" or "^" statement must have a reference defined at the beginning`},
+		"^{/test}":                        &ErrInvalidRevision{`"~" or "^" statement must have a reference defined at the beginning`},
+		"~1":                              &ErrInvalidRevision{`"~" or "^" statement must have a reference defined at the beginning`},
+		"master:/test":                    &ErrInvalidRevision{`":" statement is not valid, could be : :/<regexp>`},
 	}
 
 	for s, e := range datas {

--- a/internal/revision/parser_test.go
+++ b/internal/revision/parser_test.go
@@ -71,8 +71,11 @@ func (s *ParserSuite) TestUnscan(c *C) {
 
 func (s *ParserSuite) TestParseAtSuffixWithValidExpression(c *C) {
 	datas := map[string]atSuffixer{
-		"{1}":  atSuffixReflog{1},
-		"{-1}": atSuffixCheckout{1},
+		"{1}":        atSuffixReflog{1},
+		"{-1}":       atSuffixCheckout{1},
+		"{push}":     atPush{},
+		"{upstream}": atUpstream{},
+		"{u}":        atUpstream{},
 	}
 
 	for d, expected := range datas {

--- a/internal/revision/parser_test.go
+++ b/internal/revision/parser_test.go
@@ -126,6 +126,12 @@ func (s *ParserSuite) TestParseWithValidExpression(c *C) {
 			ref("master"),
 			colonPath{"./README", 0},
 		},
+		":0:README": []revisioner{
+			colonPath{"README", 0},
+		},
+		":3:README": []revisioner{
+			colonPath{"README", 3},
+		},
 		"master~1^{/update}~5~^^1": []revisioner{
 			ref("master"),
 			tildePath{1},
@@ -279,6 +285,10 @@ func (s *ParserSuite) TestParseColonWithValidExpression(c *C) {
 		":../parser.go":      colonPath{"../parser.go", 0},
 		":./parser.go":       colonPath{"./parser.go", 0},
 		":parser.go":         colonPath{"parser.go", 0},
+		":0:parser.go":       colonPath{"parser.go", 0},
+		":1:parser.go":       colonPath{"parser.go", 1},
+		":2:parser.go":       colonPath{"parser.go", 2},
+		":3:parser.go":       colonPath{"parser.go", 3},
 	}
 
 	for d, expected := range datas {

--- a/internal/revision/parser_test.go
+++ b/internal/revision/parser_test.go
@@ -19,7 +19,7 @@ func (s *ParserSuite) TestErrInvalidRevision(c *C) {
 }
 
 func (s *ParserSuite) TestScan(c *C) {
-	parser := newParser(bytes.NewBufferString("Hello world !"))
+	parser := NewParser(bytes.NewBufferString("Hello world !"))
 
 	expected := []struct {
 		t token
@@ -62,7 +62,7 @@ func (s *ParserSuite) TestScan(c *C) {
 }
 
 func (s *ParserSuite) TestUnscan(c *C) {
-	parser := newParser(bytes.NewBufferString("Hello world !"))
+	parser := NewParser(bytes.NewBufferString("Hello world !"))
 
 	tok, str := parser.scan()
 
@@ -80,94 +80,94 @@ func (s *ParserSuite) TestUnscan(c *C) {
 func (s *ParserSuite) TestParseWithValidExpression(c *C) {
 	tim, _ := time.Parse("2006-01-02T15:04:05Z", "2016-12-16T21:42:47Z")
 
-	datas := map[string]revisioner{
-		"@": []revisioner{ref("HEAD")},
-		"@~3": []revisioner{
-			ref("HEAD"),
-			tildePath{3},
+	datas := map[string]Revisioner{
+		"@": []Revisioner{Ref("HEAD")},
+		"@~3": []Revisioner{
+			Ref("HEAD"),
+			TildePath{3},
 		},
-		"@{2016-12-16T21:42:47Z}": []revisioner{atDate{tim}},
-		"@{1}":  []revisioner{atReflog{1}},
-		"@{-1}": []revisioner{atCheckout{1}},
-		"master@{upstream}": []revisioner{
-			ref("master"),
-			atUpstream{},
+		"@{2016-12-16T21:42:47Z}": []Revisioner{AtDate{tim}},
+		"@{1}":  []Revisioner{AtReflog{1}},
+		"@{-1}": []Revisioner{AtCheckout{1}},
+		"master@{upstream}": []Revisioner{
+			Ref("master"),
+			AtUpstream{},
 		},
-		"@{upstream}": []revisioner{
-			atUpstream{},
+		"@{upstream}": []Revisioner{
+			AtUpstream{},
 		},
-		"@{u}": []revisioner{
-			atUpstream{},
+		"@{u}": []Revisioner{
+			AtUpstream{},
 		},
-		"master@{push}": []revisioner{
-			ref("master"),
-			atPush{},
+		"master@{push}": []Revisioner{
+			Ref("master"),
+			AtPush{},
 		},
-		"master@{2016-12-16T21:42:47Z}": []revisioner{
-			ref("master"),
-			atDate{tim},
+		"master@{2016-12-16T21:42:47Z}": []Revisioner{
+			Ref("master"),
+			AtDate{tim},
 		},
-		"HEAD^": []revisioner{
-			ref("HEAD"),
-			caretPath{1},
+		"HEAD^": []Revisioner{
+			Ref("HEAD"),
+			CaretPath{1},
 		},
-		"master~3": []revisioner{
-			ref("master"),
-			tildePath{3},
+		"master~3": []Revisioner{
+			Ref("master"),
+			TildePath{3},
 		},
-		"v0.99.8^{commit}": []revisioner{
-			ref("v0.99.8"),
-			caretType{"commit"},
+		"v0.99.8^{commit}": []Revisioner{
+			Ref("v0.99.8"),
+			CaretType{"commit"},
 		},
-		"v0.99.8^{}": []revisioner{
-			ref("v0.99.8"),
-			caretType{"tag"},
+		"v0.99.8^{}": []Revisioner{
+			Ref("v0.99.8"),
+			CaretType{"tag"},
 		},
-		"HEAD^{/fix nasty bug}": []revisioner{
-			ref("HEAD"),
-			caretReg{regexp.MustCompile("fix nasty bug"), false},
+		"HEAD^{/fix nasty bug}": []Revisioner{
+			Ref("HEAD"),
+			CaretReg{regexp.MustCompile("fix nasty bug"), false},
 		},
-		":/fix nasty bug": []revisioner{
-			colonReg{regexp.MustCompile("fix nasty bug"), false},
+		":/fix nasty bug": []Revisioner{
+			ColonReg{regexp.MustCompile("fix nasty bug"), false},
 		},
-		"HEAD:README": []revisioner{
-			ref("HEAD"),
-			colonPath{"README"},
+		"HEAD:README": []Revisioner{
+			Ref("HEAD"),
+			ColonPath{"README"},
 		},
-		":README": []revisioner{
-			colonPath{"README"},
+		":README": []Revisioner{
+			ColonPath{"README"},
 		},
-		"master:./README": []revisioner{
-			ref("master"),
-			colonPath{"./README"},
+		"master:./README": []Revisioner{
+			Ref("master"),
+			ColonPath{"./README"},
 		},
-		"master^1~:./README": []revisioner{
-			ref("master"),
-			caretPath{1},
-			tildePath{1},
-			colonPath{"./README"},
+		"master^1~:./README": []Revisioner{
+			Ref("master"),
+			CaretPath{1},
+			TildePath{1},
+			ColonPath{"./README"},
 		},
-		":0:README": []revisioner{
-			colonStagePath{"README", 0},
+		":0:README": []Revisioner{
+			ColonStagePath{"README", 0},
 		},
-		":3:README": []revisioner{
-			colonStagePath{"README", 3},
+		":3:README": []Revisioner{
+			ColonStagePath{"README", 3},
 		},
-		"master~1^{/update}~5~^^1": []revisioner{
-			ref("master"),
-			tildePath{1},
-			caretReg{regexp.MustCompile("update"), false},
-			tildePath{5},
-			tildePath{1},
-			caretPath{1},
-			caretPath{1},
+		"master~1^{/update}~5~^^1": []Revisioner{
+			Ref("master"),
+			TildePath{1},
+			CaretReg{regexp.MustCompile("update"), false},
+			TildePath{5},
+			TildePath{1},
+			CaretPath{1},
+			CaretPath{1},
 		},
 	}
 
 	for d, expected := range datas {
-		parser := newParser(bytes.NewBufferString(d))
+		parser := NewParser(bytes.NewBufferString(d))
 
-		result, err := parser.parse()
+		result, err := parser.Parse()
 
 		c.Assert(err, Equals, nil)
 		c.Assert(result, DeepEquals, expected)
@@ -192,8 +192,8 @@ func (s *ParserSuite) TestParseWithUnValidExpression(c *C) {
 	}
 
 	for s, e := range datas {
-		parser := newParser(bytes.NewBufferString(s))
-		_, err := parser.parse()
+		parser := NewParser(bytes.NewBufferString(s))
+		_, err := parser.Parse()
 		c.Assert(err, DeepEquals, e)
 	}
 }
@@ -201,18 +201,18 @@ func (s *ParserSuite) TestParseWithUnValidExpression(c *C) {
 func (s *ParserSuite) TestParseAtWithValidExpression(c *C) {
 	tim, _ := time.Parse("2006-01-02T15:04:05Z", "2016-12-16T21:42:47Z")
 
-	datas := map[string]revisioner{
-		"@":           ref("HEAD"),
-		"@{1}":        atReflog{1},
-		"@{-1}":       atCheckout{1},
-		"@{push}":     atPush{},
-		"@{upstream}": atUpstream{},
-		"@{u}":        atUpstream{},
-		"@{2016-12-16T21:42:47Z}": atDate{tim},
+	datas := map[string]Revisioner{
+		"@":           Ref("HEAD"),
+		"@{1}":        AtReflog{1},
+		"@{-1}":       AtCheckout{1},
+		"@{push}":     AtPush{},
+		"@{upstream}": AtUpstream{},
+		"@{u}":        AtUpstream{},
+		"@{2016-12-16T21:42:47Z}": AtDate{tim},
 	}
 
 	for d, expected := range datas {
-		parser := newParser(bytes.NewBufferString(d))
+		parser := NewParser(bytes.NewBufferString(d))
 
 		result, err := parser.parseAt()
 
@@ -229,7 +229,7 @@ func (s *ParserSuite) TestParseAtWithUnValidExpression(c *C) {
 	}
 
 	for s, e := range datas {
-		parser := newParser(bytes.NewBufferString(s))
+		parser := NewParser(bytes.NewBufferString(s))
 
 		_, err := parser.parseAt()
 
@@ -238,22 +238,22 @@ func (s *ParserSuite) TestParseAtWithUnValidExpression(c *C) {
 }
 
 func (s *ParserSuite) TestParseCaretWithValidExpression(c *C) {
-	datas := map[string]revisioner{
-		"^":                    caretPath{1},
-		"^3":                   caretPath{3},
-		"^{}":                  caretType{"tag"},
-		"^{commit}":            caretType{"commit"},
-		"^{tree}":              caretType{"tree"},
-		"^{blob}":              caretType{"blob"},
-		"^{tag}":               caretType{"tag"},
-		"^{object}":            caretType{"object"},
-		"^{/hello world !}":    caretReg{regexp.MustCompile("hello world !"), false},
-		"^{/!-hello world !}":  caretReg{regexp.MustCompile("hello world !"), true},
-		"^{/!! hello world !}": caretReg{regexp.MustCompile("! hello world !"), false},
+	datas := map[string]Revisioner{
+		"^":                    CaretPath{1},
+		"^3":                   CaretPath{3},
+		"^{}":                  CaretType{"tag"},
+		"^{commit}":            CaretType{"commit"},
+		"^{tree}":              CaretType{"tree"},
+		"^{blob}":              CaretType{"blob"},
+		"^{tag}":               CaretType{"tag"},
+		"^{object}":            CaretType{"object"},
+		"^{/hello world !}":    CaretReg{regexp.MustCompile("hello world !"), false},
+		"^{/!-hello world !}":  CaretReg{regexp.MustCompile("hello world !"), true},
+		"^{/!! hello world !}": CaretReg{regexp.MustCompile("! hello world !"), false},
 	}
 
 	for d, expected := range datas {
-		parser := newParser(bytes.NewBufferString(d))
+		parser := NewParser(bytes.NewBufferString(d))
 
 		result, err := parser.parseCaret()
 
@@ -271,7 +271,7 @@ func (s *ParserSuite) TestParseCaretWithUnValidExpression(c *C) {
 	}
 
 	for s, e := range datas {
-		parser := newParser(bytes.NewBufferString(s))
+		parser := NewParser(bytes.NewBufferString(s))
 
 		_, err := parser.parseCaret()
 
@@ -280,14 +280,14 @@ func (s *ParserSuite) TestParseCaretWithUnValidExpression(c *C) {
 }
 
 func (s *ParserSuite) TestParseTildeWithValidExpression(c *C) {
-	datas := map[string]revisioner{
-		"~3": tildePath{3},
-		"~1": tildePath{1},
-		"~":  tildePath{1},
+	datas := map[string]Revisioner{
+		"~3": TildePath{3},
+		"~1": TildePath{1},
+		"~":  TildePath{1},
 	}
 
 	for d, expected := range datas {
-		parser := newParser(bytes.NewBufferString(d))
+		parser := NewParser(bytes.NewBufferString(d))
 
 		result, err := parser.parseTilde()
 
@@ -302,7 +302,7 @@ func (s *ParserSuite) TestParseTildeWithUnValidExpression(c *C) {
 	}
 
 	for s, e := range datas {
-		parser := newParser(bytes.NewBufferString(s))
+		parser := NewParser(bytes.NewBufferString(s))
 
 		_, err := parser.parseTilde()
 
@@ -311,21 +311,21 @@ func (s *ParserSuite) TestParseTildeWithUnValidExpression(c *C) {
 }
 
 func (s *ParserSuite) TestParseColonWithValidExpression(c *C) {
-	datas := map[string]revisioner{
-		":/hello world !":    colonReg{regexp.MustCompile("hello world !"), false},
-		":/!-hello world !":  colonReg{regexp.MustCompile("hello world !"), true},
-		":/!! hello world !": colonReg{regexp.MustCompile("! hello world !"), false},
-		":../parser.go":      colonPath{"../parser.go"},
-		":./parser.go":       colonPath{"./parser.go"},
-		":parser.go":         colonPath{"parser.go"},
-		":0:parser.go":       colonStagePath{"parser.go", 0},
-		":1:parser.go":       colonStagePath{"parser.go", 1},
-		":2:parser.go":       colonStagePath{"parser.go", 2},
-		":3:parser.go":       colonStagePath{"parser.go", 3},
+	datas := map[string]Revisioner{
+		":/hello world !":    ColonReg{regexp.MustCompile("hello world !"), false},
+		":/!-hello world !":  ColonReg{regexp.MustCompile("hello world !"), true},
+		":/!! hello world !": ColonReg{regexp.MustCompile("! hello world !"), false},
+		":../parser.go":      ColonPath{"../parser.go"},
+		":./parser.go":       ColonPath{"./parser.go"},
+		":parser.go":         ColonPath{"parser.go"},
+		":0:parser.go":       ColonStagePath{"parser.go", 0},
+		":1:parser.go":       ColonStagePath{"parser.go", 1},
+		":2:parser.go":       ColonStagePath{"parser.go", 2},
+		":3:parser.go":       ColonStagePath{"parser.go", 3},
 	}
 
 	for d, expected := range datas {
-		parser := newParser(bytes.NewBufferString(d))
+		parser := NewParser(bytes.NewBufferString(d))
 
 		result, err := parser.parseColon()
 
@@ -342,7 +342,7 @@ func (s *ParserSuite) TestParseColonWithUnValidExpression(c *C) {
 	}
 
 	for s, e := range datas {
-		parser := newParser(bytes.NewBufferString(s))
+		parser := NewParser(bytes.NewBufferString(s))
 
 		_, err := parser.parseColon()
 
@@ -364,12 +364,12 @@ func (s *ParserSuite) TestParseRefWithValidName(c *C) {
 	}
 
 	for _, d := range datas {
-		parser := newParser(bytes.NewBufferString(d))
+		parser := NewParser(bytes.NewBufferString(d))
 
 		result, err := parser.parseRef()
 
 		c.Assert(err, Equals, nil)
-		c.Assert(result, Equals, ref(d))
+		c.Assert(result, Equals, Ref(d))
 	}
 }
 
@@ -393,7 +393,7 @@ func (s *ParserSuite) TestParseRefWithUnvalidName(c *C) {
 	}
 
 	for s, e := range datas {
-		parser := newParser(bytes.NewBufferString(s))
+		parser := NewParser(bytes.NewBufferString(s))
 
 		_, err := parser.parseRef()
 

--- a/internal/revision/parser_test.go
+++ b/internal/revision/parser_test.go
@@ -115,6 +115,17 @@ func (s *ParserSuite) TestParseWithValidExpression(c *C) {
 		":/fix nasty bug": []revisioner{
 			colonReg{"fix nasty bug", false},
 		},
+		"HEAD:README": []revisioner{
+			ref("HEAD"),
+			colonPath{"README", 0},
+		},
+		":README": []revisioner{
+			colonPath{"README", 0},
+		},
+		"master:./README": []revisioner{
+			ref("master"),
+			colonPath{"./README", 0},
+		},
 		"master~1^{/update}~5~^^1": []revisioner{
 			ref("master"),
 			tildePath{1},
@@ -265,6 +276,9 @@ func (s *ParserSuite) TestParseColonWithValidExpression(c *C) {
 		":/hello world !":    colonReg{"hello world !", false},
 		":/!-hello world !":  colonReg{"hello world !", true},
 		":/!! hello world !": colonReg{"! hello world !", false},
+		":../parser.go":      colonPath{"../parser.go", 0},
+		":./parser.go":       colonPath{"./parser.go", 0},
+		":parser.go":         colonPath{"parser.go", 0},
 	}
 
 	for d, expected := range datas {
@@ -281,7 +295,6 @@ func (s *ParserSuite) TestParseColonWithUnValidExpression(c *C) {
 	datas := map[string]error{
 		"a":       &ErrInvalidRevision{`"a" found must be ":"`},
 		":/!test": &ErrInvalidRevision{`revision suffix brace component sequences starting with "/!" others than those defined are reserved`},
-		":^":      &ErrInvalidRevision{`"^" is not a valid revision suffix colon component`},
 	}
 
 	for s, e := range datas {

--- a/internal/revision/parser_test.go
+++ b/internal/revision/parser_test.go
@@ -1,0 +1,70 @@
+package revision
+
+import (
+	"bytes"
+
+	. "gopkg.in/check.v1"
+)
+
+type ParserSuite struct{}
+
+var _ = Suite(&ParserSuite{})
+
+func (s *ParserSuite) TestScan(c *C) {
+	parser := newParser(bytes.NewBufferString("Hello world !"))
+
+	expected := []struct {
+		t token
+		s string
+	}{
+		{
+			word,
+			"Hello",
+		},
+		{
+			space,
+			" ",
+		},
+		{
+			word,
+			"world",
+		},
+		{
+			space,
+			" ",
+		},
+		{
+			char,
+			"!",
+		},
+	}
+
+	for i := 0; ; {
+		tok, str := parser.scan()
+
+		if tok == eof {
+			return
+		}
+
+		c.Assert(str, Equals, expected[i].s)
+		c.Assert(tok, Equals, expected[i].t)
+
+		i++
+	}
+}
+
+func (s *ParserSuite) TestUnscan(c *C) {
+	parser := newParser(bytes.NewBufferString("Hello world !"))
+
+	tok, str := parser.scan()
+
+	c.Assert(str, Equals, "Hello")
+	c.Assert(tok, Equals, word)
+
+	parser.unscan()
+
+	tok, str = parser.scan()
+
+	c.Assert(str, Equals, "Hello")
+	c.Assert(tok, Equals, word)
+}

--- a/internal/revision/parser_test.go
+++ b/internal/revision/parser_test.go
@@ -70,7 +70,7 @@ func (s *ParserSuite) TestUnscan(c *C) {
 }
 
 func (s *ParserSuite) TestParseAtSuffixWithValidExpression(c *C) {
-	datas := map[string]suffixer{
+	datas := map[string]revisioner{
 		"@{1}":        atSuffixReflog{1},
 		"@{-1}":       atSuffixCheckout{1},
 		"@{push}":     atPush{},
@@ -106,7 +106,7 @@ func (s *ParserSuite) TestParseAtSuffixWithUnValidExpression(c *C) {
 }
 
 func (s *ParserSuite) TestParseCaretSuffixWithValidExpression(c *C) {
-	datas := map[string]suffixer{
+	datas := map[string]revisioner{
 		"^":                    caretSuffixPath{1},
 		"^3":                   caretSuffixPath{3},
 		"^{}":                  caretSuffixType{"tag"},
@@ -148,7 +148,7 @@ func (s *ParserSuite) TestParseCaretSuffixWithUnValidExpression(c *C) {
 }
 
 func (s *ParserSuite) TestParseTildeSuffixWithValidExpression(c *C) {
-	datas := map[string]suffixer{
+	datas := map[string]revisioner{
 		"~3": tildeSuffixPath{3},
 		"~1": tildeSuffixPath{1},
 		"~":  tildeSuffixPath{1},

--- a/internal/revision/parser_test.go
+++ b/internal/revision/parser_test.go
@@ -246,7 +246,7 @@ func (s *ParserSuite) TestParseAtWithUnValidExpression(c *C) {
 func (s *ParserSuite) TestParseCaretWithValidExpression(c *C) {
 	datas := map[string]Revisioner{
 		"^":                    CaretPath{1},
-		"^3":                   CaretPath{3},
+		"^2":                   CaretPath{2},
 		"^{}":                  CaretType{"tag"},
 		"^{commit}":            CaretType{"commit"},
 		"^{tree}":              CaretType{"tree"},
@@ -271,6 +271,7 @@ func (s *ParserSuite) TestParseCaretWithValidExpression(c *C) {
 func (s *ParserSuite) TestParseCaretWithUnValidExpression(c *C) {
 	datas := map[string]error{
 		"a":          &ErrInvalidRevision{`"a" found must be "^"`},
+		"^3":         &ErrInvalidRevision{`"3" found must be 0, 1 or 2 after "^"`},
 		"^{test}":    &ErrInvalidRevision{`"test" is not a valid revision suffix brace component`},
 		"^{/!test}":  &ErrInvalidRevision{`revision suffix brace component sequences starting with "/!" others than those defined are reserved`},
 		"^{/test**}": &ErrInvalidRevision{"revision suffix brace component, error parsing regexp: invalid nested repetition operator: `**`"},

--- a/internal/revision/parser_test.go
+++ b/internal/revision/parser_test.go
@@ -34,7 +34,7 @@ func (s *ParserSuite) TestScan(c *C) {
 			" ",
 		},
 		{
-			char,
+			emark,
 			"!",
 		},
 	}

--- a/internal/revision/parser_test.go
+++ b/internal/revision/parser_test.go
@@ -122,7 +122,7 @@ func (s *ParserSuite) TestParse(c *C) {
 	}
 }
 
-func (s *ParserSuite) TestParseAtSuffixWithValidExpression(c *C) {
+func (s *ParserSuite) TestParseAtWithValidExpression(c *C) {
 	datas := map[string]revisioner{
 		"@{1}":        atSuffixReflog{1},
 		"@{-1}":       atSuffixCheckout{1},
@@ -134,14 +134,14 @@ func (s *ParserSuite) TestParseAtSuffixWithValidExpression(c *C) {
 	for d, expected := range datas {
 		parser := newParser(bytes.NewBufferString(d))
 
-		result, err := parser.parseAtSuffix()
+		result, err := parser.parseAt()
 
 		c.Assert(err, Equals, nil)
 		c.Assert(result, DeepEquals, expected)
 	}
 }
 
-func (s *ParserSuite) TestParseAtSuffixWithUnValidExpression(c *C) {
+func (s *ParserSuite) TestParseAtWithUnValidExpression(c *C) {
 	datas := map[string]error{
 		"a":       &ErrInvalidRevision{`"a" found must be "@"`},
 		"@test}":  &ErrInvalidRevision{`"test" found must be "{" after @`},
@@ -152,13 +152,13 @@ func (s *ParserSuite) TestParseAtSuffixWithUnValidExpression(c *C) {
 	for s, e := range datas {
 		parser := newParser(bytes.NewBufferString(s))
 
-		_, err := parser.parseAtSuffix()
+		_, err := parser.parseAt()
 
 		c.Assert(err, DeepEquals, e)
 	}
 }
 
-func (s *ParserSuite) TestParseCaretSuffixWithValidExpression(c *C) {
+func (s *ParserSuite) TestParseCaretWithValidExpression(c *C) {
 	datas := map[string]revisioner{
 		"^":                    caretSuffixPath{1},
 		"^3":                   caretSuffixPath{3},
@@ -176,14 +176,14 @@ func (s *ParserSuite) TestParseCaretSuffixWithValidExpression(c *C) {
 	for d, expected := range datas {
 		parser := newParser(bytes.NewBufferString(d))
 
-		result, err := parser.parseCaretSuffix()
+		result, err := parser.parseCaret()
 
 		c.Assert(err, Equals, nil)
 		c.Assert(result, DeepEquals, expected)
 	}
 }
 
-func (s *ParserSuite) TestParseCaretSuffixWithUnValidExpression(c *C) {
+func (s *ParserSuite) TestParseCaretWithUnValidExpression(c *C) {
 	datas := map[string]error{
 		"a":         &ErrInvalidRevision{`"a" found must be "^"`},
 		"^a":        &ErrInvalidRevision{`"a" is not a valid revision suffix component`},
@@ -194,13 +194,13 @@ func (s *ParserSuite) TestParseCaretSuffixWithUnValidExpression(c *C) {
 	for s, e := range datas {
 		parser := newParser(bytes.NewBufferString(s))
 
-		_, err := parser.parseCaretSuffix()
+		_, err := parser.parseCaret()
 
 		c.Assert(err, DeepEquals, e)
 	}
 }
 
-func (s *ParserSuite) TestParseTildeSuffixWithValidExpression(c *C) {
+func (s *ParserSuite) TestParseTildeWithValidExpression(c *C) {
 	datas := map[string]revisioner{
 		"~3": tildeSuffixPath{3},
 		"~1": tildeSuffixPath{1},
@@ -210,14 +210,14 @@ func (s *ParserSuite) TestParseTildeSuffixWithValidExpression(c *C) {
 	for d, expected := range datas {
 		parser := newParser(bytes.NewBufferString(d))
 
-		result, err := parser.parseTildeSuffix()
+		result, err := parser.parseTilde()
 
 		c.Assert(err, Equals, nil)
 		c.Assert(result, DeepEquals, expected)
 	}
 }
 
-func (s *ParserSuite) TestParseTildeSuffixWithUnValidExpression(c *C) {
+func (s *ParserSuite) TestParseTildeWithUnValidExpression(c *C) {
 	datas := map[string]error{
 		"a":  &ErrInvalidRevision{`"a" found must be "~"`},
 		"~a": &ErrInvalidRevision{`"a" is not a valid revision suffix component`},
@@ -226,7 +226,7 @@ func (s *ParserSuite) TestParseTildeSuffixWithUnValidExpression(c *C) {
 	for s, e := range datas {
 		parser := newParser(bytes.NewBufferString(s))
 
-		_, err := parser.parseTildeSuffix()
+		_, err := parser.parseTilde()
 
 		c.Assert(err, DeepEquals, e)
 	}

--- a/internal/revision/parser_test.go
+++ b/internal/revision/parser_test.go
@@ -281,6 +281,7 @@ func (s *ParserSuite) TestParseColonWithUnValidExpression(c *C) {
 	datas := map[string]error{
 		"a":       &ErrInvalidRevision{`"a" found must be ":"`},
 		":/!test": &ErrInvalidRevision{`revision suffix brace component sequences starting with "/!" others than those defined are reserved`},
+		":^":      &ErrInvalidRevision{`"^" is not a valid revision suffix colon component`},
 	}
 
 	for s, e := range datas {

--- a/internal/revision/parser_test.go
+++ b/internal/revision/parser_test.go
@@ -257,7 +257,6 @@ func (s *ParserSuite) TestParseCaretWithValidExpression(c *C) {
 func (s *ParserSuite) TestParseCaretWithUnValidExpression(c *C) {
 	datas := map[string]error{
 		"a":         &ErrInvalidRevision{`"a" found must be "^"`},
-		"^a":        &ErrInvalidRevision{`"a" is not a valid revision suffix component`},
 		"^{test}":   &ErrInvalidRevision{`"test" is not a valid revision suffix brace component`},
 		"^{/!test}": &ErrInvalidRevision{`revision suffix brace component sequences starting with "/!" others than those defined are reserved`},
 	}
@@ -290,8 +289,7 @@ func (s *ParserSuite) TestParseTildeWithValidExpression(c *C) {
 
 func (s *ParserSuite) TestParseTildeWithUnValidExpression(c *C) {
 	datas := map[string]error{
-		"a":  &ErrInvalidRevision{`"a" found must be "~"`},
-		"~a": &ErrInvalidRevision{`"a" is not a valid revision suffix component`},
+		"a": &ErrInvalidRevision{`"a" found must be "~"`},
 	}
 
 	for s, e := range datas {

--- a/internal/revision/parser_test.go
+++ b/internal/revision/parser_test.go
@@ -74,10 +74,10 @@ func (s *ParserSuite) TestParse(c *C) {
 		"@": []revisioner{ref("HEAD")},
 		"@~3": []revisioner{
 			ref("HEAD"),
-			tildeSuffixPath{3},
+			tildePath{3},
 		},
-		"@{1}":  []revisioner{atSuffixReflog{1}},
-		"@{-1}": []revisioner{atSuffixCheckout{1}},
+		"@{1}":  []revisioner{atReflog{1}},
+		"@{-1}": []revisioner{atCheckout{1}},
 		"master@{upstream}": []revisioner{
 			ref("master"),
 			atUpstream{},
@@ -88,32 +88,32 @@ func (s *ParserSuite) TestParse(c *C) {
 		},
 		"HEAD^": []revisioner{
 			ref("HEAD"),
-			caretSuffixPath{1},
+			caretPath{1},
 		},
 		"master~3": []revisioner{
 			ref("master"),
-			tildeSuffixPath{3},
+			tildePath{3},
 		},
 		"v0.99.8^{commit}": []revisioner{
 			ref("v0.99.8"),
-			caretSuffixType{"commit"},
+			caretType{"commit"},
 		},
 		"v0.99.8^{}": []revisioner{
 			ref("v0.99.8"),
-			caretSuffixType{"tag"},
+			caretType{"tag"},
 		},
 		"HEAD^{/fix nasty bug}": []revisioner{
 			ref("HEAD"),
-			caretSuffixReg{"fix nasty bug", false},
+			caretReg{"fix nasty bug", false},
 		},
 		"master~1^{/update}~5~^^1": []revisioner{
 			ref("master"),
-			tildeSuffixPath{1},
-			caretSuffixReg{"update", false},
-			tildeSuffixPath{5},
-			tildeSuffixPath{1},
-			caretSuffixPath{1},
-			caretSuffixPath{1},
+			tildePath{1},
+			caretReg{"update", false},
+			tildePath{5},
+			tildePath{1},
+			caretPath{1},
+			caretPath{1},
 		},
 	}
 
@@ -130,8 +130,8 @@ func (s *ParserSuite) TestParse(c *C) {
 func (s *ParserSuite) TestParseAtWithValidExpression(c *C) {
 	datas := map[string]revisioner{
 		"@":           ref("HEAD"),
-		"@{1}":        atSuffixReflog{1},
-		"@{-1}":       atSuffixCheckout{1},
+		"@{1}":        atReflog{1},
+		"@{-1}":       atCheckout{1},
 		"@{push}":     atPush{},
 		"@{upstream}": atUpstream{},
 		"@{u}":        atUpstream{},
@@ -165,17 +165,17 @@ func (s *ParserSuite) TestParseAtWithUnValidExpression(c *C) {
 
 func (s *ParserSuite) TestParseCaretWithValidExpression(c *C) {
 	datas := map[string]revisioner{
-		"^":                    caretSuffixPath{1},
-		"^3":                   caretSuffixPath{3},
-		"^{}":                  caretSuffixType{"tag"},
-		"^{commit}":            caretSuffixType{"commit"},
-		"^{tree}":              caretSuffixType{"tree"},
-		"^{blob}":              caretSuffixType{"blob"},
-		"^{tag}":               caretSuffixType{"tag"},
-		"^{object}":            caretSuffixType{"object"},
-		"^{/hello world !}":    caretSuffixReg{"hello world !", false},
-		"^{/!-hello world !}":  caretSuffixReg{"hello world !", true},
-		"^{/!! hello world !}": caretSuffixReg{"! hello world !", false},
+		"^":                    caretPath{1},
+		"^3":                   caretPath{3},
+		"^{}":                  caretType{"tag"},
+		"^{commit}":            caretType{"commit"},
+		"^{tree}":              caretType{"tree"},
+		"^{blob}":              caretType{"blob"},
+		"^{tag}":               caretType{"tag"},
+		"^{object}":            caretType{"object"},
+		"^{/hello world !}":    caretReg{"hello world !", false},
+		"^{/!-hello world !}":  caretReg{"hello world !", true},
+		"^{/!! hello world !}": caretReg{"! hello world !", false},
 	}
 
 	for d, expected := range datas {
@@ -207,9 +207,9 @@ func (s *ParserSuite) TestParseCaretWithUnValidExpression(c *C) {
 
 func (s *ParserSuite) TestParseTildeWithValidExpression(c *C) {
 	datas := map[string]revisioner{
-		"~3": tildeSuffixPath{3},
-		"~1": tildeSuffixPath{1},
-		"~":  tildeSuffixPath{1},
+		"~3": tildePath{3},
+		"~1": tildePath{1},
+		"~":  tildePath{1},
 	}
 
 	for d, expected := range datas {

--- a/internal/revision/parser_test.go
+++ b/internal/revision/parser_test.go
@@ -69,6 +69,38 @@ func (s *ParserSuite) TestUnscan(c *C) {
 	c.Assert(tok, Equals, word)
 }
 
+func (s *ParserSuite) TestParseRevSuffixWithValidExpression(c *C) {
+	datas := map[string][]string{
+		"^": []string{"^"},
+		"~": []string{"~"},
+		"~^^1~2~10~^100^~1000": []string{"~", "^", "^1", "~2", "~10", "~", "^100", "^", "~1000"},
+	}
+
+	for d, expected := range datas {
+		parser := newParser(bytes.NewBufferString(d))
+
+		result, err := parser.parseRevSuffix()
+
+		c.Assert(err, Equals, nil)
+		c.Assert(result, DeepEquals, expected)
+	}
+}
+
+func (s *ParserSuite) TestParseRevSuffixWithUnValidExpression(c *C) {
+	datas := map[string]error{
+		"a":         &ErrInvalidRevision{`"a" is not a valid revision suffix component`},
+		"~^~10a^10": &ErrInvalidRevision{`"a" is not a valid revision suffix component`},
+	}
+
+	for s, e := range datas {
+		parser := newParser(bytes.NewBufferString(s))
+
+		_, err := parser.parseRevSuffix()
+
+		c.Assert(err, DeepEquals, e)
+	}
+}
+
 func (s *ParserSuite) TestParseRefWithValidName(c *C) {
 	datas := []string{
 		"lock",

--- a/internal/revision/parser_test.go
+++ b/internal/revision/parser_test.go
@@ -131,20 +131,20 @@ func (s *ParserSuite) TestParseWithValidExpression(c *C) {
 		},
 		"HEAD:README": []revisioner{
 			ref("HEAD"),
-			colonPath{"README", 0},
+			colonPath{"README"},
 		},
 		":README": []revisioner{
-			colonPath{"README", 0},
+			colonPath{"README"},
 		},
 		"master:./README": []revisioner{
 			ref("master"),
-			colonPath{"./README", 0},
+			colonPath{"./README"},
 		},
 		":0:README": []revisioner{
-			colonPath{"README", 0},
+			colonStagePath{"README", 0},
 		},
 		":3:README": []revisioner{
-			colonPath{"README", 3},
+			colonStagePath{"README", 3},
 		},
 		"master~1^{/update}~5~^^1": []revisioner{
 			ref("master"),
@@ -308,13 +308,13 @@ func (s *ParserSuite) TestParseColonWithValidExpression(c *C) {
 		":/hello world !":    colonReg{"hello world !", false},
 		":/!-hello world !":  colonReg{"hello world !", true},
 		":/!! hello world !": colonReg{"! hello world !", false},
-		":../parser.go":      colonPath{"../parser.go", 0},
-		":./parser.go":       colonPath{"./parser.go", 0},
-		":parser.go":         colonPath{"parser.go", 0},
-		":0:parser.go":       colonPath{"parser.go", 0},
-		":1:parser.go":       colonPath{"parser.go", 1},
-		":2:parser.go":       colonPath{"parser.go", 2},
-		":3:parser.go":       colonPath{"parser.go", 3},
+		":../parser.go":      colonPath{"../parser.go"},
+		":./parser.go":       colonPath{"./parser.go"},
+		":parser.go":         colonPath{"parser.go"},
+		":0:parser.go":       colonStagePath{"parser.go", 0},
+		":1:parser.go":       colonStagePath{"parser.go", 1},
+		":2:parser.go":       colonStagePath{"parser.go", 2},
+		":3:parser.go":       colonStagePath{"parser.go", 3},
 	}
 
 	for d, expected := range datas {

--- a/internal/revision/parser_test.go
+++ b/internal/revision/parser_test.go
@@ -54,12 +54,13 @@ func (s *ParserSuite) TestScan(c *C) {
 	}
 
 	for i := 0; ; {
-		tok, str := parser.scan()
+		tok, str, err := parser.scan()
 
 		if tok == eof {
 			return
 		}
 
+		c.Assert(err, Equals, nil)
 		c.Assert(str, Equals, expected[i].s)
 		c.Assert(tok, Equals, expected[i].t)
 
@@ -70,15 +71,17 @@ func (s *ParserSuite) TestScan(c *C) {
 func (s *ParserSuite) TestUnscan(c *C) {
 	parser := NewParser(bytes.NewBufferString("Hello world !"))
 
-	tok, str := parser.scan()
+	tok, str, err := parser.scan()
 
+	c.Assert(err, Equals, nil)
 	c.Assert(str, Equals, "Hello")
 	c.Assert(tok, Equals, word)
 
 	parser.unscan()
 
-	tok, str = parser.scan()
+	tok, str, err = parser.scan()
 
+	c.Assert(err, Equals, nil)
 	c.Assert(str, Equals, "Hello")
 	c.Assert(tok, Equals, word)
 }

--- a/internal/revision/parser_test.go
+++ b/internal/revision/parser_test.go
@@ -69,6 +69,36 @@ func (s *ParserSuite) TestUnscan(c *C) {
 	c.Assert(tok, Equals, word)
 }
 
+func (s *ParserSuite) TestParseAtSuffixWithValidExpression(c *C) {
+	datas := map[string]atSuffixer{
+		"{1}": atSuffixReflog{1},
+	}
+
+	for d, expected := range datas {
+		parser := newParser(bytes.NewBufferString(d))
+
+		result, err := parser.parseAtSuffix()
+
+		c.Assert(err, Equals, nil)
+		c.Assert(result, DeepEquals, expected)
+	}
+}
+
+func (s *ParserSuite) TestParseAtSuffixWithUnValidExpression(c *C) {
+	datas := map[string]error{
+		"test}":  &ErrInvalidRevision{`"test" found must be "{" after @`},
+		"{test}": &ErrInvalidRevision{`invalid expression "test" in @{} structure`},
+	}
+
+	for s, e := range datas {
+		parser := newParser(bytes.NewBufferString(s))
+
+		_, err := parser.parseAtSuffix()
+
+		c.Assert(err, DeepEquals, e)
+	}
+}
+
 func (s *ParserSuite) TestParseRevSuffixWithValidExpression(c *C) {
 	datas := map[string][]revSuffixer{
 		"^": []revSuffixer{revSuffixPath{"^", 1}},

--- a/internal/revision/parser_test.go
+++ b/internal/revision/parser_test.go
@@ -120,7 +120,7 @@ func (s *ParserSuite) TestParseRefWithValidName(c *C) {
 		result, err := parser.parseRef()
 
 		c.Assert(err, Equals, nil)
-		c.Assert(result, Equals, d)
+		c.Assert(result, Equals, ref(d))
 	}
 }
 

--- a/internal/revision/parser_test.go
+++ b/internal/revision/parser_test.go
@@ -71,7 +71,8 @@ func (s *ParserSuite) TestUnscan(c *C) {
 
 func (s *ParserSuite) TestParseAtSuffixWithValidExpression(c *C) {
 	datas := map[string]atSuffixer{
-		"{1}": atSuffixReflog{1},
+		"{1}":  atSuffixReflog{1},
+		"{-1}": atSuffixCheckout{1},
 	}
 
 	for d, expected := range datas {
@@ -88,6 +89,7 @@ func (s *ParserSuite) TestParseAtSuffixWithUnValidExpression(c *C) {
 	datas := map[string]error{
 		"test}":  &ErrInvalidRevision{`"test" found must be "{" after @`},
 		"{test}": &ErrInvalidRevision{`invalid expression "test" in @{} structure`},
+		"{-1":    &ErrInvalidRevision{`missing "}" in @{-n} structure`},
 	}
 
 	for s, e := range datas {

--- a/internal/revision/parser_test.go
+++ b/internal/revision/parser_test.go
@@ -69,7 +69,7 @@ func (s *ParserSuite) TestUnscan(c *C) {
 	c.Assert(tok, Equals, word)
 }
 
-func (s *ParserSuite) TestParse(c *C) {
+func (s *ParserSuite) TestParseWithValidExpression(c *C) {
 	datas := map[string]revisioner{
 		"@": []revisioner{ref("HEAD")},
 		"@~3": []revisioner{
@@ -254,7 +254,7 @@ func (s *ParserSuite) TestParseTildeWithUnValidExpression(c *C) {
 	}
 }
 
-func (s *ParserSuite) TestParseColon(c *C) {
+func (s *ParserSuite) TestParseColonWithValidExpression(c *C) {
 	datas := map[string]revisioner{
 		":/hello world !":    colonReg{"hello world !", false},
 		":/!-hello world !":  colonReg{"hello world !", true},

--- a/internal/revision/scanner.go
+++ b/internal/revision/scanner.go
@@ -56,6 +56,14 @@ func (s *scanner) scan() (token, string) {
 		return minus, string(ch)
 	case '@':
 		return at, string(ch)
+	case '\\':
+		return aslash, string(ch)
+	case '?':
+		return qmark, string(ch)
+	case '*':
+		return asterisk, string(ch)
+	case '[':
+		return obracket, string(ch)
 	}
 
 	if unicode.IsSpace(ch) {

--- a/internal/revision/scanner.go
+++ b/internal/revision/scanner.go
@@ -91,32 +91,32 @@ func (s *scanner) scan() (token, string) {
 
 // scanNumber return number token
 func (s *scanner) scanNumber() (token, string) {
-	var data string
+	var data []rune
 
 	for c := s.read(); c != zeroRune; c = s.read() {
 		if unicode.IsNumber(c) {
-			data += string(c)
+			data = append(data, c)
 		} else {
 			s.unread()
-			return number, data
+			return number, string(data)
 		}
 	}
 
-	return number, data
+	return number, string(data)
 }
 
 // scanWord return a word token
 func (s *scanner) scanWord() (token, string) {
-	var data string
+	var data []rune
 
 	for c := s.read(); c != zeroRune; c = s.read() {
 		if unicode.IsLetter(c) {
-			data += string(c)
+			data = append(data, c)
 		} else {
 			s.unread()
-			return word, data
+			return word, string(data)
 		}
 	}
 
-	return word, data
+	return word, string(data)
 }

--- a/internal/revision/scanner.go
+++ b/internal/revision/scanner.go
@@ -64,6 +64,8 @@ func (s *scanner) scan() (token, string) {
 		return asterisk, string(ch)
 	case '[':
 		return obracket, string(ch)
+	case '!':
+		return emark, string(ch)
 	}
 
 	if unicode.IsSpace(ch) {

--- a/internal/revision/scanner.go
+++ b/internal/revision/scanner.go
@@ -1,0 +1,112 @@
+package revision
+
+import (
+	"bufio"
+	"io"
+	"unicode"
+)
+
+var zeroRune = rune(0)
+
+// scanner represents a lexical scanner.
+type scanner struct {
+	r *bufio.Reader
+}
+
+// newScanner returns a new instance of scanner.
+func newScanner(r io.Reader) *scanner {
+	return &scanner{r: bufio.NewReader(r)}
+}
+
+// read reads the next rune from the bufferred reader.
+// Returns the rune(0) if an error occurs (or io.EOF is returned).
+func (s *scanner) read() rune {
+	ch, _, err := s.r.ReadRune()
+	if err != nil {
+		return zeroRune
+	}
+	return ch
+}
+
+// unread places the previously read rune back on the reader.
+func (s *scanner) unread() { _ = s.r.UnreadRune() }
+
+// Scan extract tokens from an input
+func (s *scanner) scan() (token, string) {
+	ch := s.read()
+
+	switch ch {
+	case zeroRune:
+		return eof, ""
+	case ':':
+		return colon, string(ch)
+	case '~':
+		return tilde, string(ch)
+	case '^':
+		return caret, string(ch)
+	case '.':
+		return dot, string(ch)
+	case '/':
+		return slash, string(ch)
+	case '{':
+		return obrace, string(ch)
+	case '}':
+		return cbrace, string(ch)
+	case '-':
+		return minus, string(ch)
+	}
+
+	if unicode.IsSpace(ch) {
+		return space, string(ch)
+	}
+
+	if unicode.IsControl(ch) {
+		return control, string(ch)
+	}
+
+	if unicode.IsLetter(ch) {
+		s.unread()
+
+		return s.scanWord()
+	}
+
+	if unicode.IsNumber(ch) {
+		s.unread()
+
+		return s.scanNumber()
+	}
+
+	return char, string(ch)
+}
+
+// scanNumber return number token
+func (s *scanner) scanNumber() (token, string) {
+	var data string
+
+	for c := s.read(); c != zeroRune; c = s.read() {
+		if unicode.IsNumber(c) {
+			data += string(c)
+		} else {
+			s.unread()
+			return number, data
+		}
+	}
+
+	return number, data
+}
+
+// scanWord return a word token
+func (s *scanner) scanWord() (token, string) {
+	var data string
+
+	for c := s.read(); c != zeroRune; c = s.read() {
+		if unicode.IsLetter(c) {
+			data += string(c)
+		} else {
+			s.unread()
+			return word, data
+		}
+	}
+
+	return word, data
+}

--- a/internal/revision/scanner.go
+++ b/internal/revision/scanner.go
@@ -78,13 +78,11 @@ func (s *scanner) scan() (token, string) {
 
 	if unicode.IsLetter(ch) {
 		s.unread()
-
 		return s.scanWord()
 	}
 
 	if unicode.IsNumber(ch) {
 		s.unread()
-
 		return s.scanNumber()
 	}
 

--- a/internal/revision/scanner.go
+++ b/internal/revision/scanner.go
@@ -31,7 +31,8 @@ func (s *scanner) read() rune {
 // unread places the previously read rune back on the reader.
 func (s *scanner) unread() { _ = s.r.UnreadRune() }
 
-// Scan extract tokens from an input
+// Scan extracts tokens and their strings counterpart
+// from the reader
 func (s *scanner) scan() (token, string) {
 	ch := s.read()
 

--- a/internal/revision/scanner.go
+++ b/internal/revision/scanner.go
@@ -54,6 +54,8 @@ func (s *scanner) scan() (token, string) {
 		return cbrace, string(ch)
 	case '-':
 		return minus, string(ch)
+	case '@':
+		return at, string(ch)
 	}
 
 	if unicode.IsSpace(ch) {

--- a/internal/revision/scanner_test.go
+++ b/internal/revision/scanner_test.go
@@ -1,0 +1,118 @@
+package revision
+
+import (
+	"bytes"
+	"testing"
+
+	. "gopkg.in/check.v1"
+)
+
+func Test(t *testing.T) { TestingT(t) }
+
+type ScannerSuite struct{}
+
+var _ = Suite(&ScannerSuite{})
+
+func (s *ScannerSuite) TestReadColon(c *C) {
+	scanner := newScanner(bytes.NewBufferString(":"))
+	tok, data := scanner.scan()
+
+	c.Assert(data, Equals, ":")
+	c.Assert(tok, Equals, colon)
+}
+
+func (s *ScannerSuite) TestReadTilde(c *C) {
+	scanner := newScanner(bytes.NewBufferString("~"))
+	tok, data := scanner.scan()
+
+	c.Assert(data, Equals, "~")
+	c.Assert(tok, Equals, tilde)
+}
+
+func (s *ScannerSuite) TestReadCaret(c *C) {
+	scanner := newScanner(bytes.NewBufferString("^"))
+	tok, data := scanner.scan()
+
+	c.Assert(data, Equals, "^")
+	c.Assert(tok, Equals, caret)
+}
+
+func (s *ScannerSuite) TestReadDot(c *C) {
+	scanner := newScanner(bytes.NewBufferString("."))
+	tok, data := scanner.scan()
+
+	c.Assert(data, Equals, ".")
+	c.Assert(tok, Equals, dot)
+}
+
+func (s *ScannerSuite) TestReadSlash(c *C) {
+	scanner := newScanner(bytes.NewBufferString("/"))
+	tok, data := scanner.scan()
+
+	c.Assert(data, Equals, "/")
+	c.Assert(tok, Equals, slash)
+}
+
+func (s *ScannerSuite) TestReadEOF(c *C) {
+	scanner := newScanner(bytes.NewBufferString(string(rune(0))))
+	tok, data := scanner.scan()
+
+	c.Assert(data, Equals, "")
+	c.Assert(tok, Equals, eof)
+}
+
+func (s *ScannerSuite) TestReadNumber(c *C) {
+	scanner := newScanner(bytes.NewBufferString("1234"))
+	tok, data := scanner.scan()
+
+	c.Assert(data, Equals, "1234")
+	c.Assert(tok, Equals, number)
+}
+
+func (s *ScannerSuite) TestReadSpace(c *C) {
+	scanner := newScanner(bytes.NewBufferString(" "))
+	tok, data := scanner.scan()
+
+	c.Assert(data, Equals, " ")
+	c.Assert(tok, Equals, space)
+}
+
+func (s *ScannerSuite) TestReadControl(c *C) {
+	scanner := newScanner(bytes.NewBufferString(""))
+	tok, data := scanner.scan()
+
+	c.Assert(data, Equals, "\x01")
+	c.Assert(tok, Equals, control)
+}
+
+func (s *ScannerSuite) TestReadOpenBrace(c *C) {
+	scanner := newScanner(bytes.NewBufferString("{"))
+	tok, data := scanner.scan()
+
+	c.Assert(data, Equals, "{")
+	c.Assert(tok, Equals, obrace)
+}
+
+func (s *ScannerSuite) TestReadCloseBrace(c *C) {
+	scanner := newScanner(bytes.NewBufferString("}"))
+	tok, data := scanner.scan()
+
+	c.Assert(data, Equals, "}")
+	c.Assert(tok, Equals, cbrace)
+}
+
+func (s *ScannerSuite) TestReadMinus(c *C) {
+	scanner := newScanner(bytes.NewBufferString("-"))
+	tok, data := scanner.scan()
+
+	c.Assert(data, Equals, "-")
+	c.Assert(tok, Equals, minus)
+}
+
+func (s *ScannerSuite) TestReadWord(c *C) {
+	scanner := newScanner(bytes.NewBufferString("abcde"))
+	tok, data := scanner.scan()
+
+	c.Assert(data, Equals, "abcde")
+	c.Assert(tok, Equals, word)
+}

--- a/internal/revision/scanner_test.go
+++ b/internal/revision/scanner_test.go
@@ -164,3 +164,11 @@ func (s *ScannerSuite) TestReadWord(c *C) {
 	c.Assert(data, Equals, "abcde")
 	c.Assert(tok, Equals, word)
 }
+
+func (s *ScannerSuite) TestReadChar(c *C) {
+	scanner := newScanner(bytes.NewBufferString("`"))
+	tok, data := scanner.scan()
+
+	c.Assert(data, Equals, "`")
+	c.Assert(tok, Equals, char)
+}

--- a/internal/revision/scanner_test.go
+++ b/internal/revision/scanner_test.go
@@ -117,6 +117,38 @@ func (s *ScannerSuite) TestReadAt(c *C) {
 	c.Assert(tok, Equals, at)
 }
 
+func (s *ScannerSuite) TestReadAntislash(c *C) {
+	scanner := newScanner(bytes.NewBufferString("\\"))
+	tok, data := scanner.scan()
+
+	c.Assert(data, Equals, "\\")
+	c.Assert(tok, Equals, aslash)
+}
+
+func (s *ScannerSuite) TestReadQuestionMark(c *C) {
+	scanner := newScanner(bytes.NewBufferString("?"))
+	tok, data := scanner.scan()
+
+	c.Assert(data, Equals, "?")
+	c.Assert(tok, Equals, qmark)
+}
+
+func (s *ScannerSuite) TestReadAsterisk(c *C) {
+	scanner := newScanner(bytes.NewBufferString("*"))
+	tok, data := scanner.scan()
+
+	c.Assert(data, Equals, "*")
+	c.Assert(tok, Equals, asterisk)
+}
+
+func (s *ScannerSuite) TestReadOpenBracket(c *C) {
+	scanner := newScanner(bytes.NewBufferString("["))
+	tok, data := scanner.scan()
+
+	c.Assert(data, Equals, "[")
+	c.Assert(tok, Equals, obracket)
+}
+
 func (s *ScannerSuite) TestReadWord(c *C) {
 	scanner := newScanner(bytes.NewBufferString("abcde"))
 	tok, data := scanner.scan()

--- a/internal/revision/scanner_test.go
+++ b/internal/revision/scanner_test.go
@@ -109,6 +109,14 @@ func (s *ScannerSuite) TestReadMinus(c *C) {
 	c.Assert(tok, Equals, minus)
 }
 
+func (s *ScannerSuite) TestReadAt(c *C) {
+	scanner := newScanner(bytes.NewBufferString("@"))
+	tok, data := scanner.scan()
+
+	c.Assert(data, Equals, "@")
+	c.Assert(tok, Equals, at)
+}
+
 func (s *ScannerSuite) TestReadWord(c *C) {
 	scanner := newScanner(bytes.NewBufferString("abcde"))
 	tok, data := scanner.scan()

--- a/internal/revision/scanner_test.go
+++ b/internal/revision/scanner_test.go
@@ -149,6 +149,14 @@ func (s *ScannerSuite) TestReadOpenBracket(c *C) {
 	c.Assert(tok, Equals, obracket)
 }
 
+func (s *ScannerSuite) TestReadExclamationMark(c *C) {
+	scanner := newScanner(bytes.NewBufferString("!"))
+	tok, data := scanner.scan()
+
+	c.Assert(data, Equals, "!")
+	c.Assert(tok, Equals, emark)
+}
+
 func (s *ScannerSuite) TestReadWord(c *C) {
 	scanner := newScanner(bytes.NewBufferString("abcde"))
 	tok, data := scanner.scan()

--- a/internal/revision/scanner_test.go
+++ b/internal/revision/scanner_test.go
@@ -15,160 +15,180 @@ var _ = Suite(&ScannerSuite{})
 
 func (s *ScannerSuite) TestReadColon(c *C) {
 	scanner := newScanner(bytes.NewBufferString(":"))
-	tok, data := scanner.scan()
+	tok, data, err := scanner.scan()
 
+	c.Assert(err, Equals, nil)
 	c.Assert(data, Equals, ":")
 	c.Assert(tok, Equals, colon)
 }
 
 func (s *ScannerSuite) TestReadTilde(c *C) {
 	scanner := newScanner(bytes.NewBufferString("~"))
-	tok, data := scanner.scan()
+	tok, data, err := scanner.scan()
 
+	c.Assert(err, Equals, nil)
 	c.Assert(data, Equals, "~")
 	c.Assert(tok, Equals, tilde)
 }
 
 func (s *ScannerSuite) TestReadCaret(c *C) {
 	scanner := newScanner(bytes.NewBufferString("^"))
-	tok, data := scanner.scan()
+	tok, data, err := scanner.scan()
 
+	c.Assert(err, Equals, nil)
 	c.Assert(data, Equals, "^")
 	c.Assert(tok, Equals, caret)
 }
 
 func (s *ScannerSuite) TestReadDot(c *C) {
 	scanner := newScanner(bytes.NewBufferString("."))
-	tok, data := scanner.scan()
+	tok, data, err := scanner.scan()
 
+	c.Assert(err, Equals, nil)
 	c.Assert(data, Equals, ".")
 	c.Assert(tok, Equals, dot)
 }
 
 func (s *ScannerSuite) TestReadSlash(c *C) {
 	scanner := newScanner(bytes.NewBufferString("/"))
-	tok, data := scanner.scan()
+	tok, data, err := scanner.scan()
 
+	c.Assert(err, Equals, nil)
 	c.Assert(data, Equals, "/")
 	c.Assert(tok, Equals, slash)
 }
 
 func (s *ScannerSuite) TestReadEOF(c *C) {
 	scanner := newScanner(bytes.NewBufferString(string(rune(0))))
-	tok, data := scanner.scan()
+	tok, data, err := scanner.scan()
 
+	c.Assert(err, Equals, nil)
 	c.Assert(data, Equals, "")
 	c.Assert(tok, Equals, eof)
 }
 
 func (s *ScannerSuite) TestReadNumber(c *C) {
 	scanner := newScanner(bytes.NewBufferString("1234"))
-	tok, data := scanner.scan()
+	tok, data, err := scanner.scan()
 
+	c.Assert(err, Equals, nil)
 	c.Assert(data, Equals, "1234")
 	c.Assert(tok, Equals, number)
 }
 
 func (s *ScannerSuite) TestReadSpace(c *C) {
 	scanner := newScanner(bytes.NewBufferString(" "))
-	tok, data := scanner.scan()
+	tok, data, err := scanner.scan()
 
+	c.Assert(err, Equals, nil)
 	c.Assert(data, Equals, " ")
 	c.Assert(tok, Equals, space)
 }
 
 func (s *ScannerSuite) TestReadControl(c *C) {
 	scanner := newScanner(bytes.NewBufferString(""))
-	tok, data := scanner.scan()
+	tok, data, err := scanner.scan()
 
+	c.Assert(err, Equals, nil)
 	c.Assert(data, Equals, "\x01")
 	c.Assert(tok, Equals, control)
 }
 
 func (s *ScannerSuite) TestReadOpenBrace(c *C) {
 	scanner := newScanner(bytes.NewBufferString("{"))
-	tok, data := scanner.scan()
+	tok, data, err := scanner.scan()
 
+	c.Assert(err, Equals, nil)
 	c.Assert(data, Equals, "{")
 	c.Assert(tok, Equals, obrace)
 }
 
 func (s *ScannerSuite) TestReadCloseBrace(c *C) {
 	scanner := newScanner(bytes.NewBufferString("}"))
-	tok, data := scanner.scan()
+	tok, data, err := scanner.scan()
 
+	c.Assert(err, Equals, nil)
 	c.Assert(data, Equals, "}")
 	c.Assert(tok, Equals, cbrace)
 }
 
 func (s *ScannerSuite) TestReadMinus(c *C) {
 	scanner := newScanner(bytes.NewBufferString("-"))
-	tok, data := scanner.scan()
+	tok, data, err := scanner.scan()
 
+	c.Assert(err, Equals, nil)
 	c.Assert(data, Equals, "-")
 	c.Assert(tok, Equals, minus)
 }
 
 func (s *ScannerSuite) TestReadAt(c *C) {
 	scanner := newScanner(bytes.NewBufferString("@"))
-	tok, data := scanner.scan()
+	tok, data, err := scanner.scan()
 
+	c.Assert(err, Equals, nil)
 	c.Assert(data, Equals, "@")
 	c.Assert(tok, Equals, at)
 }
 
 func (s *ScannerSuite) TestReadAntislash(c *C) {
 	scanner := newScanner(bytes.NewBufferString("\\"))
-	tok, data := scanner.scan()
+	tok, data, err := scanner.scan()
 
+	c.Assert(err, Equals, nil)
 	c.Assert(data, Equals, "\\")
 	c.Assert(tok, Equals, aslash)
 }
 
 func (s *ScannerSuite) TestReadQuestionMark(c *C) {
 	scanner := newScanner(bytes.NewBufferString("?"))
-	tok, data := scanner.scan()
+	tok, data, err := scanner.scan()
 
+	c.Assert(err, Equals, nil)
 	c.Assert(data, Equals, "?")
 	c.Assert(tok, Equals, qmark)
 }
 
 func (s *ScannerSuite) TestReadAsterisk(c *C) {
 	scanner := newScanner(bytes.NewBufferString("*"))
-	tok, data := scanner.scan()
+	tok, data, err := scanner.scan()
 
+	c.Assert(err, Equals, nil)
 	c.Assert(data, Equals, "*")
 	c.Assert(tok, Equals, asterisk)
 }
 
 func (s *ScannerSuite) TestReadOpenBracket(c *C) {
 	scanner := newScanner(bytes.NewBufferString("["))
-	tok, data := scanner.scan()
+	tok, data, err := scanner.scan()
 
+	c.Assert(err, Equals, nil)
 	c.Assert(data, Equals, "[")
 	c.Assert(tok, Equals, obracket)
 }
 
 func (s *ScannerSuite) TestReadExclamationMark(c *C) {
 	scanner := newScanner(bytes.NewBufferString("!"))
-	tok, data := scanner.scan()
+	tok, data, err := scanner.scan()
 
+	c.Assert(err, Equals, nil)
 	c.Assert(data, Equals, "!")
 	c.Assert(tok, Equals, emark)
 }
 
 func (s *ScannerSuite) TestReadWord(c *C) {
 	scanner := newScanner(bytes.NewBufferString("abcde"))
-	tok, data := scanner.scan()
+	tok, data, err := scanner.scan()
 
+	c.Assert(err, Equals, nil)
 	c.Assert(data, Equals, "abcde")
 	c.Assert(tok, Equals, word)
 }
 
-func (s *ScannerSuite) TestReadChar(c *C) {
+func (s *ScannerSuite) TestReadTokenError(c *C) {
 	scanner := newScanner(bytes.NewBufferString("`"))
-	tok, data := scanner.scan()
+	tok, data, err := scanner.scan()
 
+	c.Assert(err, Equals, nil)
 	c.Assert(data, Equals, "`")
-	c.Assert(tok, Equals, char)
+	c.Assert(tok, Equals, tokenError)
 }

--- a/internal/revision/token.go
+++ b/internal/revision/token.go
@@ -6,6 +6,8 @@ type token int
 const (
 	eof token = iota
 
+	aslash
+	asterisk
 	at
 	caret
 	cbrace
@@ -16,6 +18,8 @@ const (
 	minus
 	number
 	obrace
+	obracket
+	qmark
 	slash
 	space
 	tilde

--- a/internal/revision/token.go
+++ b/internal/revision/token.go
@@ -6,6 +6,7 @@ type token int
 const (
 	eof token = iota
 
+	at
 	caret
 	cbrace
 	char

--- a/internal/revision/token.go
+++ b/internal/revision/token.go
@@ -11,7 +11,6 @@ const (
 	at
 	caret
 	cbrace
-	char
 	colon
 	control
 	dot
@@ -24,5 +23,6 @@ const (
 	slash
 	space
 	tilde
+	tokenError
 	word
 )

--- a/internal/revision/token.go
+++ b/internal/revision/token.go
@@ -1,0 +1,22 @@
+package revision
+
+// token represents a entity extracted from string parsing
+type token int
+
+const (
+	eof token = iota
+
+	caret
+	cbrace
+	char
+	colon
+	control
+	dot
+	minus
+	number
+	obrace
+	slash
+	space
+	tilde
+	word
+)

--- a/internal/revision/token.go
+++ b/internal/revision/token.go
@@ -15,6 +15,7 @@ const (
 	colon
 	control
 	dot
+	emark
 	minus
 	number
 	obrace

--- a/plumbing/revision.go
+++ b/plumbing/revision.go
@@ -1,6 +1,9 @@
 package plumbing
 
 // Revision represents a git revision
+// to get more details about git revisions
+// please check git manual page :
+// https://www.kernel.org/pub/software/scm/git/docs/gitrevisions.html
 type Revision string
 
 func (r Revision) String() string {

--- a/plumbing/revision.go
+++ b/plumbing/revision.go
@@ -1,0 +1,8 @@
+package plumbing
+
+// Revision represents a git revision
+type Revision string
+
+func (r Revision) String() string {
+	return string(r)
+}

--- a/repository.go
+++ b/repository.go
@@ -719,6 +719,29 @@ func (r *Repository) ResolveRevision(rev plumbing.Revision) (*plumbing.Hash, err
 			}
 
 			commit = c
+		case revision.AtDate:
+			history, err := commit.History()
+
+			if err != nil {
+				return &plumbing.ZeroHash, err
+			}
+
+			date := item.(revision.AtDate).Date
+			var c *object.Commit
+
+			for i := 0; i < len(history); i++ {
+				if date.Equal(history[i].Committer.When.UTC()) || history[i].Committer.When.UTC().Before(date) {
+					c = history[i]
+
+					break
+				}
+			}
+
+			if c == nil {
+				return &plumbing.ZeroHash, fmt.Errorf(`No commit exists prior to date "%s"`, date.String())
+			}
+
+			commit = c
 		}
 	}
 

--- a/repository.go
+++ b/repository.go
@@ -696,6 +696,29 @@ func (r *Repository) ResolveRevision(rev plumbing.Revision) (*plumbing.Hash, err
 
 				commit = c
 			}
+		case revision.CaretReg:
+			history, err := commit.History()
+
+			if err != nil {
+				return &plumbing.ZeroHash, err
+			}
+
+			re := item.(revision.CaretReg).Regexp
+			var c *object.Commit
+
+			for i := 0; i < len(history); i++ {
+				if re.MatchString(history[i].Message) {
+					c = history[i]
+
+					break
+				}
+			}
+
+			if c == nil {
+				return &plumbing.ZeroHash, fmt.Errorf(`No commit message match regexp : "%s"`, re.String())
+			}
+
+			commit = c
 		}
 	}
 

--- a/repository.go
+++ b/repository.go
@@ -704,10 +704,18 @@ func (r *Repository) ResolveRevision(rev plumbing.Revision) (*plumbing.Hash, err
 			}
 
 			re := item.(revision.CaretReg).Regexp
+			negate := item.(revision.CaretReg).Negate
+
 			var c *object.Commit
 
 			for i := 0; i < len(history); i++ {
-				if re.MatchString(history[i].Message) {
+				if !negate && re.MatchString(history[i].Message) {
+					c = history[i]
+
+					break
+				}
+
+				if negate && !re.MatchString(history[i].Message) {
 					c = history[i]
 
 					break

--- a/repository_test.go
+++ b/repository_test.go
@@ -785,8 +785,8 @@ func (s *RepositorySuite) TestResolveRevision(c *C) {
 		fixtures.ByURL("https://github.com/git-fixtures/basic.git").One(),
 	)
 
-	r := NewMemoryRepository()
-	err := r.Clone(&CloneOptions{URL: url})
+	r, _ := Init(memory.NewStorage(), nil)
+	err := r.clone(&CloneOptions{URL: url})
 	c.Assert(err, IsNil)
 
 	datas := map[string]string{
@@ -814,8 +814,8 @@ func (s *RepositorySuite) TestResolveRevisionWithErrors(c *C) {
 		fixtures.ByURL("https://github.com/git-fixtures/basic.git").One(),
 	)
 
-	r := NewMemoryRepository()
-	err := r.Clone(&CloneOptions{URL: url})
+	r, _ := Init(memory.NewStorage(), nil)
+	err := r.clone(&CloneOptions{URL: url})
 	c.Assert(err, IsNil)
 
 	datas := map[string]string{

--- a/repository_test.go
+++ b/repository_test.go
@@ -796,6 +796,7 @@ func (s *RepositorySuite) TestResolveRevision(c *C) {
 		"HEAD~3^2":                    "a5b8b09e2f8fcb0bb99d3ccb0958157b40890d69",
 		"HEAD~3^2^0":                  "a5b8b09e2f8fcb0bb99d3ccb0958157b40890d69",
 		"HEAD~2^{/binary file}":       "35e85108805c84807bc66a02d91535e1e24b38b9",
+		"HEAD~^{!-some}":              "1669dce138d9b841a518c64b10914d88f5e488ea",
 		"HEAD@{2015-03-31T11:56:18Z}": "918c48b83bd081e863dbe1b80f8998f058cd8294",
 		"HEAD@{2015-03-31T11:49:00Z}": "1669dce138d9b841a518c64b10914d88f5e488ea",
 	}

--- a/repository_test.go
+++ b/repository_test.go
@@ -795,6 +795,7 @@ func (s *RepositorySuite) TestResolveRevision(c *C) {
 		"HEAD~2^^~":              "b029517f6300c2da0f4b651b8642506cd6aaf45d",
 		"HEAD~3^2":               "a5b8b09e2f8fcb0bb99d3ccb0958157b40890d69",
 		"HEAD~3^2^0":             "a5b8b09e2f8fcb0bb99d3ccb0958157b40890d69",
+		"HEAD~2^{/binary file}":  "35e85108805c84807bc66a02d91535e1e24b38b9",
 	}
 
 	for rev, hash := range datas {
@@ -817,6 +818,7 @@ func (s *RepositorySuite) TestResolveRevisionWithErrors(c *C) {
 	datas := map[string]string{
 		"efs/heads/master~": "reference not found",
 		"HEAD^3":            `Revision invalid : "3" found must be 0, 1 or 2 after "^"`,
+		"HEAD^{/whatever}":  `No commit message match regexp : "whatever"`,
 	}
 
 	for rev, rerr := range datas {

--- a/repository_test.go
+++ b/repository_test.go
@@ -791,11 +791,13 @@ func (s *RepositorySuite) TestResolveRevision(c *C) {
 
 	datas := map[string]string{
 		"HEAD": "6ecf0ef2c2dffb796033e5a02219af86ec6584e5",
-		"refs/heads/master~2^^~": "b029517f6300c2da0f4b651b8642506cd6aaf45d",
-		"HEAD~2^^~":              "b029517f6300c2da0f4b651b8642506cd6aaf45d",
-		"HEAD~3^2":               "a5b8b09e2f8fcb0bb99d3ccb0958157b40890d69",
-		"HEAD~3^2^0":             "a5b8b09e2f8fcb0bb99d3ccb0958157b40890d69",
-		"HEAD~2^{/binary file}":  "35e85108805c84807bc66a02d91535e1e24b38b9",
+		"refs/heads/master~2^^~":      "b029517f6300c2da0f4b651b8642506cd6aaf45d",
+		"HEAD~2^^~":                   "b029517f6300c2da0f4b651b8642506cd6aaf45d",
+		"HEAD~3^2":                    "a5b8b09e2f8fcb0bb99d3ccb0958157b40890d69",
+		"HEAD~3^2^0":                  "a5b8b09e2f8fcb0bb99d3ccb0958157b40890d69",
+		"HEAD~2^{/binary file}":       "35e85108805c84807bc66a02d91535e1e24b38b9",
+		"HEAD@{2015-03-31T11:56:18Z}": "918c48b83bd081e863dbe1b80f8998f058cd8294",
+		"HEAD@{2015-03-31T11:49:00Z}": "1669dce138d9b841a518c64b10914d88f5e488ea",
 	}
 
 	for rev, hash := range datas {
@@ -816,9 +818,10 @@ func (s *RepositorySuite) TestResolveRevisionWithErrors(c *C) {
 	c.Assert(err, IsNil)
 
 	datas := map[string]string{
-		"efs/heads/master~": "reference not found",
-		"HEAD^3":            `Revision invalid : "3" found must be 0, 1 or 2 after "^"`,
-		"HEAD^{/whatever}":  `No commit message match regexp : "whatever"`,
+		"efs/heads/master~":           "reference not found",
+		"HEAD^3":                      `Revision invalid : "3" found must be 0, 1 or 2 after "^"`,
+		"HEAD^{/whatever}":            `No commit message match regexp : "whatever"`,
+		"HEAD@{2015-03-31T09:49:00Z}": `No commit exists prior to date "2015-03-31 09:49:00 +0000 UTC"`,
 	}
 
 	for rev, rerr := range datas {


### PR DESCRIPTION
* Implement Revision entity as type Revision string and not as plain string

* Add a method ResolveReference(r *git.Repository, rev Revision) (plumbing.Hash, error)

* Place all the parser, tokenizer, etc in an internal package called revision at the root of the package. This package deals with strings, not with the type Revision

* Define a revision parser/tokenizer to comply with the """spec""" described here https://www.kernel.org/pub/software/scm/git/docs/gitrevisions.html (if something is hard and arcane this can be put in a TODO, is not required implement all the functionality)

* Resource for valid reference names : https://git-scm.com/docs/git-check-ref-format