### PR TITLE
capability: support empty input on Decode.

### DIFF
--- a/plumbing/protocol/packp/advrefs_decode.go
+++ b/plumbing/protocol/packp/advrefs_decode.go
@@ -197,10 +197,6 @@ func decodeFirstRef(l *advRefsDecoder) decoderStateFn {
 }
 
 func decodeCaps(p *advRefsDecoder) decoderStateFn {
-	if len(p.line) == 0 {
-		return decodeOtherRefs
-	}
-
 	if err := p.data.Capabilities.Decode(p.line); err != nil {
 		p.error("invalid capabilities: %s", err)
 	}

--- a/plumbing/protocol/packp/capability/list.go
+++ b/plumbing/protocol/packp/capability/list.go
@@ -48,6 +48,10 @@ func (l *List) IsEmpty() bool {
 
 // Decode decodes list of capabilities from raw into the list
 func (l *List) Decode(raw []byte) error {
+	if len(raw) == 0 {
+		return nil
+	}
+
 	for _, data := range bytes.Split(raw, []byte{' '}) {
 		pair := bytes.SplitN(data, []byte{'='}, 2)
 

--- a/plumbing/protocol/packp/capability/list_test.go
+++ b/plumbing/protocol/packp/capability/list_test.go
@@ -27,6 +27,13 @@ func (s *SuiteCapabilities) TestDecode(c *check.C) {
 	c.Assert(cap.Get(ThinPack), check.IsNil)
 }
 
+func (s *SuiteCapabilities) TestDecodeEmpty(c *check.C) {
+	cap := NewList()
+	err := cap.Decode(nil)
+	c.Assert(err, check.IsNil)
+	c.Assert(cap, check.DeepEquals, NewList())
+}
+
 func (s *SuiteCapabilities) TestDecodeWithErrArguments(c *check.C) {
 	cap := NewList()
 	err := cap.Decode([]byte("thin-pack=foo"))

--- a/plumbing/protocol/packp/ulreq_decode.go
+++ b/plumbing/protocol/packp/ulreq_decode.go
@@ -110,10 +110,6 @@ func (d *ulReqDecoder) readHash() (plumbing.Hash, bool) {
 
 // Expected format: sp cap1 sp cap2 sp cap3...
 func (d *ulReqDecoder) decodeCaps() stateFn {
-	if len(d.line) == 0 {
-		return d.decodeOtherWants
-	}
-
 	d.line = bytes.TrimPrefix(d.line, sp)
 	if err := d.data.Capabilities.Decode(d.line); err != nil {
 		d.error("invalid capabilities: %s", err)


### PR DESCRIPTION
Calling capability.List's Decode with nil input will have no effect.
This is useful in other decoders, where an empty capability list is
received as an empty byte slice.