### PR TITLE
remote: sideband support

### DIFF
--- a/plumbing/protocol/packp/sideband/demux.go
+++ b/plumbing/protocol/packp/sideband/demux.go
@@ -20,17 +20,17 @@ type Progress interface {
 // Demuxer demultiplex the progress reports and error info interleaved with the
 // packfile itself.
 //
-// A sideband has three diferent channels the main one, call PackData, contains
+// A sideband has three different channels the main one, call PackData, contains
 // the packfile data, the ErrorMessage channel, that contains server errors and
 // the last one ProgressMessage channel containing information about the ongoing
-// tast happening in the server (optinal, can be suppressed sending NoProgress
+// task happening in the server (optional, can be suppressed sending NoProgress
 // or Quiet capabilities to the server)
 //
 // In order to demultiplex the data stream, method `Read` should be called to
 // retrieve the PackData channel, the incoming data from the ProgressMessage is
 // written at `Progress` (if any), if any message is retrieved from the
 // ErrorMessage channel an error is returned and we can assume that the
-// conection has been closed.
+// connection has been closed.
 type Demuxer struct {
 	t Type
 	r io.Reader
@@ -59,12 +59,11 @@ func NewDemuxer(t Type, r io.Reader) *Demuxer {
 }
 
 // Read reads up to len(p) bytes from the PackData channel into p, an error can
-// be return if an error happends when reading or if a message is sent in the
+// be return if an error happens when reading or if a message is sent in the
 // ErrorMessage channel.
 //
-// If a ProgressMessage is read, it won't be copied to b. Instead of this,
-// Progress was set will be stored there. If the n value returned is zero, err
-// will be nil unless an error reading happens.
+// When a ProgressMessage is read, is not copy to b, instead of this is written
+// to the Progress
 func (d *Demuxer) Read(b []byte) (n int, err error) {
 	var read, req int
 

--- a/plumbing/protocol/packp/sideband/demux.go
+++ b/plumbing/protocol/packp/sideband/demux.go
@@ -1,7 +1,6 @@
 package sideband
 
 import (
-	"bytes"
 	"errors"
 	"fmt"
 	"io"
@@ -15,12 +14,13 @@ var ErrMaxPackedExceeded = errors.New("max. packed size exceeded")
 // Progress allows to read the progress information
 type Progress interface {
 	io.Reader
+	io.Writer
 }
 
 // Demuxer demultiplex the progress reports and error info interleaved with the
 // packfile itself.
 //
-// A sideband has three diferent channels the main one call PackData contains
+// A sideband has three diferent channels the main one, call PackData, contains
 // the packfile data, the ErrorMessage channel, that contains server errors and
 // the last one ProgressMessage channel containing information about the ongoing
 // tast happening in the server (optinal, can be suppressed sending NoProgress
@@ -28,8 +28,8 @@ type Progress interface {
 //
 // In order to demultiplex the data stream, method `Read` should be called to
 // retrieve the PackData channel, the incoming data from the ProgressMessage is
-// stored and can be read from `Progress` field, if any message is retrieved
-// from the ErrorMessage channel an error is returned and we can assume that the
+// written at `Progress` (if any), if any message is retrieved from the
+// ErrorMessage channel an error is returned and we can assume that the
 // conection has been closed.
 type Demuxer struct {
 	t Type
@@ -39,7 +39,7 @@ type Demuxer struct {
 	max     int
 	pending []byte
 
-	// Progress contains progress information
+	// Progress is where the progress messages are stored
 	Progress Progress
 }
 
@@ -51,11 +51,10 @@ func NewDemuxer(t Type, r io.Reader) *Demuxer {
 	}
 
 	return &Demuxer{
-		t:        t,
-		r:        r,
-		max:      max,
-		s:        pktline.NewScanner(r),
-		Progress: bytes.NewBuffer(nil),
+		t:   t,
+		r:   r,
+		max: max,
+		s:   pktline.NewScanner(r),
 	}
 }
 
@@ -63,9 +62,9 @@ func NewDemuxer(t Type, r io.Reader) *Demuxer {
 // be return if an error happends when reading or if a message is sent in the
 // ErrorMessage channel.
 //
-// If a ProgressMessage is read, it won't be copied to b. Instead of this, it is
-// stored and can be read through the reader Progress. If the n value returned
-// is zero, err will be nil unless an error reading happens.
+// If a ProgressMessage is read, it won't be copied to b. Instead of this,
+// Progress was set will be stored there. If the n value returned is zero, err
+// will be nil unless an error reading happens.
 func (d *Demuxer) Read(b []byte) (n int, err error) {
 	var read, req int
 
@@ -126,13 +125,17 @@ func (d *Demuxer) nextPackData() ([]byte, error) {
 	case PackData:
 		return content[1:], nil
 	case ProgressMessage:
-		_, err := d.Progress.(io.Writer).Write(content[1:])
-		return nil, err
+		if d.Progress != nil {
+			_, err := d.Progress.Write(content[1:])
+			return nil, err
+		}
 	case ErrorMessage:
 		return nil, fmt.Errorf("unexpected error: %s", content[1:])
 	default:
 		return nil, fmt.Errorf("unknown channel %s", content)
 	}
+
+	return nil, nil
 }
 
 func (d *Demuxer) getPending() (b []byte) {

--- a/plumbing/protocol/packp/sideband/demux_test.go
+++ b/plumbing/protocol/packp/sideband/demux_test.go
@@ -24,6 +24,7 @@ func (s *SidebandSuite) TestDecode(c *C) {
 	buf := bytes.NewBuffer(nil)
 	e := pktline.NewEncoder(buf)
 	e.Encode(PackData.WithPayload(expected[0:8]))
+	e.Encode(ProgressMessage.WithPayload([]byte{'F', 'O', 'O', '\n'}))
 	e.Encode(PackData.WithPayload(expected[8:16]))
 	e.Encode(PackData.WithPayload(expected[16:26]))
 
@@ -92,6 +93,8 @@ func (s *SidebandSuite) TestDecodeWithProgress(c *C) {
 
 	content := make([]byte, 26)
 	d := NewDemuxer(Sideband64k, buf)
+	d.Progress = bytes.NewBuffer(nil)
+
 	n, err := io.ReadFull(d, content)
 	c.Assert(err, IsNil)
 	c.Assert(n, Equals, 26)

--- a/plumbing/protocol/packp/sideband/muxer.go
+++ b/plumbing/protocol/packp/sideband/muxer.go
@@ -19,7 +19,7 @@ const chLen = 1
 //
 // If t is equal to `Sideband` the max pack size is set to MaxPackedSize, in any
 // other value is given, max pack is set to MaxPackedSize64k, that is the
-// maximum lenght of a line in pktline format.
+// maximum length of a line in pktline format.
 func NewMuxer(t Type, w io.Writer) *Muxer {
 	max := MaxPackedSize64k
 	if t == Sideband {

--- a/plumbing/protocol/packp/ulreq.go
+++ b/plumbing/protocol/packp/ulreq.go
@@ -69,6 +69,12 @@ func NewUploadRequestFromCapabilities(adv *capability.List) *UploadRequest {
 		r.Capabilities.Set(capability.MultiACK)
 	}
 
+	if adv.Supports(capability.Sideband64k) {
+		r.Capabilities.Set(capability.Sideband64k)
+	} else if adv.Supports(capability.Sideband) {
+		r.Capabilities.Set(capability.Sideband)
+	}
+
 	if adv.Supports(capability.ThinPack) {
 		r.Capabilities.Set(capability.ThinPack)
 	}

--- a/plumbing/protocol/packp/ulreq_test.go
+++ b/plumbing/protocol/packp/ulreq_test.go
@@ -29,7 +29,7 @@ func (s *UlReqSuite) TestNewUploadRequestFromCapabilities(c *C) {
 
 	r := NewUploadRequestFromCapabilities(cap)
 	c.Assert(r.Capabilities.String(), Equals,
-		"multi_ack_detailed thin-pack ofs-delta agent=go-git/4.x",
+		"multi_ack_detailed side-band-64k thin-pack ofs-delta agent=go-git/4.x",
 	)
 }
 

--- a/plumbing/transport/common.go
+++ b/plumbing/transport/common.go
@@ -131,8 +131,6 @@ func transformSCPLikeIfNeeded(endpoint string) string {
 var UnsupportedCapabilities = []capability.Capability{
 	capability.MultiACK,
 	capability.MultiACKDetailed,
-	capability.Sideband,
-	capability.Sideband64k,
 	capability.ThinPack,
 }
 

--- a/plumbing/transport/http/fetch_pack.go
+++ b/plumbing/transport/http/fetch_pack.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"strings"
+	"strconv"
 
 	"gopkg.in/src-d/go-git.v4/plumbing"
 	"gopkg.in/src-d/go-git.v4/plumbing/format/pktline"
@@ -131,7 +131,7 @@ func discardResponseInfo(r io.Reader) error {
 	return s.Err()
 }
 
-func (s *fetchPackSession) doRequest(method, url string, content *strings.Reader) (*http.Response, error) {
+func (s *fetchPackSession) doRequest(method, url string, content *bytes.Buffer) (*http.Response, error) {
 	var body io.Reader
 	if content != nil {
 		body = content
@@ -158,44 +158,33 @@ func (s *fetchPackSession) doRequest(method, url string, content *strings.Reader
 	return res, nil
 }
 
-func (s *fetchPackSession) applyHeadersToRequest(req *http.Request, content *strings.Reader) {
+// it requires a bytes.Buffer, because we need to know the length
+func (s *fetchPackSession) applyHeadersToRequest(req *http.Request, content *bytes.Buffer) {
 	req.Header.Add("User-Agent", "git/1.0")
-	req.Header.Add("Host", "github.com")
+	req.Header.Add("Host", s.endpoint.Host)
 
 	if content == nil {
 		req.Header.Add("Accept", "*/*")
-	} else {
-		req.Header.Add("Accept", "application/x-git-upload-pack-result")
-		req.Header.Add("Content-Type", "application/x-git-upload-pack-request")
-		req.Header.Add("Content-Length", string(content.Len()))
+		return
 	}
+
+	req.Header.Add("Accept", "application/x-git-upload-pack-result")
+	req.Header.Add("Content-Type", "application/x-git-upload-pack-request")
+	req.Header.Add("Content-Length", strconv.Itoa(content.Len()))
 }
 
-func uploadPackRequestToReader(r *packp.UploadPackRequest) (*strings.Reader, error) {
-	var buf bytes.Buffer
-	e := pktline.NewEncoder(&buf)
+func uploadPackRequestToReader(req *packp.UploadPackRequest) (*bytes.Buffer, error) {
+	buf := bytes.NewBuffer(nil)
+	e := pktline.NewEncoder(buf)
 
-	for _, want := range r.Wants {
-		_ = e.Encodef("want %s\n", want)
+	if err := req.UploadRequest.Encode(buf); err != nil {
+		return nil, fmt.Errorf("sending upload-req message: %s", err)
 	}
 
-	for _, have := range r.Haves {
-		_ = e.Encodef("have %s\n", have)
+	if err := req.UploadHaves.Encode(buf); err != nil {
+		return nil, fmt.Errorf("sending haves message: %s", err)
 	}
 
-	if r.Depth != nil {
-		depth, ok := r.Depth.(packp.DepthCommits)
-		if !ok {
-			return nil, fmt.Errorf("only commit depth is supported")
-		}
-
-		if depth != 0 {
-			_ = e.Encodef("deepen %d\n", depth)
-		}
-	}
-
-	_ = e.Flush()
 	_ = e.EncodeString("done\n")
-
-	return strings.NewReader(buf.String()), nil
+	return buf, nil
 }

--- a/plumbing/transport/http/fetch_pack_test.go
+++ b/plumbing/transport/http/fetch_pack_test.go
@@ -51,8 +51,8 @@ func (s *FetchPackSuite) TestuploadPackRequestToReader(c *C) {
 	c.Assert(err, IsNil)
 	b, _ := ioutil.ReadAll(sr)
 	c.Assert(string(b), Equals,
-		"0032want d82f291cde9987322c8a0c81a325e1ba6159684c\n"+
-			"0032want 2b41ef280fdb67a9b250678686a0c3e03b0a9989\n"+
+		"0032want 2b41ef280fdb67a9b250678686a0c3e03b0a9989\n"+
+			"0032want d82f291cde9987322c8a0c81a325e1ba6159684c\n0000"+
 			"0032have 6ecf0ef2c2dffb796033e5a02219af86ec6584e5\n0000"+
 			"0009done\n",
 	)

--- a/remote_test.go
+++ b/remote_test.go
@@ -19,6 +19,8 @@ import (
 	"gopkg.in/src-d/go-git.v4/storage/memory"
 	osfs "gopkg.in/src-d/go-git.v4/utils/fs/os"
 
+	"bytes"
+
 	. "gopkg.in/check.v1"
 )
 
@@ -30,21 +32,21 @@ var _ = Suite(&RemoteSuite{})
 
 func (s *RemoteSuite) TestConnect(c *C) {
 	url := s.GetBasicLocalRepositoryURL()
-	r := newRemote(nil, &config.RemoteConfig{Name: "foo", URL: url})
+	r := newRemote(nil, nil, &config.RemoteConfig{Name: "foo", URL: url})
 
 	err := r.Connect()
 	c.Assert(err, IsNil)
 }
 
 func (s *RemoteSuite) TestnewRemoteInvalidEndpoint(c *C) {
-	r := newRemote(nil, &config.RemoteConfig{Name: "foo", URL: "qux"})
+	r := newRemote(nil, nil, &config.RemoteConfig{Name: "foo", URL: "qux"})
 
 	err := r.Connect()
 	c.Assert(err, NotNil)
 }
 
 func (s *RemoteSuite) TestnewRemoteInvalidSchemaEndpoint(c *C) {
-	r := newRemote(nil, &config.RemoteConfig{Name: "foo", URL: "qux://foo"})
+	r := newRemote(nil, nil, &config.RemoteConfig{Name: "foo", URL: "qux://foo"})
 
 	err := r.Connect()
 	c.Assert(err, NotNil)
@@ -52,7 +54,7 @@ func (s *RemoteSuite) TestnewRemoteInvalidSchemaEndpoint(c *C) {
 
 func (s *RemoteSuite) TestInfo(c *C) {
 	url := s.GetBasicLocalRepositoryURL()
-	r := newRemote(nil, &config.RemoteConfig{Name: "foo", URL: url})
+	r := newRemote(nil, nil, &config.RemoteConfig{Name: "foo", URL: url})
 	c.Assert(r.AdvertisedReferences(), IsNil)
 	c.Assert(r.Connect(), IsNil)
 	c.Assert(r.AdvertisedReferences(), NotNil)
@@ -61,14 +63,14 @@ func (s *RemoteSuite) TestInfo(c *C) {
 
 func (s *RemoteSuite) TestDefaultBranch(c *C) {
 	url := s.GetBasicLocalRepositoryURL()
-	r := newRemote(nil, &config.RemoteConfig{Name: "foo", URL: url})
+	r := newRemote(nil, nil, &config.RemoteConfig{Name: "foo", URL: url})
 	c.Assert(r.Connect(), IsNil)
 	c.Assert(r.Head().Name(), Equals, plumbing.ReferenceName("refs/heads/master"))
 }
 
 func (s *RemoteSuite) TestCapabilities(c *C) {
 	url := s.GetBasicLocalRepositoryURL()
-	r := newRemote(nil, &config.RemoteConfig{Name: "foo", URL: url})
+	r := newRemote(nil, nil, &config.RemoteConfig{Name: "foo", URL: url})
 	c.Assert(r.Connect(), IsNil)
 	c.Assert(r.Capabilities().Get(capability.Agent), HasLen, 1)
 }
@@ -76,7 +78,7 @@ func (s *RemoteSuite) TestCapabilities(c *C) {
 func (s *RemoteSuite) TestFetch(c *C) {
 	url := s.GetBasicLocalRepositoryURL()
 	sto := memory.NewStorage()
-	r := newRemote(sto, &config.RemoteConfig{Name: "foo", URL: url})
+	r := newRemote(sto, nil, &config.RemoteConfig{Name: "foo", URL: url})
 	c.Assert(r.Connect(), IsNil)
 
 	refspec := config.RefSpec("+refs/heads/*:refs/remotes/origin/*")
@@ -98,6 +100,25 @@ func (s *RemoteSuite) TestFetch(c *C) {
 	}
 }
 
+func (s *RemoteSuite) TestFetchWithProgress(c *C) {
+	url := s.GetBasicLocalRepositoryURL()
+	sto := memory.NewStorage()
+	buf := bytes.NewBuffer(nil)
+
+	r := newRemote(sto, buf, &config.RemoteConfig{Name: "foo", URL: url})
+	c.Assert(r.Connect(), IsNil)
+
+	refspec := config.RefSpec("+refs/heads/*:refs/remotes/origin/*")
+	err := r.Fetch(&FetchOptions{
+		RefSpecs: []config.RefSpec{refspec},
+	})
+
+	c.Assert(err, IsNil)
+	c.Assert(sto.Objects, HasLen, 31)
+
+	c.Assert(buf.Len(), Not(Equals), 0)
+}
+
 type mockPackfileWriter struct {
 	Storer
 	PackfileWriterCalled bool
@@ -109,7 +130,6 @@ func (m *mockPackfileWriter) PackfileWriter() (io.WriteCloser, error) {
 }
 
 func (s *RemoteSuite) TestFetchWithPackfileWriter(c *C) {
-
 	dir, err := ioutil.TempDir("", "fetch")
 	c.Assert(err, IsNil)
 
@@ -121,7 +141,7 @@ func (s *RemoteSuite) TestFetchWithPackfileWriter(c *C) {
 	mock := &mockPackfileWriter{Storer: fss}
 
 	url := s.GetBasicLocalRepositoryURL()
-	r := newRemote(mock, &config.RemoteConfig{Name: "foo", URL: url})
+	r := newRemote(mock, nil, &config.RemoteConfig{Name: "foo", URL: url})
 	c.Assert(r.Connect(), IsNil)
 
 	refspec := config.RefSpec("+refs/heads/*:refs/remotes/origin/*")
@@ -147,7 +167,7 @@ func (s *RemoteSuite) TestFetchWithPackfileWriter(c *C) {
 func (s *RemoteSuite) TestFetchNoErrAlreadyUpToDate(c *C) {
 	url := s.GetBasicLocalRepositoryURL()
 	sto := memory.NewStorage()
-	r := newRemote(sto, &config.RemoteConfig{Name: "foo", URL: url})
+	r := newRemote(sto, nil, &config.RemoteConfig{Name: "foo", URL: url})
 	c.Assert(r.Connect(), IsNil)
 
 	refspec := config.RefSpec("+refs/heads/*:refs/remotes/origin/*")
@@ -163,7 +183,7 @@ func (s *RemoteSuite) TestFetchNoErrAlreadyUpToDate(c *C) {
 
 func (s *RemoteSuite) TestHead(c *C) {
 	url := s.GetBasicLocalRepositoryURL()
-	r := newRemote(nil, &config.RemoteConfig{Name: "foo", URL: url})
+	r := newRemote(nil, nil, &config.RemoteConfig{Name: "foo", URL: url})
 
 	err := r.Connect()
 	c.Assert(err, IsNil)
@@ -172,7 +192,7 @@ func (s *RemoteSuite) TestHead(c *C) {
 
 func (s *RemoteSuite) TestRef(c *C) {
 	url := s.GetBasicLocalRepositoryURL()
-	r := newRemote(nil, &config.RemoteConfig{Name: "foo", URL: url})
+	r := newRemote(nil, nil, &config.RemoteConfig{Name: "foo", URL: url})
 	err := r.Connect()
 	c.Assert(err, IsNil)
 
@@ -187,7 +207,7 @@ func (s *RemoteSuite) TestRef(c *C) {
 
 func (s *RemoteSuite) TestRefs(c *C) {
 	url := s.GetBasicLocalRepositoryURL()
-	r := newRemote(nil, &config.RemoteConfig{Name: "foo", URL: url})
+	r := newRemote(nil, nil, &config.RemoteConfig{Name: "foo", URL: url})
 	err := r.Connect()
 	c.Assert(err, IsNil)
 
@@ -197,7 +217,7 @@ func (s *RemoteSuite) TestRefs(c *C) {
 }
 
 func (s *RemoteSuite) TestString(c *C) {
-	r := newRemote(nil, &config.RemoteConfig{
+	r := newRemote(nil, nil, &config.RemoteConfig{
 		Name: "foo",
 		URL:  "https://github.com/git-fixtures/basic.git",
 	})

--- a/remote_test.go
+++ b/remote_test.go
@@ -1,6 +1,7 @@
 package git
 
 import (
+	"bytes"
 	"crypto/tls"
 	"fmt"
 	"io"
@@ -18,8 +19,6 @@ import (
 	"gopkg.in/src-d/go-git.v4/storage/filesystem"
 	"gopkg.in/src-d/go-git.v4/storage/memory"
 	osfs "gopkg.in/src-d/go-git.v4/utils/fs/os"
-
-	"bytes"
 
 	. "gopkg.in/check.v1"
 )

--- a/repository_test.go
+++ b/repository_test.go
@@ -6,6 +6,8 @@ import (
 	"gopkg.in/src-d/go-git.v4/plumbing"
 	"gopkg.in/src-d/go-git.v4/storage/memory"
 
+	"bytes"
+
 	. "gopkg.in/check.v1"
 )
 
@@ -34,6 +36,21 @@ func (s *RepositorySuite) TestCreateRemoteAndRemote(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(alt, Not(Equals), remote)
 	c.Assert(alt.Config().Name, Equals, "foo")
+}
+
+func (s *RepositorySuite) TestRemoteWithProgress(c *C) {
+	buf := bytes.NewBuffer(nil)
+
+	r := NewMemoryRepository()
+	r.Progress = buf
+
+	remote, err := r.CreateRemote(&config.RemoteConfig{
+		Name: "foo",
+		URL:  "http://foo/foo.git",
+	})
+
+	c.Assert(err, IsNil)
+	c.Assert(remote.p, Equals, buf)
 }
 
 func (s *RepositorySuite) TestCreateRemoteInvalid(c *C) {


### PR DESCRIPTION
This is the support of `Remote` for sideband capable servers.

When `Remote. Fetch` is called If the request contained a `side-band-64k` or `side-band` a `sideband.Demux` is used inside of `Remote` to read the packfile data. 

If the human readable progress is needed a io.Reader/io.Writer should be provided to `Repository.Progress` field, this pointer will be pass to the remotes and be used when the packfile is read.  If the `Repository.Progress` is not set the `no-progress` capability is set if supported.


Also a couple of bugs are solved at transport/client: 
- Content-Length is correctly encoded using `strconv.Itoa` instead of just casting a integer to string. 
- Request encoding is done now using the encoders provide by the `protocol/packp package