### PR TITLE
protocol/packp: improve AdvRefs tests

### DIFF
--- a/plumbing/protocol/packp/advrefs_decode_test.go
+++ b/plumbing/protocol/packp/advrefs_decode_test.go
@@ -17,38 +17,27 @@ type AdvRefsDecodeSuite struct{}
 var _ = Suite(&AdvRefsDecodeSuite{})
 
 func (s *AdvRefsDecodeSuite) TestEmpty(c *C) {
-	ar := NewAdvRefs()
 	var buf bytes.Buffer
-	d := newAdvRefsDecoder(&buf)
-
-	err := d.Decode(ar)
-	c.Assert(err, Equals, ErrEmptyAdvRefs)
+	ar := NewAdvRefs()
+	c.Assert(ar.Decode(&buf), Equals, ErrEmptyAdvRefs)
 }
 
 func (s *AdvRefsDecodeSuite) TestEmptyFlush(c *C) {
-	ar := NewAdvRefs()
 	var buf bytes.Buffer
 	e := pktline.NewEncoder(&buf)
 	e.Flush()
-
-	d := newAdvRefsDecoder(&buf)
-
-	err := d.Decode(ar)
-	c.Assert(err, Equals, ErrEmptyAdvRefs)
+	ar := NewAdvRefs()
+	c.Assert(ar.Decode(&buf), Equals, ErrEmptyAdvRefs)
 }
 
 func (s *AdvRefsDecodeSuite) TestEmptyPrefixFlush(c *C) {
-	ar := NewAdvRefs()
 	var buf bytes.Buffer
 	e := pktline.NewEncoder(&buf)
 	e.EncodeString("# service=git-upload-pack")
 	e.Flush()
 	e.Flush()
-
-	d := newAdvRefsDecoder(&buf)
-
-	err := d.Decode(ar)
-	c.Assert(err, Equals, ErrEmptyAdvRefs)
+	ar := NewAdvRefs()
+	c.Assert(ar.Decode(&buf), Equals, ErrEmptyAdvRefs)
 }
 
 func (s *AdvRefsDecodeSuite) TestShortForHash(c *C) {
@@ -62,10 +51,7 @@ func (s *AdvRefsDecodeSuite) TestShortForHash(c *C) {
 
 func (s *AdvRefsDecodeSuite) testDecoderErrorMatches(c *C, input io.Reader, pattern string) {
 	ar := NewAdvRefs()
-	d := newAdvRefsDecoder(input)
-
-	err := d.Decode(ar)
-	c.Assert(err, ErrorMatches, pattern)
+	c.Assert(ar.Decode(input), ErrorMatches, pattern)
 }
 
 func (s *AdvRefsDecodeSuite) TestInvalidFirstHash(c *C) {
@@ -93,10 +79,7 @@ func (s *AdvRefsDecodeSuite) testDecodeOK(c *C, payloads []string) *AdvRefs {
 	c.Assert(err, IsNil)
 
 	ar := NewAdvRefs()
-	d := newAdvRefsDecoder(&buf)
-
-	err = d.Decode(ar)
-	c.Assert(err, IsNil)
+	c.Assert(ar.Decode(&buf), IsNil)
 
 	return ar
 }

--- a/plumbing/protocol/packp/advrefs_encode_test.go
+++ b/plumbing/protocol/packp/advrefs_encode_test.go
@@ -17,9 +17,7 @@ var _ = Suite(&AdvRefsEncodeSuite{})
 
 func testEncode(c *C, input *AdvRefs, expected []byte) {
 	var buf bytes.Buffer
-	e := newAdvRefsEncoder(&buf)
-	err := e.Encode(input)
-	c.Assert(err, IsNil)
+	c.Assert(input.Encode(&buf), IsNil)
 	obtained := buf.Bytes()
 
 	comment := Commentf("\nobtained = %s\nexpected = %s\n", string(obtained), string(expected))
@@ -232,7 +230,6 @@ func (s *AdvRefsEncodeSuite) TestErrorTooLong(c *C) {
 	}
 
 	var buf bytes.Buffer
-	e := newAdvRefsEncoder(&buf)
-	err := e.Encode(ar)
+	err := ar.Encode(&buf)
 	c.Assert(err, ErrorMatches, ".*payload is too long.*")
 }

--- a/plumbing/protocol/packp/advrefs_test.go
+++ b/plumbing/protocol/packp/advrefs_test.go
@@ -302,7 +302,7 @@ func (s *AdvRefsDecodeEncodeSuite) TestAllSmartBug(c *C) {
 	s.test(c, input, expected)
 }
 
-func ExampleDecoder_Decode() {
+func ExampleAdvRefs_Decode() {
 	// Here is a raw advertised-ref message.
 	raw := "" +
 		"0065a6930aaee06755d1bdcfd943fbf614e4d92bb0c7 HEAD\x00multi_ack ofs-delta symref=HEAD:/refs/heads/master\n" +
@@ -330,7 +330,7 @@ func ExampleDecoder_Decode() {
 	// shallows = [5dc01c595e6c6ec9ccda4f6f69c131c0dd945f8c]
 }
 
-func ExampleEncoder_Encode() {
+func ExampleAdvRefs_Encode() {
 	// Create an AdvRefs with the contents you want...
 	ar := NewAdvRefs()
 


### PR DESCRIPTION
* protocol/packp: fix Example* func names for AdvRefs.
*  protocol/packp: test AdvRefs Encode/Decode, no internal functions.