### PR TITLE
plumbing/protocol: packp avoid duplication of haves, wants and shallow

### DIFF
--- a/plumbing/hash.go
+++ b/plumbing/hash.go
@@ -1,9 +1,11 @@
 package plumbing
 
 import (
+	"bytes"
 	"crypto/sha1"
 	"encoding/hex"
 	"hash"
+	"sort"
 	"strconv"
 )
 
@@ -56,3 +58,16 @@ func (h Hasher) Sum() (hash Hash) {
 	copy(hash[:], h.Hash.Sum(nil))
 	return
 }
+
+// HashesSort sorts a slice of Hashes in increasing order.
+func HashesSort(a []Hash) {
+	sort.Sort(HashSlice(a))
+}
+
+// HashSlice attaches the methods of sort.Interface to []Hash, sorting in
+// increasing order.
+type HashSlice []Hash
+
+func (p HashSlice) Len() int           { return len(p) }
+func (p HashSlice) Less(i, j int) bool { return bytes.Compare(p[i][:], p[j][:]) < 0 }
+func (p HashSlice) Swap(i, j int)      { p[i], p[j] = p[j], p[i] }

--- a/plumbing/hash_test.go
+++ b/plumbing/hash_test.go
@@ -40,3 +40,15 @@ func (s *HashSuite) TestNewHasher(c *C) {
 	hasher.Write([]byte(content))
 	c.Assert(hasher.Sum().String(), Equals, "dc42c3cc80028d0ec61f0a6b24cadd1c195c4dfc")
 }
+
+func (s *HashSuite) TestHashesSort(c *C) {
+	i := []Hash{
+		NewHash("2222222222222222222222222222222222222222"),
+		NewHash("1111111111111111111111111111111111111111"),
+	}
+
+	HashesSort(i)
+
+	c.Assert(i[0], Equals, NewHash("1111111111111111111111111111111111111111"))
+	c.Assert(i[1], Equals, NewHash("2222222222222222222222222222222222222222"))
+}

--- a/plumbing/protocol/packp/ulreq_encode_test.go
+++ b/plumbing/protocol/packp/ulreq_encode_test.go
@@ -76,11 +76,13 @@ func (s *UlReqEncodeSuite) TestOneWantWithCapabilities(c *C) {
 
 func (s *UlReqEncodeSuite) TestWants(c *C) {
 	ur := NewUploadRequest()
-	ur.Wants = append(ur.Wants, plumbing.NewHash("4444444444444444444444444444444444444444"))
-	ur.Wants = append(ur.Wants, plumbing.NewHash("1111111111111111111111111111111111111111"))
-	ur.Wants = append(ur.Wants, plumbing.NewHash("3333333333333333333333333333333333333333"))
-	ur.Wants = append(ur.Wants, plumbing.NewHash("2222222222222222222222222222222222222222"))
-	ur.Wants = append(ur.Wants, plumbing.NewHash("5555555555555555555555555555555555555555"))
+	ur.Wants = append(ur.Wants,
+		plumbing.NewHash("4444444444444444444444444444444444444444"),
+		plumbing.NewHash("1111111111111111111111111111111111111111"),
+		plumbing.NewHash("3333333333333333333333333333333333333333"),
+		plumbing.NewHash("2222222222222222222222222222222222222222"),
+		plumbing.NewHash("5555555555555555555555555555555555555555"),
+	)
 
 	expected := []string{
 		"want 1111111111111111111111111111111111111111\n",
@@ -94,13 +96,37 @@ func (s *UlReqEncodeSuite) TestWants(c *C) {
 	testUlReqEncode(c, ur, expected)
 }
 
+func (s *UlReqEncodeSuite) TestWantsDuplicates(c *C) {
+	ur := NewUploadRequest()
+	ur.Wants = append(ur.Wants,
+		plumbing.NewHash("4444444444444444444444444444444444444444"),
+		plumbing.NewHash("1111111111111111111111111111111111111111"),
+		plumbing.NewHash("3333333333333333333333333333333333333333"),
+		plumbing.NewHash("1111111111111111111111111111111111111111"),
+		plumbing.NewHash("2222222222222222222222222222222222222222"),
+		plumbing.NewHash("1111111111111111111111111111111111111111"),
+	)
+
+	expected := []string{
+		"want 1111111111111111111111111111111111111111\n",
+		"want 2222222222222222222222222222222222222222\n",
+		"want 3333333333333333333333333333333333333333\n",
+		"want 4444444444444444444444444444444444444444\n",
+		pktline.FlushString,
+	}
+
+	testUlReqEncode(c, ur, expected)
+}
+
 func (s *UlReqEncodeSuite) TestWantsWithCapabilities(c *C) {
 	ur := NewUploadRequest()
-	ur.Wants = append(ur.Wants, plumbing.NewHash("4444444444444444444444444444444444444444"))
-	ur.Wants = append(ur.Wants, plumbing.NewHash("1111111111111111111111111111111111111111"))
-	ur.Wants = append(ur.Wants, plumbing.NewHash("3333333333333333333333333333333333333333"))
-	ur.Wants = append(ur.Wants, plumbing.NewHash("2222222222222222222222222222222222222222"))
-	ur.Wants = append(ur.Wants, plumbing.NewHash("5555555555555555555555555555555555555555"))
+	ur.Wants = append(ur.Wants,
+		plumbing.NewHash("4444444444444444444444444444444444444444"),
+		plumbing.NewHash("1111111111111111111111111111111111111111"),
+		plumbing.NewHash("3333333333333333333333333333333333333333"),
+		plumbing.NewHash("2222222222222222222222222222222222222222"),
+		plumbing.NewHash("5555555555555555555555555555555555555555"),
+	)
 
 	ur.Capabilities.Add(capability.MultiACK)
 	ur.Capabilities.Add(capability.OFSDelta)
@@ -139,10 +165,12 @@ func (s *UlReqEncodeSuite) TestManyShallows(c *C) {
 	ur := NewUploadRequest()
 	ur.Wants = append(ur.Wants, plumbing.NewHash("1111111111111111111111111111111111111111"))
 	ur.Capabilities.Add(capability.MultiACK)
-	ur.Shallows = append(ur.Shallows, plumbing.NewHash("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"))
-	ur.Shallows = append(ur.Shallows, plumbing.NewHash("dddddddddddddddddddddddddddddddddddddddd"))
-	ur.Shallows = append(ur.Shallows, plumbing.NewHash("cccccccccccccccccccccccccccccccccccccccc"))
-	ur.Shallows = append(ur.Shallows, plumbing.NewHash("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"))
+	ur.Shallows = append(ur.Shallows,
+		plumbing.NewHash("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"),
+		plumbing.NewHash("dddddddddddddddddddddddddddddddddddddddd"),
+		plumbing.NewHash("cccccccccccccccccccccccccccccccccccccccc"),
+		plumbing.NewHash("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
+	)
 
 	expected := []string{
 		"want 1111111111111111111111111111111111111111 multi_ack\n",
@@ -150,6 +178,28 @@ func (s *UlReqEncodeSuite) TestManyShallows(c *C) {
 		"shallow bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\n",
 		"shallow cccccccccccccccccccccccccccccccccccccccc\n",
 		"shallow dddddddddddddddddddddddddddddddddddddddd\n",
+		pktline.FlushString,
+	}
+
+	testUlReqEncode(c, ur, expected)
+}
+
+func (s *UlReqEncodeSuite) TestShallowsDuplicate(c *C) {
+	ur := NewUploadRequest()
+	ur.Wants = append(ur.Wants, plumbing.NewHash("1111111111111111111111111111111111111111"))
+	ur.Capabilities.Add(capability.MultiACK)
+	ur.Shallows = append(ur.Shallows,
+		plumbing.NewHash("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"),
+		plumbing.NewHash("cccccccccccccccccccccccccccccccccccccccc"),
+		plumbing.NewHash("cccccccccccccccccccccccccccccccccccccccc"),
+		plumbing.NewHash("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
+	)
+
+	expected := []string{
+		"want 1111111111111111111111111111111111111111 multi_ack\n",
+		"shallow aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\n",
+		"shallow bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\n",
+		"shallow cccccccccccccccccccccccccccccccccccccccc\n",
 		pktline.FlushString,
 	}
 
@@ -220,11 +270,13 @@ func (s *UlReqEncodeSuite) TestDepthReference(c *C) {
 
 func (s *UlReqEncodeSuite) TestAll(c *C) {
 	ur := NewUploadRequest()
-	ur.Wants = append(ur.Wants, plumbing.NewHash("4444444444444444444444444444444444444444"))
-	ur.Wants = append(ur.Wants, plumbing.NewHash("1111111111111111111111111111111111111111"))
-	ur.Wants = append(ur.Wants, plumbing.NewHash("3333333333333333333333333333333333333333"))
-	ur.Wants = append(ur.Wants, plumbing.NewHash("2222222222222222222222222222222222222222"))
-	ur.Wants = append(ur.Wants, plumbing.NewHash("5555555555555555555555555555555555555555"))
+	ur.Wants = append(ur.Wants,
+		plumbing.NewHash("4444444444444444444444444444444444444444"),
+		plumbing.NewHash("1111111111111111111111111111111111111111"),
+		plumbing.NewHash("3333333333333333333333333333333333333333"),
+		plumbing.NewHash("2222222222222222222222222222222222222222"),
+		plumbing.NewHash("5555555555555555555555555555555555555555"),
+	)
 
 	ur.Capabilities.Add(capability.MultiACK)
 	ur.Capabilities.Add(capability.OFSDelta)

--- a/plumbing/protocol/packp/uppackreq.go
+++ b/plumbing/protocol/packp/uppackreq.go
@@ -1,6 +1,7 @@
 package packp
 
 import (
+	"bytes"
 	"fmt"
 	"io"
 
@@ -68,10 +69,20 @@ type UploadHaves struct {
 // Encode encodes the UploadHaves into the Writer.
 func (u *UploadHaves) Encode(w io.Writer) error {
 	e := pktline.NewEncoder(w)
+
+	plumbing.HashesSort(u.Haves)
+
+	var last plumbing.Hash
 	for _, have := range u.Haves {
+		if bytes.Compare(last[:], have[:]) == 0 {
+			continue
+		}
+
 		if err := e.Encodef("have %s\n", have); err != nil {
 			return fmt.Errorf("sending haves for %q: %s", have, err)
 		}
+
+		last = have
 	}
 
 	if len(u.Haves) != 0 {

--- a/plumbing/protocol/packp/uppackreq_test.go
+++ b/plumbing/protocol/packp/uppackreq_test.go
@@ -4,6 +4,8 @@ import (
 	"gopkg.in/src-d/go-git.v4/plumbing"
 	"gopkg.in/src-d/go-git.v4/plumbing/protocol/packp/capability"
 
+	"bytes"
+
 	. "gopkg.in/check.v1"
 )
 
@@ -39,4 +41,29 @@ func (s *UploadPackRequestSuite) TestIsEmpty(c *C) {
 	r.Haves = append(r.Haves, plumbing.NewHash("d82f291cde9987322c8a0c81a325e1ba6159684c"))
 
 	c.Assert(r.IsEmpty(), Equals, true)
+}
+
+type UploadHavesSuite struct{}
+
+var _ = Suite(&UploadHavesSuite{})
+
+func (s *UploadHavesSuite) TestEncode(c *C) {
+	uh := &UploadHaves{}
+	uh.Haves = append(uh.Haves,
+		plumbing.NewHash("1111111111111111111111111111111111111111"),
+		plumbing.NewHash("3333333333333333333333333333333333333333"),
+		plumbing.NewHash("1111111111111111111111111111111111111111"),
+		plumbing.NewHash("2222222222222222222222222222222222222222"),
+		plumbing.NewHash("1111111111111111111111111111111111111111"),
+	)
+
+	buf := bytes.NewBuffer(nil)
+	err := uh.Encode(buf)
+	c.Assert(err, IsNil)
+	c.Assert(buf.String(), Equals, ""+
+		"0032have 1111111111111111111111111111111111111111\n"+
+		"0032have 2222222222222222222222222222222222222222\n"+
+		"0032have 3333333333333333333333333333333333333333\n"+
+		"0000",
+	)
 }


### PR DESCRIPTION
This avoid to have any duplicated hash in haves, wants or shallow lists in different messages.
Additionally `plumbing.HashesSort` has been added to easy hash list sorting