### PR TITLE
plumbing/transport: allow AdvertisedReferences being called multiple times

### DIFF
--- a/plumbing/transport/common.go
+++ b/plumbing/transport/common.go
@@ -30,8 +30,6 @@ var (
 	ErrAuthorizationRequired  = errors.New("authorization required")
 	ErrEmptyUploadPackRequest = errors.New("empty git-upload-pack given")
 	ErrInvalidAuthMethod      = errors.New("invalid auth method")
-
-	ErrAdvertistedReferencesAlreadyCalled = errors.New("cannot call AdvertisedReference twice")
 )
 
 const (
@@ -49,6 +47,9 @@ type Client interface {
 
 type Session interface {
 	SetAuth(auth AuthMethod) error
+	// AdvertisedReferences retrieves the advertised references for a
+	// repository.
+	AdvertisedReferences() (*packp.AdvRefs, error)
 	io.Closer
 }
 
@@ -63,10 +64,6 @@ type AuthMethod interface {
 // In that order.
 type FetchPackSession interface {
 	Session
-	// AdvertisedReferences retrieves the advertised references for a
-	// repository. It should be called before FetchPack, and it cannot be
-	// called after FetchPack.
-	AdvertisedReferences() (*packp.AdvRefs, error)
 	// FetchPack takes a request and returns a reader for the packfile
 	// received from the server.
 	FetchPack(*packp.UploadPackRequest) (*packp.UploadPackResponse, error)
@@ -78,10 +75,6 @@ type FetchPackSession interface {
 // In that order.
 type SendPackSession interface {
 	Session
-	// AdvertisedReferences retrieves the advertised references for a
-	// repository. It should be called before FetchPack, and it cannot be
-	// called after FetchPack.
-	AdvertisedReferences() (*packp.AdvRefs, error)
 	// UpdateReferences sends an update references request and returns a
 	// writer to be used for packfile writing.
 	//TODO: Complete signature.

--- a/plumbing/transport/http/common.go
+++ b/plumbing/transport/http/common.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 
 	"gopkg.in/src-d/go-git.v4/plumbing"
+	"gopkg.in/src-d/go-git.v4/plumbing/protocol/packp"
 	"gopkg.in/src-d/go-git.v4/plumbing/transport"
 )
 
@@ -50,6 +51,7 @@ type session struct {
 	auth     AuthMethod
 	client   *http.Client
 	endpoint transport.Endpoint
+	advRefs  *packp.AdvRefs
 }
 
 func (s *session) SetAuth(auth transport.AuthMethod) error {

--- a/plumbing/transport/http/fetch_pack.go
+++ b/plumbing/transport/http/fetch_pack.go
@@ -17,7 +17,6 @@ import (
 
 type fetchPackSession struct {
 	*session
-	advRefsRun bool
 }
 
 func newFetchPackSession(c *http.Client,
@@ -33,11 +32,9 @@ func newFetchPackSession(c *http.Client,
 }
 
 func (s *fetchPackSession) AdvertisedReferences() (*packp.AdvRefs, error) {
-	if s.advRefsRun {
-		return nil, transport.ErrAdvertistedReferencesAlreadyCalled
+	if s.advRefs != nil {
+		return s.advRefs, nil
 	}
-
-	defer func() { s.advRefsRun = true }()
 
 	url := fmt.Sprintf(
 		"%s/info/refs?service=%s",
@@ -72,6 +69,7 @@ func (s *fetchPackSession) AdvertisedReferences() (*packp.AdvRefs, error) {
 	}
 
 	transport.FilterUnsupportedCapabilities(ar.Capabilities)
+	s.advRefs = ar
 	return ar, nil
 }
 

--- a/plumbing/transport/test/common.go
+++ b/plumbing/transport/test/common.go
@@ -49,13 +49,15 @@ func (s *FetchPackSuite) TestInfoNotExists(c *C) {
 	c.Assert(reader, IsNil)
 }
 
-func (s *FetchPackSuite) TestCannotCallAdvertisedReferenceTwice(c *C) {
+func (s *FetchPackSuite) TestCallAdvertisedReferenceTwice(c *C) {
 	r, err := s.Client.NewFetchPackSession(s.Endpoint)
 	c.Assert(err, IsNil)
-	_, err = r.AdvertisedReferences()
+	ar1, err := r.AdvertisedReferences()
 	c.Assert(err, IsNil)
-	_, err = r.AdvertisedReferences()
-	c.Assert(err, Equals, transport.ErrAdvertistedReferencesAlreadyCalled)
+	c.Assert(ar1, NotNil)
+	ar2, err := r.AdvertisedReferences()
+	c.Assert(err, IsNil)
+	c.Assert(ar2, DeepEquals, ar1)
 }
 
 func (s *FetchPackSuite) TestDefaultBranch(c *C) {


### PR DESCRIPTION
* AdvertisedReferences is now part of transport.Session.
* It is allowed to be called more than once.
* It is allowed to be called before and after FetchPack/SendPack.
* Implementations cache its result.