### PR TITLE
packp/capability: trim spaces on capabilities decode.

### DIFF
--- a/plumbing/protocol/packp/capability/list.go
+++ b/plumbing/protocol/packp/capability/list.go
@@ -48,6 +48,11 @@ func (l *List) IsEmpty() bool {
 
 // Decode decodes list of capabilities from raw into the list
 func (l *List) Decode(raw []byte) error {
+	// git 1.x receive pack used to send a leading space on its
+	// git-receive-pack capabilities announcement. We just trim space to be
+	// tolerant to space changes in different versions.
+	raw = bytes.TrimSpace(raw)
+
 	if len(raw) == 0 {
 		return nil
 	}

--- a/plumbing/protocol/packp/capability/list_test.go
+++ b/plumbing/protocol/packp/capability/list_test.go
@@ -27,6 +27,15 @@ func (s *SuiteCapabilities) TestDecode(c *check.C) {
 	c.Assert(cap.Get(ThinPack), check.IsNil)
 }
 
+func (s *SuiteCapabilities) TestDecodeWithLeadingSpace(c *check.C) {
+	cap := NewList()
+	err := cap.Decode([]byte(" report-status"))
+	c.Assert(err, check.IsNil)
+
+	c.Assert(cap.m, check.HasLen, 1)
+	c.Assert(cap.Supports(ReportStatus), check.Equals, true)
+}
+
 func (s *SuiteCapabilities) TestDecodeEmpty(c *check.C) {
 	cap := NewList()
 	err := cap.Decode(nil)


### PR DESCRIPTION
git 1.8 used to write a leading space in the capabilities
announcement for git-receive-pack. We now trim spaces before
decoding a capabilities list to be more tolerant about
this kind of difference.