### PR TITLE
config: Config, bare flag

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -26,6 +26,9 @@ var (
 
 // Config contains the repository configuration
 type Config struct {
+	Core struct {
+		IsBare bool
+	}
 	Remotes map[string]*RemoteConfig
 }
 

--- a/config/config.go
+++ b/config/config.go
@@ -60,21 +60,7 @@ type RemoteConfig struct {
 	URL   string
 	Fetch []RefSpec
 }
-re(cfg, ini)
-	c.marshalRemotes(cfg, ini)
-	return c.marshal(ini)
-}
 
-func (c *ConfigStorage) marshalCore(cfg *config.Config, ini *gitconfig.Config) {
-	s := ini.Section(coreSection)
-	s.AddOption(bareKey, fmt.Sprintf("%t", cfg.Core.IsBare))
-}
-
-func (c *ConfigStorage) marshalRemotes(cfg *config.Config, ini *gitconfig.Config) {
-	s := ini.Section(remoteSection)
-	s.Subsections = make(gitconfig.Subsections, len(cfg.Remotes))
-
-	var i in
 // Validate validate the fields and set the default values
 func (c *RemoteConfig) Validate() error {
 	if c.Name == "" {

--- a/config/config.go
+++ b/config/config.go
@@ -60,7 +60,21 @@ type RemoteConfig struct {
 	URL   string
 	Fetch []RefSpec
 }
+re(cfg, ini)
+	c.marshalRemotes(cfg, ini)
+	return c.marshal(ini)
+}
 
+func (c *ConfigStorage) marshalCore(cfg *config.Config, ini *gitconfig.Config) {
+	s := ini.Section(coreSection)
+	s.AddOption(bareKey, fmt.Sprintf("%t", cfg.Core.IsBare))
+}
+
+func (c *ConfigStorage) marshalRemotes(cfg *config.Config, ini *gitconfig.Config) {
+	s := ini.Section(remoteSection)
+	s.Subsections = make(gitconfig.Subsections, len(cfg.Remotes))
+
+	var i in
 // Validate validate the fields and set the default values
 func (c *RemoteConfig) Validate() error {
 	if c.Name == "" {

--- a/repository_test.go
+++ b/repository_test.go
@@ -118,6 +118,27 @@ func (s *RepositorySuite) TestClone(c *C) {
 	c.Assert(branch.Hash().String(), Equals, "6ecf0ef2c2dffb796033e5a02219af86ec6584e5")
 }
 
+func (s *RepositorySuite) TestCloneConfig(c *C) {
+	r := NewMemoryRepository()
+
+	head, err := r.Head()
+	c.Assert(err, Equals, plumbing.ErrReferenceNotFound)
+	c.Assert(head, IsNil)
+
+	err = r.Clone(&CloneOptions{
+		URL: s.GetBasicLocalRepositoryURL(),
+	})
+
+	c.Assert(err, IsNil)
+
+	cfg, err := r.Config()
+	c.Assert(err, IsNil)
+
+	c.Assert(cfg.Core.IsBare, Equals, true)
+	c.Assert(cfg.Remotes, HasLen, 1)
+	c.Assert(cfg.Remotes["origin"].Name, Equals, "origin")
+	c.Assert(cfg.Remotes["origin"].URL, Not(Equals), "")
+}
 func (s *RepositorySuite) TestCloneNonEmpty(c *C) {
 	r := NewMemoryRepository()
 

--- a/storage/filesystem/config.go
+++ b/storage/filesystem/config.go
@@ -1,9 +1,8 @@
 package filesystem
 
 import (
-	"os"
-
 	"fmt"
+	"os"
 
 	"gopkg.in/src-d/go-git.v4/config"
 	gitconfig "gopkg.in/src-d/go-git.v4/plumbing/format/config"

--- a/storage/filesystem/config.go
+++ b/storage/filesystem/config.go
@@ -3,6 +3,8 @@ package filesystem
 import (
 	"os"
 
+	"fmt"
+
 	"gopkg.in/src-d/go-git.v4/config"
 	gitconfig "gopkg.in/src-d/go-git.v4/plumbing/format/config"
 	"gopkg.in/src-d/go-git.v4/storage/filesystem/internal/dotgit"
@@ -10,8 +12,10 @@ import (
 
 const (
 	remoteSection = "remote"
+	coreSection   = "core"
 	fetchKey      = "fetch"
 	urlKey        = "url"
+	bareKey       = "bare"
 )
 
 type ConfigStorage struct {
@@ -26,11 +30,8 @@ func (c *ConfigStorage) Config() (*config.Config, error) {
 		return nil, err
 	}
 
-	sect := ini.Section(remoteSection)
-	for _, s := range sect.Subsections {
-		r := c.unmarshalRemote(s)
-		cfg.Remotes[r.Name] = r
-	}
+	c.unmarshalCore(cfg, ini)
+	c.unmarshalRemotes(cfg, ini)
 
 	return cfg, nil
 }
@@ -55,6 +56,21 @@ func (c *ConfigStorage) unmarshal() (*gitconfig.Config, error) {
 	}
 
 	return cfg, nil
+}
+
+func (c *ConfigStorage) unmarshalCore(cfg *config.Config, ini *gitconfig.Config) {
+	s := ini.Section(coreSection)
+	if s.Options.Get(bareKey) == "true" {
+		cfg.Core.IsBare = true
+	}
+}
+
+func (c *ConfigStorage) unmarshalRemotes(cfg *config.Config, ini *gitconfig.Config) {
+	s := ini.Section(remoteSection)
+	for _, sub := range s.Subsections {
+		r := c.unmarshalRemote(sub)
+		cfg.Remotes[r.Name] = r
+	}
 }
 
 func (c *ConfigStorage) unmarshalRemote(s *gitconfig.Subsection) *config.RemoteConfig {
@@ -83,6 +99,17 @@ func (c *ConfigStorage) SetConfig(cfg *config.Config) error {
 		return err
 	}
 
+	c.marshalCore(cfg, ini)
+	c.marshalRemotes(cfg, ini)
+	return c.marshal(ini)
+}
+
+func (c *ConfigStorage) marshalCore(cfg *config.Config, ini *gitconfig.Config) {
+	s := ini.Section(coreSection)
+	s.AddOption(bareKey, fmt.Sprintf("%t", cfg.Core.IsBare))
+}
+
+func (c *ConfigStorage) marshalRemotes(cfg *config.Config, ini *gitconfig.Config) {
 	s := ini.Section(remoteSection)
 	s.Subsections = make(gitconfig.Subsections, len(cfg.Remotes))
 
@@ -91,8 +118,16 @@ func (c *ConfigStorage) SetConfig(cfg *config.Config) error {
 		s.Subsections[i] = c.marshalRemote(r)
 		i++
 	}
+}
 
-	return c.marshal(ini)
+func (c *ConfigStorage) marshalRemote(r *config.RemoteConfig) *gitconfig.Subsection {
+	s := &gitconfig.Subsection{Name: r.Name}
+	s.AddOption(urlKey, r.URL)
+	for _, rs := range r.Fetch {
+		s.AddOption(fetchKey, rs.String())
+	}
+
+	return s
 }
 
 func (c *ConfigStorage) marshal(ini *gitconfig.Config) error {
@@ -105,14 +140,4 @@ func (c *ConfigStorage) marshal(ini *gitconfig.Config) error {
 
 	e := gitconfig.NewEncoder(f)
 	return e.Encode(ini)
-}
-
-func (c *ConfigStorage) marshalRemote(r *config.RemoteConfig) *gitconfig.Subsection {
-	s := &gitconfig.Subsection{Name: r.Name}
-	s.AddOption(urlKey, r.URL)
-	for _, rs := range r.Fetch {
-		s.AddOption(fetchKey, rs.String())
-	}
-
-	return s
 }

--- a/storage/test/storage_suite.go
+++ b/storage/test/storage_suite.go
@@ -265,6 +265,7 @@ func (s *BaseStorageSuite) TestIterReferences(c *C) {
 
 func (s *BaseStorageSuite) TestSetConfigAndConfig(c *C) {
 	expected := config.NewConfig()
+	expected.Core.IsBare = true
 	expected.Remotes["foo"] = &config.RemoteConfig{
 		Name: "foo",
 		URL:  "http://foo/bar.git",


### PR DESCRIPTION
This is the `core.bare` config flag, this PR implemente the encoding/decoding of the flag, and also the `Repository.Clone` makes use of it