### PR TITLE
storage: shallow storage

### DIFF
--- a/common.go
+++ b/common.go
@@ -15,6 +15,7 @@ import (
 type Storer interface {
 	storer.ObjectStorer
 	storer.ReferenceStorer
+	storer.ShallowStorer
 	config.ConfigStorer
 }
 

--- a/plumbing/storer/shallow.go
+++ b/plumbing/storer/shallow.go
@@ -2,8 +2,8 @@ package storer
 
 import "gopkg.in/src-d/go-git.v4/plumbing"
 
-// ShallowStorer storage of shallow commits, meaning that it does not have the
-// parents of a commit (explanation from git documentation)
+// ShallowStorer storage of references to shallow commits by hash, meaning that
+// these commits have missing parents because of a shallow fetch.
 type ShallowStorer interface {
 	SetShallow([]plumbing.Hash) error
 	Shallow() ([]plumbing.Hash, error)

--- a/plumbing/storer/shallow.go
+++ b/plumbing/storer/shallow.go
@@ -1,0 +1,10 @@
+package storer
+
+import "gopkg.in/src-d/go-git.v4/plumbing"
+
+// ShallowStorer storage of shallow commits, meaning that it does not have the
+// parents of a commit (explanation from git documentation)
+type ShallowStorer interface {
+	SetShallow([]plumbing.Hash) error
+	Shallow() ([]plumbing.Hash, error)
+}

--- a/remote.go
+++ b/remote.go
@@ -128,6 +128,10 @@ func (r *Remote) Fetch(o *FetchOptions) (err error) {
 
 	defer checkClose(reader, &err)
 
+	if err := r.updateShallow(o, reader); err != nil {
+		return err
+	}
+
 	if err = r.updateObjectStorage(
 		r.buildSidebandIfSupported(req.Capabilities, reader),
 	); err != nil {
@@ -292,6 +296,14 @@ func (r *Remote) buildFetchedTags() error {
 
 		return r.s.SetReference(ref)
 	})
+}
+
+func (r *Remote) updateShallow(o *FetchOptions, resp *packp.UploadPackResponse) error {
+	if o.Depth == 0 {
+		return nil
+	}
+
+	return r.s.SetShallow(resp.Shallows)
 }
 
 // Head returns the Reference of the HEAD

--- a/remote_test.go
+++ b/remote_test.go
@@ -124,6 +124,14 @@ func (s *RemoteSuite) TestFetchDepth(c *C) {
 		r, _ := sto.Reference(exp.Name())
 		c.Assert(exp.String(), Equals, r.String())
 	}
+
+	h, err := sto.Shallow()
+	c.Assert(err, IsNil)
+	c.Assert(h, HasLen, 2)
+	c.Assert(h, DeepEquals, []plumbing.Hash{
+		plumbing.NewHash("e8d3ffab552895c19b9fcf7aa264d277cde33881"),
+		plumbing.NewHash("6ecf0ef2c2dffb796033e5a02219af86ec6584e5"),
+	})
 }
 
 func (s *RemoteSuite) TestFetchWithProgress(c *C) {

--- a/storage/filesystem/internal/dotgit/dotgit.go
+++ b/storage/filesystem/internal/dotgit/dotgit.go
@@ -17,6 +17,7 @@ const (
 	suffix         = ".git"
 	packedRefsPath = "packed-refs"
 	configPath     = "config"
+	shallowPath    = "shallow"
 
 	objectsPath = "objects"
 	packPath    = "pack"
@@ -60,13 +61,33 @@ func New(fs fs.Filesystem) *DotGit {
 	return &DotGit{fs: fs}
 }
 
+// ConfigWriter returns a file pointer for write to the config file
 func (d *DotGit) ConfigWriter() (fs.File, error) {
 	return d.fs.Create(configPath)
 }
 
-// Config returns the path of the config file
+// Config returns a file pointer for read to the config file
 func (d *DotGit) Config() (fs.File, error) {
 	return d.fs.Open(configPath)
+}
+
+// ShallowWriter returns a file pointer for write to the shallow file
+func (d *DotGit) ShallowWriter() (fs.File, error) {
+	return d.fs.Create(shallowPath)
+}
+
+// Shallow returns a file pointer for read to the shallow file
+func (d *DotGit) Shallow() (fs.File, error) {
+	f, err := d.fs.Open(shallowPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+
+		return nil, err
+	}
+
+	return f, nil
 }
 
 // NewObjectPack return a writer for a new packfile, it saves the packfile to

--- a/storage/filesystem/internal/dotgit/dotgit_test.go
+++ b/storage/filesystem/internal/dotgit/dotgit_test.go
@@ -130,6 +130,61 @@ func (s *SuiteDotGit) TestConfig(c *C) {
 	c.Assert(filepath.Base(file.Filename()), Equals, "config")
 }
 
+func (s *SuiteDotGit) TestConfigWriteAndConfig(c *C) {
+	tmp, err := ioutil.TempDir("", "dot-git")
+	c.Assert(err, IsNil)
+	defer os.RemoveAll(tmp)
+
+	fs := osfs.New(tmp)
+	dir := New(fs)
+
+	f, err := dir.ConfigWriter()
+	c.Assert(err, IsNil)
+
+	_, err = f.Write([]byte("foo"))
+	c.Assert(err, IsNil)
+
+	f, err = dir.Config()
+	c.Assert(err, IsNil)
+
+	cnt, err := ioutil.ReadAll(f)
+	c.Assert(err, IsNil)
+
+	c.Assert(string(cnt), Equals, "foo")
+}
+
+func (s *SuiteDotGit) TestShallow(c *C) {
+	fs := fixtures.Basic().ByTag(".git").One().DotGit()
+	dir := New(fs)
+
+	file, err := dir.Shallow()
+	c.Assert(err, IsNil)
+	c.Assert(file, IsNil)
+}
+
+func (s *SuiteDotGit) TestShallowWriteAndShallow(c *C) {
+	tmp, err := ioutil.TempDir("", "dot-git")
+	c.Assert(err, IsNil)
+	defer os.RemoveAll(tmp)
+
+	fs := osfs.New(tmp)
+	dir := New(fs)
+
+	f, err := dir.ShallowWriter()
+	c.Assert(err, IsNil)
+
+	_, err = f.Write([]byte("foo"))
+	c.Assert(err, IsNil)
+
+	f, err = dir.Shallow()
+	c.Assert(err, IsNil)
+
+	cnt, err := ioutil.ReadAll(f)
+	c.Assert(err, IsNil)
+
+	c.Assert(string(cnt), Equals, "foo")
+}
+
 func findReference(refs []*plumbing.Reference, name string) *plumbing.Reference {
 	n := plumbing.ReferenceName(name)
 	for _, ref := range refs {
@@ -220,6 +275,18 @@ func (s *SuiteDotGit) TestObjects(c *C) {
 	c.Assert(hashes[0].String(), Equals, "0097821d427a3c3385898eb13b50dcbc8702b8a3")
 	c.Assert(hashes[1].String(), Equals, "01d5fa556c33743006de7e76e67a2dfcd994ca04")
 	c.Assert(hashes[2].String(), Equals, "03db8e1fbe133a480f2867aac478fd866686d69e")
+}
+
+func (s *SuiteDotGit) TestObjectsNoFolder(c *C) {
+	tmp, err := ioutil.TempDir("", "dot-git")
+	c.Assert(err, IsNil)
+	defer os.RemoveAll(tmp)
+
+	fs := osfs.New(tmp)
+	dir := New(fs)
+	hash, err := dir.Objects()
+	c.Assert(err, IsNil)
+	c.Assert(hash, HasLen, 0)
 }
 
 func (s *SuiteDotGit) TestObject(c *C) {

--- a/storage/filesystem/shallow.go
+++ b/storage/filesystem/shallow.go
@@ -1,9 +1,8 @@
 package filesystem
 
 import (
-	"fmt"
-
 	"bufio"
+	"fmt"
 
 	"gopkg.in/src-d/go-git.v4/plumbing"
 	"gopkg.in/src-d/go-git.v4/storage/filesystem/internal/dotgit"

--- a/storage/filesystem/shallow.go
+++ b/storage/filesystem/shallow.go
@@ -1,0 +1,52 @@
+package filesystem
+
+import (
+	"fmt"
+
+	"bufio"
+
+	"gopkg.in/src-d/go-git.v4/plumbing"
+	"gopkg.in/src-d/go-git.v4/storage/filesystem/internal/dotgit"
+)
+
+// ShallowStorage where the shallow commits are stored, an internal to
+// manipulate the shallow file
+type ShallowStorage struct {
+	dir *dotgit.DotGit
+}
+
+// SetShallow save the shallows in the shallow file in the .git folder as one
+// commit per line represented by 40-byte hexadecimal object terminated by a
+// newline.
+func (s *ShallowStorage) SetShallow(commits []plumbing.Hash) error {
+	f, err := s.dir.ShallowWriter()
+	if err != nil {
+		return err
+	}
+
+	defer f.Close()
+	for _, h := range commits {
+		if _, err := fmt.Fprintf(f, "%s\n", h); err != err {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// Shallow return the shallow commits reading from shallo file from .git
+func (s *ShallowStorage) Shallow() ([]plumbing.Hash, error) {
+	f, err := s.dir.Shallow()
+	if err != nil {
+		return nil, err
+	}
+
+	var hash []plumbing.Hash
+
+	scn := bufio.NewScanner(f)
+	for scn.Scan() {
+		hash = append(hash, plumbing.NewHash(scn.Text()))
+	}
+
+	return hash, scn.Err()
+}

--- a/storage/filesystem/storage.go
+++ b/storage/filesystem/storage.go
@@ -12,6 +12,7 @@ import (
 type Storage struct {
 	ObjectStorage
 	ReferenceStorage
+	ShallowStorage
 	ConfigStorage
 }
 
@@ -26,6 +27,7 @@ func NewStorage(fs fs.Filesystem) (*Storage, error) {
 	return &Storage{
 		ObjectStorage:    o,
 		ReferenceStorage: ReferenceStorage{dir: dir},
+		ShallowStorage:   ShallowStorage{dir: dir},
 		ConfigStorage:    ConfigStorage{dir: dir},
 	}, nil
 }

--- a/storage/memory/storage.go
+++ b/storage/memory/storage.go
@@ -18,6 +18,7 @@ var ErrUnsupportedObjectType = fmt.Errorf("unsupported object type")
 type Storage struct {
 	ConfigStorage
 	ObjectStorage
+	ShallowStorage
 	ReferenceStorage
 }
 
@@ -26,6 +27,7 @@ func NewStorage() *Storage {
 	return &Storage{
 		ReferenceStorage: make(ReferenceStorage, 0),
 		ConfigStorage:    ConfigStorage{},
+		ShallowStorage:   ShallowStorage{},
 		ObjectStorage: ObjectStorage{
 			Objects: make(map[plumbing.Hash]plumbing.Object, 0),
 			Commits: make(map[plumbing.Hash]plumbing.Object, 0),
@@ -194,4 +196,15 @@ func (r ReferenceStorage) IterReferences() (storer.ReferenceIter, error) {
 	}
 
 	return storer.NewReferenceSliceIter(refs), nil
+}
+
+type ShallowStorage []plumbing.Hash
+
+func (s *ShallowStorage) SetShallow(commits []plumbing.Hash) error {
+	*s = commits
+	return nil
+}
+
+func (s ShallowStorage) Shallow() ([]plumbing.Hash, error) {
+	return s, nil
 }

--- a/storage/test/storage_suite.go
+++ b/storage/test/storage_suite.go
@@ -17,6 +17,7 @@ import (
 type Storer interface {
 	storer.ObjectStorer
 	storer.ReferenceStorer
+	storer.ShallowStorer
 	config.ConfigStorer
 }
 
@@ -261,6 +262,21 @@ func (s *BaseStorageSuite) TestIterReferences(c *C) {
 	e, err = i.Next()
 	c.Assert(e, IsNil)
 	c.Assert(err, Equals, io.EOF)
+}
+
+func (s *BaseStorageSuite) TestSetShallowAndShallow(c *C) {
+	expected := []plumbing.Hash{
+		plumbing.NewHash("b66c08ba28aa1f81eb06a1127aa3936ff77e5e2c"),
+		plumbing.NewHash("c3f4688a08fd86f1bf8e055724c84b7a40a09733"),
+		plumbing.NewHash("c78874f116be67ecf54df225a613162b84cc6ebf"),
+	}
+
+	err := s.Storer.SetShallow(expected)
+	c.Assert(err, IsNil)
+
+	result, err := s.Storer.Shallow()
+	c.Assert(err, IsNil)
+	c.Assert(result, DeepEquals, expected)
 }
 
 func (s *BaseStorageSuite) TestSetConfigAndConfig(c *C) {


### PR DESCRIPTION
This PR implements the shallow storage, when a Repository is cloned using Depth != 0, the shallow commits should be saved