### PR TITLE
transport: ssh, keeping the original path

### DIFF
--- a/plumbing/transport/ssh/common.go
+++ b/plumbing/transport/ssh/common.go
@@ -117,8 +117,5 @@ func (c *command) setAuthFromEndpoint() error {
 }
 
 func endpointToCommand(cmd string, ep transport.Endpoint) string {
-	directory := ep.Path
-	directory = directory[1:]
-
-	return fmt.Sprintf("%s '%s'", cmd, directory)
+	return fmt.Sprintf("%s '%s'", cmd, ep.Path)
 }


### PR DESCRIPTION
For some reason, we where removing the initial "/" in the path, this is wrong:
- At GitHub, `/foo` and `foo` are exactly the same thing
- In a bare git server, `/foo` and `foo` not are the same thing, ending in a "Not Found repository" 

I don't know how provide a test because, this was not tested, so since I am removing "feature" don't require a test, at least as I see  