### PR TITLE
plumbing: fix signature with `>` before `<` parsing

### DIFF
--- a/plumbing/object/object.go
+++ b/plumbing/object/object.go
@@ -83,9 +83,13 @@ type Signature struct {
 
 // Decode decodes a byte slice into a signature
 func (s *Signature) Decode(b []byte) {
-	open := bytes.IndexByte(b, '<')
-	close := bytes.IndexByte(b, '>')
+	open := bytes.LastIndexByte(b, '<')
+	close := bytes.LastIndexByte(b, '>')
 	if open == -1 || close == -1 {
+		return
+	}
+
+	if close < open {
 		return
 	}
 

--- a/plumbing/object/object_test.go
+++ b/plumbing/object/object_test.go
@@ -138,6 +138,16 @@ func (s *ObjectsSuite) TestParseSignature(c *C) {
 			Email: "foo@bar.com",
 			When:  time.Time{},
 		},
+		`crap> <foo@bar.com> 1257894000 +1000`: {
+			Name:  "crap>",
+			Email: "foo@bar.com",
+			When:  MustParseTime("2009-11-11 09:00:00 +1000"),
+		},
+		`><`: {
+			Name:  "",
+			Email: "",
+			When:  time.Time{},
+		},
 		``: {
 			Name:  "",
 			Email: "",


### PR DESCRIPTION
This is a fix for issue: https://github.com/src-d/go-git/issues/202

Since the fullname is free text, given a `foo>` the result was a panic, now this is handled properly returning  `foo>` as the fullname. Another extra security guards was added to protect the function against malformed signatures.