### PR TITLE
remote: fix ErrEmptyUploadPackRequest error in fetch

### DIFF
--- a/remote.go
+++ b/remote.go
@@ -355,7 +355,8 @@ func getWants(spec []config.RefSpec, localStorer Storer, remoteRefs storer.Refer
 		}
 
 		hash := ref.Hash()
-		exists, err := commitExists(localStorer, hash)
+
+		exists, err := objectExists(localStorer, hash)
 		if err != nil {
 			return err
 		}
@@ -378,8 +379,8 @@ func getWants(spec []config.RefSpec, localStorer Storer, remoteRefs storer.Refer
 	return result, nil
 }
 
-func commitExists(s storer.EncodedObjectStorer, h plumbing.Hash) (bool, error) {
-	_, err := s.EncodedObject(plumbing.CommitObject, h)
+func objectExists(s storer.EncodedObjectStorer, h plumbing.Hash) (bool, error) {
+	_, err := s.EncodedObject(plumbing.AnyObject, h)
 	if err == plumbing.ErrObjectNotFound {
 		return false, nil
 	}

--- a/remote_test.go
+++ b/remote_test.go
@@ -171,6 +171,17 @@ func (s *RemoteSuite) TestFetchWithPackfileWriter(c *C) {
 
 func (s *RemoteSuite) TestFetchNoErrAlreadyUpToDate(c *C) {
 	url := s.GetBasicLocalRepositoryURL()
+	s.doTestFetchNoErrAlreadyUpToDate(c, url)
+}
+
+func (s *RemoteSuite) TestFetchNoErrAlreadyUpToDateWithNonCommitObjects(c *C) {
+	fixture := fixtures.ByTag("tags").One()
+	url := s.GetLocalRepositoryURL(fixture)
+	s.doTestFetchNoErrAlreadyUpToDate(c, url)
+}
+
+func (s *RemoteSuite) doTestFetchNoErrAlreadyUpToDate(c *C, url string) {
+
 	sto := memory.NewStorage()
 	r := newRemote(sto, nil, &config.RemoteConfig{Name: "foo", URL: url})
 


### PR DESCRIPTION
Fetching a repository give a error ErrEmptyUploadPackRequest. This is due to check only if the hash exists as a commit, when a reference can point to other kind of objects

Fixes: https://github.com/src-d/go-git/issues/208