### PR TITLE
update transport Command interface to support SetAuth after creation

### DIFF
--- a/options.go
+++ b/options.go
@@ -112,6 +112,8 @@ type PushOptions struct {
 	// RefSpecs specify what destination ref to update with what source
 	// object. A refspec with empty src can be used to delete a reference.
 	RefSpecs []config.RefSpec
+	// Auth credentials, if required, to use with the remote repository
+	Auth transport.AuthMethod
 }
 
 // Validate validate the fields and set the default values

--- a/options.go
+++ b/options.go
@@ -22,7 +22,7 @@ var (
 type CloneOptions struct {
 	// The (possibly remote) repository URL to clone from
 	URL string
-	// Auth credentials, if required, to uses with the remote repository
+	// Auth credentials, if required, to use with the remote repository
 	Auth transport.AuthMethod
 	// Name of the remote to be added, by default `origin`
 	RemoteName string
@@ -61,6 +61,8 @@ type PullOptions struct {
 	SingleBranch bool
 	// Limit fetching to the specified number of commits.
 	Depth int
+	// Auth credentials, if required, to use with the remote repository
+	Auth transport.AuthMethod
 }
 
 // Validate validate the fields and set the default values.
@@ -84,6 +86,8 @@ type FetchOptions struct {
 	// Depth limit fetching to the specified number of commits from the tip of
 	// each remote branch history.
 	Depth int
+	// Auth credentials, if required, to use with the remote repository
+	Auth transport.AuthMethod
 }
 
 // Validate validate the fields and set the default values

--- a/plumbing/transport/client/client_test.go
+++ b/plumbing/transport/client/client_test.go
@@ -58,12 +58,12 @@ type dummyClient struct {
 	*http.Client
 }
 
-func (*dummyClient) NewUploadPackSession(transport.Endpoint) (
+func (*dummyClient) NewUploadPackSession(transport.Endpoint, transport.AuthMethod) (
 	transport.UploadPackSession, error) {
 	return nil, nil
 }
 
-func (*dummyClient) NewReceivePackSession(transport.Endpoint) (
+func (*dummyClient) NewReceivePackSession(transport.Endpoint, transport.AuthMethod) (
 	transport.ReceivePackSession, error) {
 	return nil, nil
 }

--- a/plumbing/transport/common.go
+++ b/plumbing/transport/common.go
@@ -30,6 +30,7 @@ var (
 	ErrAuthorizationRequired  = errors.New("authorization required")
 	ErrEmptyUploadPackRequest = errors.New("empty git-upload-pack given")
 	ErrInvalidAuthMethod      = errors.New("invalid auth method")
+	ErrAlreadyConnected       = errors.New("session already established")
 )
 
 const (

--- a/plumbing/transport/common.go
+++ b/plumbing/transport/common.go
@@ -42,9 +42,9 @@ const (
 // It is implemented both by the client and the server, making this a RPC.
 type Transport interface {
 	// NewUploadPackSession starts a git-upload-pack session for an endpoint.
-	NewUploadPackSession(Endpoint) (UploadPackSession, error)
+	NewUploadPackSession(Endpoint, AuthMethod) (UploadPackSession, error)
 	// NewReceivePackSession starts a git-receive-pack session for an endpoint.
-	NewReceivePackSession(Endpoint) (ReceivePackSession, error)
+	NewReceivePackSession(Endpoint, AuthMethod) (ReceivePackSession, error)
 }
 
 type Session interface {
@@ -53,8 +53,6 @@ type Session interface {
 	// If the repository does not exist, returns ErrRepositoryNotFound.
 	// If the repository exists, but is empty, returns ErrEmptyRemoteRepository.
 	AdvertisedReferences() (*packp.AdvRefs, error)
-	//TODO: Move to Client level.
-	SetAuth(auth AuthMethod) error
 	io.Closer
 }
 

--- a/plumbing/transport/file/client.go
+++ b/plumbing/transport/file/client.go
@@ -35,6 +35,11 @@ func (r *runner) Command(cmd string, ep transport.Endpoint) (common.Command, err
 	case transport.ReceivePackServiceName:
 		cmd = r.ReceivePackBin
 	}
+
+	if _, err := exec.LookPath(cmd); err != nil {
+		return nil, err
+	}
+
 	return &command{cmd: exec.Command(cmd, ep.Path)}, nil
 }
 
@@ -48,6 +53,11 @@ func (c *command) SetAuth(auth transport.AuthMethod) error {
 		return transport.ErrInvalidAuthMethod
 	}
 
+	return nil
+}
+
+func (c *command) Connect() error {
+	// the file transport requires no network connectivity
 	return nil
 }
 

--- a/plumbing/transport/file/client.go
+++ b/plumbing/transport/file/client.go
@@ -28,7 +28,7 @@ func NewClient(uploadPackBin, receivePackBin string) transport.Transport {
 	})
 }
 
-func (r *runner) Command(cmd string, ep transport.Endpoint) (common.Command, error) {
+func (r *runner) Command(cmd string, ep transport.Endpoint, auth transport.AuthMethod) (common.Command, error) {
 	switch cmd {
 	case transport.UploadPackServiceName:
 		cmd = r.UploadPackBin
@@ -46,19 +46,6 @@ func (r *runner) Command(cmd string, ep transport.Endpoint) (common.Command, err
 type command struct {
 	cmd    *exec.Cmd
 	closed bool
-}
-
-func (c *command) SetAuth(auth transport.AuthMethod) error {
-	if auth != nil {
-		return transport.ErrInvalidAuthMethod
-	}
-
-	return nil
-}
-
-func (c *command) Connect() error {
-	// the file transport requires no network connectivity
-	return nil
 }
 
 func (c *command) Start() error {

--- a/plumbing/transport/file/receive_pack_test.go
+++ b/plumbing/transport/file/receive_pack_test.go
@@ -46,7 +46,7 @@ func (s *ReceivePackSuite) TestCommandNoOutput(c *C) {
 	}
 
 	client := NewClient("true", "true")
-	session, err := client.NewReceivePackSession(s.Endpoint)
+	session, err := client.NewReceivePackSession(s.Endpoint, s.EmptyAuth)
 	c.Assert(err, IsNil)
 	ar, err := session.AdvertisedReferences()
 	c.Assert(err, IsNil)
@@ -59,7 +59,7 @@ func (s *ReceivePackSuite) TestMalformedInputNoErrors(c *C) {
 	}
 
 	client := NewClient("yes", "yes")
-	session, err := client.NewReceivePackSession(s.Endpoint)
+	session, err := client.NewReceivePackSession(s.Endpoint, s.EmptyAuth)
 	c.Assert(err, IsNil)
 	ar, err := session.AdvertisedReferences()
 	c.Assert(err, NotNil)
@@ -69,7 +69,7 @@ func (s *ReceivePackSuite) TestMalformedInputNoErrors(c *C) {
 func (s *ReceivePackSuite) TestNonExistentCommand(c *C) {
 	cmd := "/non-existent-git"
 	client := NewClient(cmd, cmd)
-	session, err := client.NewReceivePackSession(s.Endpoint)
+	session, err := client.NewReceivePackSession(s.Endpoint, s.EmptyAuth)
 	c.Assert(err, ErrorMatches, ".*no such file or directory.*")
 	c.Assert(session, IsNil)
 }

--- a/plumbing/transport/file/server.go
+++ b/plumbing/transport/file/server.go
@@ -19,7 +19,8 @@ func ServeUploadPack(path string) error {
 		return err
 	}
 
-	s, err := server.DefaultServer.NewUploadPackSession(ep)
+	// TODO: define and implement a server-side AuthMethod
+	s, err := server.DefaultServer.NewUploadPackSession(ep, nil)
 	if err != nil {
 		return fmt.Errorf("error creating session: %s", err)
 	}
@@ -36,7 +37,8 @@ func ServeReceivePack(path string) error {
 		return err
 	}
 
-	s, err := server.DefaultServer.NewReceivePackSession(ep)
+	// TODO: define and implement a server-side AuthMethod
+	s, err := server.DefaultServer.NewReceivePackSession(ep, nil)
 	if err != nil {
 		return fmt.Errorf("error creating session: %s", err)
 	}

--- a/plumbing/transport/file/upload_pack_test.go
+++ b/plumbing/transport/file/upload_pack_test.go
@@ -52,7 +52,7 @@ func (s *UploadPackSuite) TestCommandNoOutput(c *C) {
 	}
 
 	client := NewClient("true", "true")
-	session, err := client.NewUploadPackSession(s.Endpoint)
+	session, err := client.NewUploadPackSession(s.Endpoint, s.EmptyAuth)
 	c.Assert(err, IsNil)
 	ar, err := session.AdvertisedReferences()
 	c.Assert(err, IsNil)
@@ -65,7 +65,7 @@ func (s *UploadPackSuite) TestMalformedInputNoErrors(c *C) {
 	}
 
 	client := NewClient("yes", "yes")
-	session, err := client.NewUploadPackSession(s.Endpoint)
+	session, err := client.NewUploadPackSession(s.Endpoint, s.EmptyAuth)
 	c.Assert(err, IsNil)
 	ar, err := session.AdvertisedReferences()
 	c.Assert(err, NotNil)
@@ -75,7 +75,7 @@ func (s *UploadPackSuite) TestMalformedInputNoErrors(c *C) {
 func (s *UploadPackSuite) TestNonExistentCommand(c *C) {
 	cmd := "/non-existent-git"
 	client := NewClient(cmd, cmd)
-	session, err := client.NewUploadPackSession(s.Endpoint)
+	session, err := client.NewUploadPackSession(s.Endpoint, s.EmptyAuth)
 	c.Assert(err, ErrorMatches, ".*no such file or directory.*")
 	c.Assert(session, IsNil)
 }

--- a/plumbing/transport/git/common.go
+++ b/plumbing/transport/git/common.go
@@ -1,7 +1,6 @@
 package git
 
 import (
-	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -13,10 +12,6 @@ import (
 	"gopkg.in/src-d/go-git.v4/utils/ioutil"
 )
 
-var (
-	errAlreadyConnected = errors.New("tcp connection already connected")
-)
-
 // DefaultClient is the default git client.
 var DefaultClient = common.NewClient(&runner{})
 
@@ -24,12 +19,7 @@ type runner struct{}
 
 // Command returns a new Command for the given cmd in the given Endpoint
 func (r *runner) Command(cmd string, ep transport.Endpoint) (common.Command, error) {
-	c := &command{command: cmd, endpoint: ep}
-	if err := c.connect(); err != nil {
-		return nil, err
-	}
-
-	return c, nil
+	return &command{command: cmd, endpoint: ep}, nil
 }
 
 type command struct {
@@ -52,9 +42,9 @@ func (c *command) Start() error {
 	return e.Encode([]byte(cmd))
 }
 
-func (c *command) connect() error {
+func (c *command) Connect() error {
 	if c.connected {
-		return errAlreadyConnected
+		return transport.ErrAlreadyConnected
 	}
 
 	var err error

--- a/plumbing/transport/http/common.go
+++ b/plumbing/transport/http/common.go
@@ -35,16 +35,16 @@ func NewClient(c *http.Client) transport.Transport {
 	}
 }
 
-func (c *client) NewUploadPackSession(ep transport.Endpoint) (
+func (c *client) NewUploadPackSession(ep transport.Endpoint, auth transport.AuthMethod) (
 	transport.UploadPackSession, error) {
 
-	return newUploadPackSession(c.c, ep), nil
+	return newUploadPackSession(c.c, ep, auth)
 }
 
-func (c *client) NewReceivePackSession(ep transport.Endpoint) (
+func (c *client) NewReceivePackSession(ep transport.Endpoint, auth transport.AuthMethod) (
 	transport.ReceivePackSession, error) {
 
-	return newReceivePackSession(c.c, ep), nil
+	return newReceivePackSession(c.c, ep, auth)
 }
 
 type session struct {
@@ -52,16 +52,6 @@ type session struct {
 	client   *http.Client
 	endpoint transport.Endpoint
 	advRefs  *packp.AdvRefs
-}
-
-func (s *session) SetAuth(auth transport.AuthMethod) error {
-	a, ok := auth.(AuthMethod)
-	if !ok {
-		return transport.ErrInvalidAuthMethod
-	}
-
-	s.auth = a
-	return nil
 }
 
 func (*session) Close() error {

--- a/plumbing/transport/http/common_test.go
+++ b/plumbing/transport/http/common_test.go
@@ -13,7 +13,8 @@ import (
 func Test(t *testing.T) { TestingT(t) }
 
 type ClientSuite struct {
-	Endpoint transport.Endpoint
+	Endpoint  transport.Endpoint
+	EmptyAuth transport.AuthMethod
 }
 
 var _ = Suite(&ClientSuite{})
@@ -76,9 +77,8 @@ func (s *ClientSuite) testNewHTTPError(c *C, code int, msg string) {
 
 func (s *ClientSuite) TestSetAuth(c *C) {
 	auth := &BasicAuth{}
-	r, err := DefaultClient.NewUploadPackSession(s.Endpoint)
+	r, err := DefaultClient.NewUploadPackSession(s.Endpoint, auth)
 	c.Assert(err, IsNil)
-	r.SetAuth(auth)
 	c.Assert(auth, Equals, r.(*upSession).auth)
 }
 
@@ -88,7 +88,6 @@ func (*mockAuth) Name() string   { return "" }
 func (*mockAuth) String() string { return "" }
 
 func (s *ClientSuite) TestSetAuthWrongType(c *C) {
-	r, err := DefaultClient.NewUploadPackSession(s.Endpoint)
-	c.Assert(err, IsNil)
-	c.Assert(r.SetAuth(&mockAuth{}), Equals, transport.ErrInvalidAuthMethod)
+	_, err := DefaultClient.NewUploadPackSession(s.Endpoint, &mockAuth{})
+	c.Assert(err, Equals, transport.ErrInvalidAuthMethod)
 }

--- a/plumbing/transport/http/receive_pack.go
+++ b/plumbing/transport/http/receive_pack.go
@@ -14,8 +14,8 @@ type rpSession struct {
 	*session
 }
 
-func newReceivePackSession(c *http.Client, ep transport.Endpoint) transport.ReceivePackSession {
-	return &rpSession{&session{}}
+func newReceivePackSession(c *http.Client, ep transport.Endpoint, auth transport.AuthMethod) (transport.ReceivePackSession, error) {
+	return &rpSession{&session{}}, nil
 }
 
 func (s *rpSession) AdvertisedReferences() (*packp.AdvRefs, error) {

--- a/plumbing/transport/http/upload_pack.go
+++ b/plumbing/transport/http/upload_pack.go
@@ -19,16 +19,22 @@ type upSession struct {
 	*session
 }
 
-func newUploadPackSession(c *http.Client,
-	ep transport.Endpoint) transport.UploadPackSession {
-
-	return &upSession{
-		session: &session{
-			auth:     basicAuthFromEndpoint(ep),
-			client:   c,
-			endpoint: ep,
-		},
+func newUploadPackSession(c *http.Client, ep transport.Endpoint, auth transport.AuthMethod) (transport.UploadPackSession, error) {
+	s := &session{
+		auth:     basicAuthFromEndpoint(ep),
+		client:   c,
+		endpoint: ep,
 	}
+	if auth != nil {
+		a, ok := auth.(AuthMethod)
+		if !ok {
+			return nil, transport.ErrInvalidAuthMethod
+		}
+
+		s.auth = a
+	}
+
+	return &upSession{session: s}, nil
 }
 
 func (s *upSession) AdvertisedReferences() (*packp.AdvRefs, error) {

--- a/plumbing/transport/http/upload_pack_test.go
+++ b/plumbing/transport/http/upload_pack_test.go
@@ -35,7 +35,7 @@ func (s *UploadPackSuite) SetUpSuite(c *C) {
 
 // Overwritten, different behaviour for HTTP.
 func (s *UploadPackSuite) TestAdvertisedReferencesNotExists(c *C) {
-	r, err := s.Client.NewUploadPackSession(s.NonExistentEndpoint)
+	r, err := s.Client.NewUploadPackSession(s.NonExistentEndpoint, s.EmptyAuth)
 	c.Assert(err, IsNil)
 	info, err := r.AdvertisedReferences()
 	c.Assert(err, Equals, transport.ErrAuthorizationRequired)

--- a/plumbing/transport/server/receive_pack_test.go
+++ b/plumbing/transport/server/receive_pack_test.go
@@ -34,7 +34,7 @@ func (s *ReceivePackSuite) TestSendPackAddDeleteReference(c *C) {
 
 // Overwritten, server returns error earlier.
 func (s *ReceivePackSuite) TestAdvertisedReferencesNotExists(c *C) {
-	r, err := s.Client.NewReceivePackSession(s.NonExistentEndpoint)
+	r, err := s.Client.NewReceivePackSession(s.NonExistentEndpoint, s.EmptyAuth)
 	c.Assert(err, Equals, transport.ErrRepositoryNotFound)
 	c.Assert(r, IsNil)
 }

--- a/plumbing/transport/server/server.go
+++ b/plumbing/transport/server/server.go
@@ -30,7 +30,7 @@ func NewServer(loader Loader) transport.Transport {
 	return &server{loader, &handler{}}
 }
 
-func (s *server) NewUploadPackSession(ep transport.Endpoint) (transport.UploadPackSession, error) {
+func (s *server) NewUploadPackSession(ep transport.Endpoint, auth transport.AuthMethod) (transport.UploadPackSession, error) {
 	sto, err := s.loader.Load(ep)
 	if err != nil {
 		return nil, err
@@ -39,7 +39,7 @@ func (s *server) NewUploadPackSession(ep transport.Endpoint) (transport.UploadPa
 	return s.handler.NewUploadPackSession(sto)
 }
 
-func (s *server) NewReceivePackSession(ep transport.Endpoint) (transport.ReceivePackSession, error) {
+func (s *server) NewReceivePackSession(ep transport.Endpoint, auth transport.AuthMethod) (transport.ReceivePackSession, error) {
 	sto, err := s.loader.Load(ep)
 	if err != nil {
 		return nil, err

--- a/plumbing/transport/server/upload_pack_test.go
+++ b/plumbing/transport/server/upload_pack_test.go
@@ -25,7 +25,7 @@ func (s *UploadPackSuite) SetUpTest(c *C) {
 
 // Overwritten, it's not an error in server-side.
 func (s *UploadPackSuite) TestAdvertisedReferencesEmpty(c *C) {
-	r, err := s.Client.NewUploadPackSession(s.EmptyEndpoint)
+	r, err := s.Client.NewUploadPackSession(s.EmptyEndpoint, s.EmptyAuth)
 	c.Assert(err, IsNil)
 	ar, err := r.AdvertisedReferences()
 	c.Assert(err, IsNil)
@@ -34,7 +34,7 @@ func (s *UploadPackSuite) TestAdvertisedReferencesEmpty(c *C) {
 
 // Overwritten, server returns error earlier.
 func (s *UploadPackSuite) TestAdvertisedReferencesNotExists(c *C) {
-	r, err := s.Client.NewUploadPackSession(s.NonExistentEndpoint)
+	r, err := s.Client.NewUploadPackSession(s.NonExistentEndpoint, s.EmptyAuth)
 	c.Assert(err, Equals, transport.ErrRepositoryNotFound)
 	c.Assert(r, IsNil)
 }

--- a/plumbing/transport/test/receive_pack.go
+++ b/plumbing/transport/test/receive_pack.go
@@ -23,11 +23,12 @@ type ReceivePackSuite struct {
 	Endpoint            transport.Endpoint
 	EmptyEndpoint       transport.Endpoint
 	NonExistentEndpoint transport.Endpoint
+	EmptyAuth           transport.AuthMethod
 	Client              transport.Transport
 }
 
 func (s *ReceivePackSuite) TestAdvertisedReferencesEmpty(c *C) {
-	r, err := s.Client.NewReceivePackSession(s.EmptyEndpoint)
+	r, err := s.Client.NewReceivePackSession(s.EmptyEndpoint, s.EmptyAuth)
 	c.Assert(err, IsNil)
 	defer func() { c.Assert(r.Close(), IsNil) }()
 	ar, err := r.AdvertisedReferences()
@@ -36,14 +37,14 @@ func (s *ReceivePackSuite) TestAdvertisedReferencesEmpty(c *C) {
 }
 
 func (s *ReceivePackSuite) TestAdvertisedReferencesNotExists(c *C) {
-	r, err := s.Client.NewReceivePackSession(s.NonExistentEndpoint)
+	r, err := s.Client.NewReceivePackSession(s.NonExistentEndpoint, s.EmptyAuth)
 	c.Assert(err, IsNil)
 	defer func() { c.Assert(r.Close(), IsNil) }()
 	ar, err := r.AdvertisedReferences()
 	c.Assert(err, Equals, transport.ErrRepositoryNotFound)
 	c.Assert(ar, IsNil)
 
-	r, err = s.Client.NewReceivePackSession(s.NonExistentEndpoint)
+	r, err = s.Client.NewReceivePackSession(s.NonExistentEndpoint, s.EmptyAuth)
 	c.Assert(err, IsNil)
 	req := packp.NewReferenceUpdateRequest()
 	req.Commands = []*packp.Command{
@@ -56,7 +57,7 @@ func (s *ReceivePackSuite) TestAdvertisedReferencesNotExists(c *C) {
 }
 
 func (s *ReceivePackSuite) TestCallAdvertisedReferenceTwice(c *C) {
-	r, err := s.Client.NewReceivePackSession(s.Endpoint)
+	r, err := s.Client.NewReceivePackSession(s.Endpoint, s.EmptyAuth)
 	c.Assert(err, IsNil)
 	ar1, err := r.AdvertisedReferences()
 	c.Assert(err, IsNil)
@@ -67,7 +68,7 @@ func (s *ReceivePackSuite) TestCallAdvertisedReferenceTwice(c *C) {
 }
 
 func (s *ReceivePackSuite) TestDefaultBranch(c *C) {
-	r, err := s.Client.NewReceivePackSession(s.Endpoint)
+	r, err := s.Client.NewReceivePackSession(s.Endpoint, s.EmptyAuth)
 	c.Assert(err, IsNil)
 	defer func() { c.Assert(r.Close(), IsNil) }()
 
@@ -79,7 +80,7 @@ func (s *ReceivePackSuite) TestDefaultBranch(c *C) {
 }
 
 func (s *ReceivePackSuite) TestCapabilities(c *C) {
-	r, err := s.Client.NewReceivePackSession(s.Endpoint)
+	r, err := s.Client.NewReceivePackSession(s.Endpoint, s.EmptyAuth)
 	c.Assert(err, IsNil)
 	defer func() { c.Assert(r.Close(), IsNil) }()
 
@@ -196,7 +197,7 @@ func (s *ReceivePackSuite) receivePackNoCheck(c *C, ep transport.Endpoint,
 		ep.String(), url, callAdvertisedReferences,
 	)
 
-	r, err := s.Client.NewReceivePackSession(ep)
+	r, err := s.Client.NewReceivePackSession(ep, s.EmptyAuth)
 	c.Assert(err, IsNil, comment)
 	defer func() { c.Assert(r.Close(), IsNil, comment) }()
 
@@ -247,7 +248,7 @@ func (s *ReceivePackSuite) checkRemoteHead(c *C, ep transport.Endpoint, head plu
 func (s *ReceivePackSuite) checkRemoteReference(c *C, ep transport.Endpoint,
 	refName string, head plumbing.Hash) {
 
-	r, err := s.Client.NewUploadPackSession(ep)
+	r, err := s.Client.NewUploadPackSession(ep, s.EmptyAuth)
 	c.Assert(err, IsNil)
 	defer func() { c.Assert(r.Close(), IsNil) }()
 	ar, err := r.AdvertisedReferences()
@@ -267,7 +268,7 @@ func (s *ReceivePackSuite) TestSendPackAddDeleteReference(c *C) {
 }
 
 func (s *ReceivePackSuite) testSendPackAddReference(c *C) {
-	r, err := s.Client.NewReceivePackSession(s.Endpoint)
+	r, err := s.Client.NewReceivePackSession(s.Endpoint, s.EmptyAuth)
 	c.Assert(err, IsNil)
 	defer func() { c.Assert(r.Close(), IsNil) }()
 
@@ -289,7 +290,7 @@ func (s *ReceivePackSuite) testSendPackAddReference(c *C) {
 }
 
 func (s *ReceivePackSuite) testSendPackDeleteReference(c *C) {
-	r, err := s.Client.NewReceivePackSession(s.Endpoint)
+	r, err := s.Client.NewReceivePackSession(s.Endpoint, s.EmptyAuth)
 	c.Assert(err, IsNil)
 	defer func() { c.Assert(r.Close(), IsNil) }()
 

--- a/plumbing/transport/test/upload_pack.go
+++ b/plumbing/transport/test/upload_pack.go
@@ -22,11 +22,12 @@ type UploadPackSuite struct {
 	Endpoint            transport.Endpoint
 	EmptyEndpoint       transport.Endpoint
 	NonExistentEndpoint transport.Endpoint
+	EmptyAuth           transport.AuthMethod
 	Client              transport.Transport
 }
 
 func (s *UploadPackSuite) TestAdvertisedReferencesEmpty(c *C) {
-	r, err := s.Client.NewUploadPackSession(s.EmptyEndpoint)
+	r, err := s.Client.NewUploadPackSession(s.EmptyEndpoint, s.EmptyAuth)
 	c.Assert(err, IsNil)
 	ar, err := r.AdvertisedReferences()
 	c.Assert(err, Equals, transport.ErrEmptyRemoteRepository)
@@ -34,13 +35,13 @@ func (s *UploadPackSuite) TestAdvertisedReferencesEmpty(c *C) {
 }
 
 func (s *UploadPackSuite) TestAdvertisedReferencesNotExists(c *C) {
-	r, err := s.Client.NewUploadPackSession(s.NonExistentEndpoint)
+	r, err := s.Client.NewUploadPackSession(s.NonExistentEndpoint, s.EmptyAuth)
 	c.Assert(err, IsNil)
 	ar, err := r.AdvertisedReferences()
 	c.Assert(err, Equals, transport.ErrRepositoryNotFound)
 	c.Assert(ar, IsNil)
 
-	r, err = s.Client.NewUploadPackSession(s.NonExistentEndpoint)
+	r, err = s.Client.NewUploadPackSession(s.NonExistentEndpoint, s.EmptyAuth)
 	c.Assert(err, IsNil)
 	req := packp.NewUploadPackRequest()
 	req.Wants = append(req.Wants, plumbing.NewHash("6ecf0ef2c2dffb796033e5a02219af86ec6584e5"))
@@ -50,7 +51,7 @@ func (s *UploadPackSuite) TestAdvertisedReferencesNotExists(c *C) {
 }
 
 func (s *UploadPackSuite) TestCallAdvertisedReferenceTwice(c *C) {
-	r, err := s.Client.NewUploadPackSession(s.Endpoint)
+	r, err := s.Client.NewUploadPackSession(s.Endpoint, s.EmptyAuth)
 	c.Assert(err, IsNil)
 	ar1, err := r.AdvertisedReferences()
 	c.Assert(err, IsNil)
@@ -61,7 +62,7 @@ func (s *UploadPackSuite) TestCallAdvertisedReferenceTwice(c *C) {
 }
 
 func (s *UploadPackSuite) TestDefaultBranch(c *C) {
-	r, err := s.Client.NewUploadPackSession(s.Endpoint)
+	r, err := s.Client.NewUploadPackSession(s.Endpoint, s.EmptyAuth)
 	c.Assert(err, IsNil)
 	defer func() { c.Assert(r.Close(), IsNil) }()
 
@@ -73,7 +74,7 @@ func (s *UploadPackSuite) TestDefaultBranch(c *C) {
 }
 
 func (s *UploadPackSuite) TestAdvertisedReferencesFilterUnsupported(c *C) {
-	r, err := s.Client.NewUploadPackSession(s.Endpoint)
+	r, err := s.Client.NewUploadPackSession(s.Endpoint, s.EmptyAuth)
 	c.Assert(err, IsNil)
 	defer func() { c.Assert(r.Close(), IsNil) }()
 
@@ -83,7 +84,7 @@ func (s *UploadPackSuite) TestAdvertisedReferencesFilterUnsupported(c *C) {
 }
 
 func (s *UploadPackSuite) TestCapabilities(c *C) {
-	r, err := s.Client.NewUploadPackSession(s.Endpoint)
+	r, err := s.Client.NewUploadPackSession(s.Endpoint, s.EmptyAuth)
 	c.Assert(err, IsNil)
 	defer func() { c.Assert(r.Close(), IsNil) }()
 
@@ -93,7 +94,7 @@ func (s *UploadPackSuite) TestCapabilities(c *C) {
 }
 
 func (s *UploadPackSuite) TestFullUploadPack(c *C) {
-	r, err := s.Client.NewUploadPackSession(s.Endpoint)
+	r, err := s.Client.NewUploadPackSession(s.Endpoint, s.EmptyAuth)
 	c.Assert(err, IsNil)
 	defer func() { c.Assert(r.Close(), IsNil) }()
 
@@ -111,7 +112,7 @@ func (s *UploadPackSuite) TestFullUploadPack(c *C) {
 }
 
 func (s *UploadPackSuite) TestUploadPack(c *C) {
-	r, err := s.Client.NewUploadPackSession(s.Endpoint)
+	r, err := s.Client.NewUploadPackSession(s.Endpoint, s.EmptyAuth)
 	c.Assert(err, IsNil)
 	defer func() { c.Assert(r.Close(), IsNil) }()
 
@@ -125,7 +126,7 @@ func (s *UploadPackSuite) TestUploadPack(c *C) {
 }
 
 func (s *UploadPackSuite) TestUploadPackInvalidReq(c *C) {
-	r, err := s.Client.NewUploadPackSession(s.Endpoint)
+	r, err := s.Client.NewUploadPackSession(s.Endpoint, s.EmptyAuth)
 	c.Assert(err, IsNil)
 	defer func() { c.Assert(r.Close(), IsNil) }()
 
@@ -139,7 +140,7 @@ func (s *UploadPackSuite) TestUploadPackInvalidReq(c *C) {
 }
 
 func (s *UploadPackSuite) TestUploadPackNoChanges(c *C) {
-	r, err := s.Client.NewUploadPackSession(s.Endpoint)
+	r, err := s.Client.NewUploadPackSession(s.Endpoint, s.EmptyAuth)
 	c.Assert(err, IsNil)
 	defer func() { c.Assert(r.Close(), IsNil) }()
 
@@ -153,7 +154,7 @@ func (s *UploadPackSuite) TestUploadPackNoChanges(c *C) {
 }
 
 func (s *UploadPackSuite) TestUploadPackMulti(c *C) {
-	r, err := s.Client.NewUploadPackSession(s.Endpoint)
+	r, err := s.Client.NewUploadPackSession(s.Endpoint, s.EmptyAuth)
 	c.Assert(err, IsNil)
 	defer func() { c.Assert(r.Close(), IsNil) }()
 
@@ -168,7 +169,7 @@ func (s *UploadPackSuite) TestUploadPackMulti(c *C) {
 }
 
 func (s *UploadPackSuite) TestFetchError(c *C) {
-	r, err := s.Client.NewUploadPackSession(s.Endpoint)
+	r, err := s.Client.NewUploadPackSession(s.Endpoint, s.EmptyAuth)
 	c.Assert(err, IsNil)
 
 	req := packp.NewUploadPackRequest()

--- a/remote.go
+++ b/remote.go
@@ -72,7 +72,7 @@ func (r *Remote) Push(o *PushOptions) (err error) {
 		return fmt.Errorf("remote names don't match: %s != %s", o.RemoteName, r.c.Name)
 	}
 
-	s, err := newSendPackSession(r.c.URL)
+	s, err := newSendPackSession(r.c.URL, o.Auth)
 	if err != nil {
 		return err
 	}
@@ -132,13 +132,9 @@ func (r *Remote) fetch(o *FetchOptions) (refs storer.ReferenceStorer, err error)
 		o.RefSpecs = r.c.Fetch
 	}
 
-	s, err := newUploadPackSession(r.c.URL)
+	s, err := newUploadPackSession(r.c.URL, o.Auth)
 	if err != nil {
 		return nil, err
-	}
-
-	if o.Auth != nil {
-		s.SetAuth(o.Auth)
 	}
 
 	defer ioutil.CheckClose(s, &err)
@@ -179,22 +175,22 @@ func (r *Remote) fetch(o *FetchOptions) (refs storer.ReferenceStorer, err error)
 	return remoteRefs, err
 }
 
-func newUploadPackSession(url string) (transport.UploadPackSession, error) {
+func newUploadPackSession(url string, auth transport.AuthMethod) (transport.UploadPackSession, error) {
 	c, ep, err := newClient(url)
 	if err != nil {
 		return nil, err
 	}
 
-	return c.NewUploadPackSession(ep)
+	return c.NewUploadPackSession(ep, auth)
 }
 
-func newSendPackSession(url string) (transport.ReceivePackSession, error) {
+func newSendPackSession(url string, auth transport.AuthMethod) (transport.ReceivePackSession, error) {
 	c, ep, err := newClient(url)
 	if err != nil {
 		return nil, err
 	}
 
-	return c.NewReceivePackSession(ep)
+	return c.NewReceivePackSession(ep, auth)
 }
 
 func newClient(url string) (transport.Transport, transport.Endpoint, error) {

--- a/remote.go
+++ b/remote.go
@@ -137,6 +137,10 @@ func (r *Remote) fetch(o *FetchOptions) (refs storer.ReferenceStorer, err error)
 		return nil, err
 	}
 
+	if o.Auth != nil {
+		s.SetAuth(o.Auth)
+	}
+
 	defer ioutil.CheckClose(s, &err)
 
 	ar, err := s.AdvertisedReferences()

--- a/repository.go
+++ b/repository.go
@@ -168,6 +168,7 @@ func (r *Repository) Clone(o *CloneOptions) error {
 	remoteRefs, err := remote.fetch(&FetchOptions{
 		RefSpecs: r.cloneRefSpec(o, c),
 		Depth:    o.Depth,
+		Auth:     o.Auth,
 	})
 	if err != nil {
 		return err
@@ -321,6 +322,7 @@ func (r *Repository) Pull(o *PullOptions) error {
 
 	remoteRefs, err := remote.fetch(&FetchOptions{
 		Depth: o.Depth,
+		Auth:  o.Auth,
 	})
 	if err != nil {
 		return err


### PR DESCRIPTION
Reworks `Command` interface to split the session creation into two components: general object create & session connect. This allows an external caller to create the session, call `SetAuth()`, and **then** perform the network connection. This network connection is "baked" in to the other interface functions to keep the external interface the same.

Addresses #206.