### PR TITLE
blame: make line types and its fields public so they can be actually used

### DIFF
--- a/blame.go
+++ b/blame.go
@@ -16,7 +16,7 @@ import (
 type BlameResult struct {
 	Path  string
 	Rev   plumbing.Hash
-	Lines []*line
+	Lines []*Line
 }
 
 // Blame returns the last commit that modified each line of a file in a
@@ -100,23 +100,24 @@ func Blame(c *object.Commit, path string) (*BlameResult, error) {
 	}, nil
 }
 
-type line struct {
-	author string
-	text   string
+// Line values represent the contents and author of a line in BlamedResult values.
+type Line struct {
+	Author string // email address of the author of the line.
+	Text   string // original text of the line.
 }
 
-func newLine(author, text string) *line {
-	return &line{
-		author: author,
-		text:   text,
+func newLine(author, text string) *Line {
+	return &Line{
+		Author: author,
+		Text:   text,
 	}
 }
 
-func newLines(contents []string, commits []*object.Commit) ([]*line, error) {
+func newLines(contents []string, commits []*object.Commit) ([]*Line, error) {
 	if len(contents) != len(commits) {
 		return nil, errors.New("contents and commits have different length")
 	}
-	result := make([]*line, 0, len(contents))
+	result := make([]*Line, 0, len(contents))
 	for i := range contents {
 		l := newLine(commits[i].Author.Email, contents[i])
 		result = append(result, l)

--- a/blame_test.go
+++ b/blame_test.go
@@ -46,13 +46,13 @@ func (s *BlameSuite) mockBlame(c *C, t blameTest, r *Repository) (blame *BlameRe
 	c.Assert(len(t.blames), Equals, len(lines), Commentf(
 		"repo=%s, path=%s, rev=%s: the number of lines in the file and the number of expected blames differ (len(blames)=%d, len(lines)=%d)\nblames=%#q\nlines=%#q", t.repo, t.path, t.rev, len(t.blames), len(lines), t.blames, lines))
 
-	blamedLines := make([]*line, 0, len(t.blames))
+	blamedLines := make([]*Line, 0, len(t.blames))
 	for i := range t.blames {
 		commit, err := r.Commit(plumbing.NewHash(t.blames[i]))
 		c.Assert(err, IsNil)
-		l := &line{
-			author: commit.Author.Email,
-			text:   lines[i],
+		l := &Line{
+			Author: commit.Author.Email,
+			Text:   lines[i],
 		}
 		blamedLines = append(blamedLines, l)
 	}


### PR DESCRIPTION
In #211 @olivierbeaulieu noticed the line type is not public, so it is not actually very useful.

This fix makes line and its members public so they can be actually used.