### PR TITLE
adds Tree method to Tree

### DIFF
--- a/plumbing/object/tree.go
+++ b/plumbing/object/tree.go
@@ -77,7 +77,7 @@ func (t *Tree) File(path string) (*File, error) {
 
 	blob, err := GetBlob(t.s, e.Hash)
 	if err != nil {
-		return nil, err
+		return nil, ErrFileNotFound
 	}
 
 	return NewFile(path, e.Mode, blob), nil
@@ -91,7 +91,12 @@ func (t *Tree) Tree(path string) (*Tree, error) {
 		return nil, ErrDirectoryNotFound
 	}
 
-	return GetTree(t.s, e.Hash)
+	ret, err := GetTree(t.s, e.Hash)
+	if err != nil {
+		return nil, ErrDirectoryNotFound
+	}
+
+	return ret, nil
 }
 
 // TreeEntryFile returns the *File for a given *TreeEntry.

--- a/plumbing/object/tree.go
+++ b/plumbing/object/tree.go
@@ -24,8 +24,9 @@ const (
 
 // New errors defined by this package.
 var (
-	ErrMaxTreeDepth = errors.New("maximum tree depth exceeded")
-	ErrFileNotFound = errors.New("file not found")
+	ErrMaxTreeDepth      = errors.New("maximum tree depth exceeded")
+	ErrFileNotFound      = errors.New("file not found")
+	ErrDirectoryNotFound = errors.New("directory not found")
 )
 
 // Tree is basically like a directory - it references a bunch of other trees
@@ -80,6 +81,17 @@ func (t *Tree) File(path string) (*File, error) {
 	}
 
 	return NewFile(path, e.Mode, blob), nil
+}
+
+// Tree returns the tree identified by the `path` argument.
+// The path is interpreted as relative to the tree receiver.
+func (t *Tree) Tree(path string) (*Tree, error) {
+	e, err := t.findEntry(path)
+	if err != nil {
+		return nil, ErrDirectoryNotFound
+	}
+
+	return GetTree(t.s, e.Hash)
 }
 
 // TreeEntryFile returns the *File for a given *TreeEntry.

--- a/plumbing/object/tree.go
+++ b/plumbing/object/tree.go
@@ -77,7 +77,10 @@ func (t *Tree) File(path string) (*File, error) {
 
 	blob, err := GetBlob(t.s, e.Hash)
 	if err != nil {
-		return nil, ErrFileNotFound
+		if err == plumbing.ErrObjectNotFound {
+			return nil, ErrFileNotFound
+		}
+		return nil, err
 	}
 
 	return NewFile(path, e.Mode, blob), nil
@@ -91,12 +94,12 @@ func (t *Tree) Tree(path string) (*Tree, error) {
 		return nil, ErrDirectoryNotFound
 	}
 
-	ret, err := GetTree(t.s, e.Hash)
-	if err != nil {
+	tree, err := GetTree(t.s, e.Hash)
+	if err == plumbing.ErrObjectNotFound {
 		return nil, ErrDirectoryNotFound
 	}
 
-	return ret, nil
+	return tree, err
 }
 
 // TreeEntryFile returns the *File for a given *TreeEntry.
@@ -123,12 +126,10 @@ func (t *Tree) findEntry(path string) (*TreeEntry, error) {
 	return tree.entry(pathParts[0])
 }
 
-var errDirNotFound = errors.New("directory not found")
-
 func (t *Tree) dir(baseName string) (*Tree, error) {
 	entry, err := t.entry(baseName)
 	if err != nil {
-		return nil, errDirNotFound
+		return nil, ErrDirectoryNotFound
 	}
 
 	obj, err := t.s.EncodedObject(plumbing.TreeObject, entry.Hash)

--- a/plumbing/object/tree_test.go
+++ b/plumbing/object/tree_test.go
@@ -64,7 +64,10 @@ func (s *TreeSuite) TestTreeNotFound(c *C) {
 	c.Assert(err, Equals, ErrDirectoryNotFound)
 }
 
-func (s *TreeSuite) TestTreeFailsWithFiles(c *C) {
+func (s *TreeSuite) TestTreeFailsWithExistingFiles(c *C) {
+	_, err := s.Tree.File("LICENSE")
+	c.Assert(err, IsNil)
+
 	d, err := s.Tree.Tree("LICENSE")
 	c.Assert(d, IsNil)
 	c.Assert(err, Equals, ErrDirectoryNotFound)
@@ -82,9 +85,12 @@ func (s *TreeSuite) TestFileNotFound(c *C) {
 	c.Assert(err, Equals, ErrFileNotFound)
 }
 
-func (s *TreeSuite) TestFileFailsWithTrees(c *C) {
-	d, err := s.Tree.File("vendor")
-	c.Assert(d, IsNil)
+func (s *TreeSuite) TestFileFailsWithExistingTrees(c *C) {
+	_, err := s.Tree.Tree("vendor")
+	c.Assert(err, IsNil)
+
+	f, err := s.Tree.File("vendor")
+	c.Assert(f, IsNil)
 	c.Assert(err, Equals, ErrFileNotFound)
 }
 

--- a/plumbing/object/tree_test.go
+++ b/plumbing/object/tree_test.go
@@ -48,6 +48,22 @@ func (s *TreeSuite) TestType(c *C) {
 	c.Assert(s.Tree.Type(), Equals, plumbing.TreeObject)
 }
 
+func (s *TreeSuite) TestTree(c *C) {
+	expectedEntry, ok := s.Tree.m["vendor"]
+	c.Assert(ok, Equals, true)
+	expected := expectedEntry.Hash
+
+	obtainedTree, err := s.Tree.Tree("vendor")
+	c.Assert(err, IsNil)
+	c.Assert(obtainedTree.Hash, Equals, expected)
+}
+
+func (s *TreeSuite) TestTreeNotFound(c *C) {
+	d, err := s.Tree.Tree("not-found")
+	c.Assert(d, IsNil)
+	c.Assert(err, Equals, ErrDirectoryNotFound)
+}
+
 func (s *TreeSuite) TestFile(c *C) {
 	f, err := s.Tree.File("LICENSE")
 	c.Assert(err, IsNil)

--- a/plumbing/object/tree_test.go
+++ b/plumbing/object/tree_test.go
@@ -64,6 +64,12 @@ func (s *TreeSuite) TestTreeNotFound(c *C) {
 	c.Assert(err, Equals, ErrDirectoryNotFound)
 }
 
+func (s *TreeSuite) TestTreeFailsWithFiles(c *C) {
+	d, err := s.Tree.Tree("LICENSE")
+	c.Assert(d, IsNil)
+	c.Assert(err, Equals, ErrDirectoryNotFound)
+}
+
 func (s *TreeSuite) TestFile(c *C) {
 	f, err := s.Tree.File("LICENSE")
 	c.Assert(err, IsNil)
@@ -73,6 +79,12 @@ func (s *TreeSuite) TestFile(c *C) {
 func (s *TreeSuite) TestFileNotFound(c *C) {
 	f, err := s.Tree.File("not-found")
 	c.Assert(f, IsNil)
+	c.Assert(err, Equals, ErrFileNotFound)
+}
+
+func (s *TreeSuite) TestFileFailsWithTrees(c *C) {
+	d, err := s.Tree.File("vendor")
+	c.Assert(d, IsNil)
 	c.Assert(err, Equals, ErrFileNotFound)
 }
 


### PR DESCRIPTION
This patch adds a new method to the Tree object that allows you to get a child tree from a parent tree by its relative name.

Before this patch, this was only possible with files, using the `File` method.

The new `Tree` method has a similar signature to the old `File` method for consistency.