### PR TITLE
config: marshal and unmarshal done inside of the package, and submodules config file

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -2,8 +2,11 @@
 package config
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
+
+	"gopkg.in/src-d/go-git.v4/plumbing/format/config"
 )
 
 const (
@@ -27,17 +30,24 @@ var (
 )
 
 // Config contains the repository configuration
+// https://www.kernel.org/pub/software/scm/git/docs/git-config.html
 type Config struct {
 	Core struct {
 		IsBare bool
 	}
 	Remotes map[string]*RemoteConfig
+
+	// contains the raw information of a config file, the main goal is preserve
+	// the parsed information from the original format, to avoid miss not
+	// supported properties
+	raw *config.Config
 }
 
 // NewConfig returns a new empty Config
 func NewConfig() *Config {
 	return &Config{
 		Remotes: make(map[string]*RemoteConfig, 0),
+		raw:     config.New(),
 	}
 }
 
@@ -56,11 +66,82 @@ func (c *Config) Validate() error {
 	return nil
 }
 
+const (
+	remoteSection = "remote"
+	coreSection   = "core"
+	fetchKey      = "fetch"
+	urlKey        = "url"
+	bareKey       = "bare"
+)
+
+// Unmarshal parses a git-config file and stores it
+func (c *Config) Unmarshal(b []byte) error {
+	r := bytes.NewBuffer(b)
+	d := config.NewDecoder(r)
+
+	c.raw = config.New()
+	if err := d.Decode(c.raw); err != nil {
+		return err
+	}
+
+	c.unmarshalCore()
+	c.unmarshalRemotes()
+	return nil
+}
+
+func (c *Config) unmarshalCore() {
+	s := c.raw.Section(coreSection)
+	if s.Options.Get(bareKey) == "true" {
+		c.Core.IsBare = true
+	}
+}
+
+func (c *Config) unmarshalRemotes() {
+	s := c.raw.Section(remoteSection)
+	for _, sub := range s.Subsections {
+		r := &RemoteConfig{}
+		r.unmarshal(sub)
+
+		c.Remotes[r.Name] = r
+	}
+}
+
+// Marshal returns Config encoded as a git-config file
+func (c *Config) Marshal() ([]byte, error) {
+	c.marshalCore()
+	c.marshalRemotes()
+
+	buf := bytes.NewBuffer(nil)
+	if err := config.NewEncoder(buf).Encode(c.raw); err != nil {
+		return nil, err
+	}
+
+	return buf.Bytes(), nil
+}
+
+func (c *Config) marshalCore() {
+	s := c.raw.Section(coreSection)
+	s.SetOption(bareKey, fmt.Sprintf("%t", c.Core.IsBare))
+}
+
+func (c *Config) marshalRemotes() {
+	s := c.raw.Section(remoteSection)
+	s.Subsections = make(config.Subsections, len(c.Remotes))
+
+	var i int
+	for _, r := range c.Remotes {
+		s.Subsections[i] = r.marshal()
+		i++
+	}
+}
+
 // RemoteConfig contains the configuration for a given repository
 type RemoteConfig struct {
 	Name  string
 	URL   string
 	Fetch []RefSpec
+
+	raw *config.Subsection
 }
 
 // Validate validate the fields and set the default values
@@ -78,4 +159,34 @@ func (c *RemoteConfig) Validate() error {
 	}
 
 	return nil
+}
+
+func (c *RemoteConfig) unmarshal(s *config.Subsection) {
+	c.raw = s
+
+	fetch := []RefSpec{}
+	for _, f := range c.raw.Options.GetAll(fetchKey) {
+		rs := RefSpec(f)
+		if rs.IsValid() {
+			fetch = append(fetch, rs)
+		}
+	}
+
+	c.Name = c.raw.Name
+	c.URL = c.raw.Option(urlKey)
+	c.Fetch = fetch
+}
+
+func (c *RemoteConfig) marshal() *config.Subsection {
+	if c.raw == nil {
+		c.raw = &config.Subsection{}
+	}
+
+	c.raw.Name = c.Name
+	c.raw.SetOption(urlKey, c.URL)
+	for _, rs := range c.Fetch {
+		c.raw.SetOption(fetchKey, rs.String())
+	}
+
+	return c.raw
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -6,7 +6,51 @@ type ConfigSuite struct{}
 
 var _ = Suite(&ConfigSuite{})
 
-func (s *ConfigSuite) TestConfigValidateInvalidRemote(c *C) {
+func (s *ConfigSuite) TestUnmarshall(c *C) {
+	input := []byte(`[core]
+        bare = true
+[remote "origin"]
+        url = git@github.com:mcuadros/go-git.git
+        fetch = +refs/heads/*:refs/remotes/origin/*
+[branch "master"]
+        remote = origin
+        merge = refs/heads/master
+`)
+
+	cfg := NewConfig()
+	err := cfg.Unmarshal(input)
+	c.Assert(err, IsNil)
+
+	c.Assert(cfg.Core.IsBare, Equals, true)
+	c.Assert(cfg.Remotes, HasLen, 1)
+	c.Assert(cfg.Remotes["origin"].Name, Equals, "origin")
+	c.Assert(cfg.Remotes["origin"].URL, Equals, "git@github.com:mcuadros/go-git.git")
+	c.Assert(cfg.Remotes["origin"].Fetch, DeepEquals, []RefSpec{"+refs/heads/*:refs/remotes/origin/*"})
+}
+
+func (s *ConfigSuite) TestUnmarshallMarshall(c *C) {
+	input := []byte(`[core]
+	bare = true
+	custom = ignored
+[remote "origin"]
+	url = git@github.com:mcuadros/go-git.git
+	fetch = +refs/heads/*:refs/remotes/origin/*
+	mirror = true
+[branch "master"]
+	remote = origin
+	merge = refs/heads/master
+`)
+
+	cfg := NewConfig()
+	err := cfg.Unmarshal(input)
+	c.Assert(err, IsNil)
+
+	output, err := cfg.Marshal()
+	c.Assert(err, IsNil)
+	c.Assert(output, DeepEquals, input)
+}
+
+func (s *ConfigSuite) TestValidateInvalidRemote(c *C) {
 	config := &Config{
 		Remotes: map[string]*RemoteConfig{
 			"foo": {Name: "foo"},
@@ -16,7 +60,7 @@ func (s *ConfigSuite) TestConfigValidateInvalidRemote(c *C) {
 	c.Assert(config.Validate(), Equals, ErrRemoteConfigEmptyURL)
 }
 
-func (s *ConfigSuite) TestConfigValidateInvalidKey(c *C) {
+func (s *ConfigSuite) TestValidateInvalidKey(c *C) {
 	config := &Config{
 		Remotes: map[string]*RemoteConfig{
 			"bar": {Name: "foo"},

--- a/config/modules.go
+++ b/config/modules.go
@@ -1,20 +1,83 @@
 package config
 
-import "errors"
+import (
+	"bytes"
+	"errors"
+
+	"gopkg.in/src-d/go-git.v4/plumbing/format/config"
+)
 
 var (
 	ErrModuleEmptyURL  = errors.New("module config: empty URL")
 	ErrModuleEmptyPath = errors.New("module config: empty path")
 )
 
-const DefaultModuleBranch = "master"
-
 // Modules defines the submodules properties
-type Modules map[string]*Module
+type Modules struct {
+	Submodules map[string]*Submodule
 
-// Module defines a submodule
+	raw *config.Config
+}
+
+// NewModules returns a new empty Modules
+func NewModules() *Modules {
+	return &Modules{
+		Submodules: make(map[string]*Submodule, 0),
+		raw:        config.New(),
+	}
+}
+
+const (
+	submoduleSection = "submodule"
+	pathKey          = "path"
+	branchKey        = "branch"
+)
+
+// Unmarshal parses a git-config file and stores it
+func (m *Modules) Unmarshal(b []byte) error {
+	r := bytes.NewBuffer(b)
+	d := config.NewDecoder(r)
+
+	m.raw = config.New()
+	if err := d.Decode(m.raw); err != nil {
+		return err
+	}
+
+	s := m.raw.Section(submoduleSection)
+	for _, sub := range s.Subsections {
+		mod := &Submodule{}
+		mod.unmarshal(sub)
+
+		m.Submodules[mod.Path] = mod
+	}
+
+	return nil
+}
+
+// Marshal returns Modules encoded as a git-config file
+func (m *Modules) Marshal() ([]byte, error) {
+	s := m.raw.Section(submoduleSection)
+	s.Subsections = make(config.Subsections, len(m.Submodules))
+
+	var i int
+	for _, r := range m.Submodules {
+		s.Subsections[i] = r.marshal()
+		i++
+	}
+
+	buf := bytes.NewBuffer(nil)
+	if err := config.NewEncoder(buf).Encode(m.raw); err != nil {
+		return nil, err
+	}
+
+	return buf.Bytes(), nil
+}
+
+// Submodule defines a submodule
 // https://www.kernel.org/pub/software/scm/git/docs/gitmodules.html
-type Module struct {
+type Submodule struct {
+	// Name module name
+	Name string
 	// Path defines the path, relative to the top-level directory of the Git
 	// working tree,
 	Path string
@@ -23,10 +86,12 @@ type Module struct {
 	// Branch is a remote branch name for tracking updates in the upstream
 	// submodule.
 	Branch string
+
+	raw *config.Subsection
 }
 
 // Validate validate the fields and set the default values
-func (m *Module) Validate() error {
+func (m *Submodule) Validate() error {
 	if m.Path == "" {
 		return ErrModuleEmptyPath
 	}
@@ -35,9 +100,34 @@ func (m *Module) Validate() error {
 		return ErrModuleEmptyURL
 	}
 
-	if m.Branch == "" {
-		m.Branch = DefaultModuleBranch
+	return nil
+}
+
+func (m *Submodule) unmarshal(s *config.Subsection) {
+	m.raw = s
+
+	m.Name = m.raw.Name
+	m.Path = m.raw.Option(pathKey)
+	m.URL = m.raw.Option(urlKey)
+	m.Branch = m.raw.Option(branchKey)
+}
+
+func (m *Submodule) marshal() *config.Subsection {
+	if m.raw == nil {
+		m.raw = &config.Subsection{}
 	}
 
-	return nil
+	m.raw.Name = m.Name
+	if m.raw.Name == "" {
+		m.raw.Name = m.Path
+	}
+
+	m.raw.SetOption(pathKey, m.Path)
+	m.raw.SetOption(urlKey, m.URL)
+
+	if m.Branch != "" {
+		m.raw.SetOption(branchKey, m.Branch)
+	}
+
+	return m.raw
 }

--- a/config/modules.go
+++ b/config/modules.go
@@ -1,0 +1,43 @@
+package config
+
+import "errors"
+
+var (
+	ErrModuleEmptyURL  = errors.New("module config: empty URL")
+	ErrModuleEmptyPath = errors.New("module config: empty path")
+)
+
+const DefaultModuleBranch = "master"
+
+// Modules defines the submodules properties
+type Modules map[string]*Module
+
+// Module defines a submodule
+// https://www.kernel.org/pub/software/scm/git/docs/gitmodules.html
+type Module struct {
+	// Path defines the path, relative to the top-level directory of the Git
+	// working tree,
+	Path string
+	// URL defines a URL from which the submodule repository can be cloned.
+	URL string
+	// Branch is a remote branch name for tracking updates in the upstream
+	// submodule.
+	Branch string
+}
+
+// Validate validate the fields and set the default values
+func (m *Module) Validate() error {
+	if m.Path == "" {
+		return ErrModuleEmptyPath
+	}
+
+	if m.URL == "" {
+		return ErrModuleEmptyURL
+	}
+
+	if m.Branch == "" {
+		m.Branch = DefaultModuleBranch
+	}
+
+	return nil
+}

--- a/config/modules_test.go
+++ b/config/modules_test.go
@@ -69,5 +69,5 @@ func (s *ModulesSuite) TestUnmarshallMarshall(c *C) {
 
 	output, err := cfg.Marshal()
 	c.Assert(err, IsNil)
-	c.Assert(output, DeepEquals, input)
+	c.Assert(string(output), DeepEquals, string(input))
 }

--- a/config/modules_test.go
+++ b/config/modules_test.go
@@ -1,0 +1,23 @@
+package config
+
+import . "gopkg.in/check.v1"
+
+type ModuleSuite struct{}
+
+var _ = Suite(&ModuleSuite{})
+
+func (s *ModuleSuite) TestModuleValidateMissingURL(c *C) {
+	m := &Module{Path: "foo"}
+	c.Assert(m.Validate(), Equals, ErrModuleEmptyURL)
+}
+
+func (s *ModuleSuite) TestModuleValidateMissingName(c *C) {
+	m := &Module{URL: "bar"}
+	c.Assert(m.Validate(), Equals, ErrModuleEmptyPath)
+}
+
+func (s *ModuleSuite) TestModuleValidateDefault(c *C) {
+	m := &Module{Path: "foo", URL: "http://foo/bar"}
+	c.Assert(m.Validate(), IsNil)
+	c.Assert(m.Branch, Equals, DefaultModuleBranch)
+}

--- a/config/modules_test.go
+++ b/config/modules_test.go
@@ -2,22 +2,72 @@ package config
 
 import . "gopkg.in/check.v1"
 
-type ModuleSuite struct{}
+type ModulesSuite struct{}
 
-var _ = Suite(&ModuleSuite{})
+var _ = Suite(&ModulesSuite{})
 
-func (s *ModuleSuite) TestModuleValidateMissingURL(c *C) {
-	m := &Module{Path: "foo"}
+func (s *ModulesSuite) TestValidateMissingURL(c *C) {
+	m := &Submodule{Path: "foo"}
 	c.Assert(m.Validate(), Equals, ErrModuleEmptyURL)
 }
 
-func (s *ModuleSuite) TestModuleValidateMissingName(c *C) {
-	m := &Module{URL: "bar"}
+func (s *ModulesSuite) TestValidateMissingName(c *C) {
+	m := &Submodule{URL: "bar"}
 	c.Assert(m.Validate(), Equals, ErrModuleEmptyPath)
 }
 
-func (s *ModuleSuite) TestModuleValidateDefault(c *C) {
-	m := &Module{Path: "foo", URL: "http://foo/bar"}
-	c.Assert(m.Validate(), IsNil)
-	c.Assert(m.Branch, Equals, DefaultModuleBranch)
+func (s *ModulesSuite) TestMarshall(c *C) {
+	input := []byte(`[submodule "qux"]
+	path = qux
+	url = baz
+	branch = bar
+`)
+
+	cfg := NewModules()
+	cfg.Submodules["qux"] = &Submodule{Path: "qux", URL: "baz", Branch: "bar"}
+
+	output, err := cfg.Marshal()
+	c.Assert(err, IsNil)
+	c.Assert(output, DeepEquals, input)
+}
+
+func (s *ModulesSuite) TestUnmarshall(c *C) {
+	input := []byte(`[submodule "qux"]
+        path = qux
+        url = https://github.com/foo/qux.git
+[submodule "foo/bar"]
+        path = foo/bar
+        url = https://github.com/foo/bar.git
+		branch = dev
+`)
+
+	cfg := NewModules()
+	err := cfg.Unmarshal(input)
+	c.Assert(err, IsNil)
+
+	c.Assert(cfg.Submodules, HasLen, 2)
+	c.Assert(cfg.Submodules["qux"].Name, Equals, "qux")
+	c.Assert(cfg.Submodules["qux"].URL, Equals, "https://github.com/foo/qux.git")
+	c.Assert(cfg.Submodules["foo/bar"].Name, Equals, "foo/bar")
+	c.Assert(cfg.Submodules["foo/bar"].URL, Equals, "https://github.com/foo/bar.git")
+	c.Assert(cfg.Submodules["foo/bar"].Branch, Equals, "dev")
+}
+
+func (s *ModulesSuite) TestUnmarshallMarshall(c *C) {
+	input := []byte(`[submodule "qux"]
+	path = qux
+	url = https://github.com/foo/qux.git
+[submodule "foo/bar"]
+	path = foo/bar
+	url = https://github.com/foo/bar.git
+	ignore = all
+`)
+
+	cfg := NewModules()
+	err := cfg.Unmarshal(input)
+	c.Assert(err, IsNil)
+
+	output, err := cfg.Marshal()
+	c.Assert(err, IsNil)
+	c.Assert(output, DeepEquals, input)
 }

--- a/storage/filesystem/config.go
+++ b/storage/filesystem/config.go
@@ -1,9 +1,8 @@
 package filesystem
 
 import (
-	"os"
-
 	"io/ioutil"
+	"os"
 
 	"gopkg.in/src-d/go-git.v4/config"
 	"gopkg.in/src-d/go-git.v4/storage/filesystem/internal/dotgit"

--- a/storage/filesystem/config.go
+++ b/storage/filesystem/config.go
@@ -1,20 +1,12 @@
 package filesystem
 
 import (
-	"fmt"
 	"os"
 
-	"gopkg.in/src-d/go-git.v4/config"
-	gitconfig "gopkg.in/src-d/go-git.v4/plumbing/format/config"
-	"gopkg.in/src-d/go-git.v4/storage/filesystem/internal/dotgit"
-)
+	"io/ioutil"
 
-const (
-	remoteSection = "remote"
-	coreSection   = "core"
-	fetchKey      = "fetch"
-	urlKey        = "url"
-	bareKey       = "bare"
+	"gopkg.in/src-d/go-git.v4/config"
+	"gopkg.in/src-d/go-git.v4/storage/filesystem/internal/dotgit"
 )
 
 type ConfigStorage struct {
@@ -23,20 +15,6 @@ type ConfigStorage struct {
 
 func (c *ConfigStorage) Config() (*config.Config, error) {
 	cfg := config.NewConfig()
-
-	ini, err := c.unmarshal()
-	if err != nil {
-		return nil, err
-	}
-
-	c.unmarshalCore(cfg, ini)
-	c.unmarshalRemotes(cfg, ini)
-
-	return cfg, nil
-}
-
-func (c *ConfigStorage) unmarshal() (*gitconfig.Config, error) {
-	cfg := gitconfig.New()
 
 	f, err := c.dir.Config()
 	if err != nil {
@@ -49,43 +27,16 @@ func (c *ConfigStorage) unmarshal() (*gitconfig.Config, error) {
 
 	defer f.Close()
 
-	d := gitconfig.NewDecoder(f)
-	if err := d.Decode(cfg); err != nil {
+	b, err := ioutil.ReadAll(f)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := cfg.Unmarshal(b); err != nil {
 		return nil, err
 	}
 
 	return cfg, nil
-}
-
-func (c *ConfigStorage) unmarshalCore(cfg *config.Config, ini *gitconfig.Config) {
-	s := ini.Section(coreSection)
-	if s.Options.Get(bareKey) == "true" {
-		cfg.Core.IsBare = true
-	}
-}
-
-func (c *ConfigStorage) unmarshalRemotes(cfg *config.Config, ini *gitconfig.Config) {
-	s := ini.Section(remoteSection)
-	for _, sub := range s.Subsections {
-		r := c.unmarshalRemote(sub)
-		cfg.Remotes[r.Name] = r
-	}
-}
-
-func (c *ConfigStorage) unmarshalRemote(s *gitconfig.Subsection) *config.RemoteConfig {
-	fetch := []config.RefSpec{}
-	for _, f := range s.Options.GetAll(fetchKey) {
-		rs := config.RefSpec(f)
-		if rs.IsValid() {
-			fetch = append(fetch, rs)
-		}
-	}
-
-	return &config.RemoteConfig{
-		Name:  s.Name,
-		URL:   s.Option(urlKey),
-		Fetch: fetch,
-	}
 }
 
 func (c *ConfigStorage) SetConfig(cfg *config.Config) error {
@@ -93,43 +44,6 @@ func (c *ConfigStorage) SetConfig(cfg *config.Config) error {
 		return err
 	}
 
-	ini, err := c.unmarshal()
-	if err != nil {
-		return err
-	}
-
-	c.marshalCore(cfg, ini)
-	c.marshalRemotes(cfg, ini)
-	return c.marshal(ini)
-}
-
-func (c *ConfigStorage) marshalCore(cfg *config.Config, ini *gitconfig.Config) {
-	s := ini.Section(coreSection)
-	s.AddOption(bareKey, fmt.Sprintf("%t", cfg.Core.IsBare))
-}
-
-func (c *ConfigStorage) marshalRemotes(cfg *config.Config, ini *gitconfig.Config) {
-	s := ini.Section(remoteSection)
-	s.Subsections = make(gitconfig.Subsections, len(cfg.Remotes))
-
-	var i int
-	for _, r := range cfg.Remotes {
-		s.Subsections[i] = c.marshalRemote(r)
-		i++
-	}
-}
-
-func (c *ConfigStorage) marshalRemote(r *config.RemoteConfig) *gitconfig.Subsection {
-	s := &gitconfig.Subsection{Name: r.Name}
-	s.AddOption(urlKey, r.URL)
-	for _, rs := range r.Fetch {
-		s.AddOption(fetchKey, rs.String())
-	}
-
-	return s
-}
-
-func (c *ConfigStorage) marshal(ini *gitconfig.Config) error {
 	f, err := c.dir.ConfigWriter()
 	if err != nil {
 		return err
@@ -137,6 +51,11 @@ func (c *ConfigStorage) marshal(ini *gitconfig.Config) error {
 
 	defer f.Close()
 
-	e := gitconfig.NewEncoder(f)
-	return e.Encode(ini)
+	b, err := cfg.Marshal()
+	if err != nil {
+		return err
+	}
+
+	_, err = f.Write(b)
+	return err
 }


### PR DESCRIPTION
This is the implementation of the submodules files, also include the refactor of the marshal and unmashal functions for config. 

The marshalling logic was moved from the `storage.Filesystem` because at the end anyone may want marshal the struct for many other reason than just save it in a filesystem. Also we are implementing the submodule file that use the same format and is not stored in the same way.