### PR TITLE
Repository.Progress moved as a field in *Options

### DIFF
--- a/examples/progress/main.go
+++ b/examples/progress/main.go
@@ -15,17 +15,17 @@ func main() {
 	r, err := git.NewFilesystemRepository(directory)
 	CheckIfError(err)
 
-	// as git does, when you make a clone, pull or some other operations, the
-	// server sends information via the sideband, this information can being
-	// collected provinding a io.Writer to the repository
-	r.Progress = os.Stdout
-
 	// Clone the given repository to the given directory
 	Info("git clone %s %s", url, directory)
 
 	err = r.Clone(&git.CloneOptions{
 		URL:   url,
 		Depth: 1,
+
+		// as git does, when you make a clone, pull or some other operations the
+		// server sends information via the sideband, this information can being
+		// collected provinding a io.Writer to the CloneOptions options
+		Progress: os.Stdout,
 	})
 
 	CheckIfError(err)

--- a/options.go
+++ b/options.go
@@ -5,6 +5,7 @@ import (
 
 	"gopkg.in/src-d/go-git.v4/config"
 	"gopkg.in/src-d/go-git.v4/plumbing"
+	"gopkg.in/src-d/go-git.v4/plumbing/protocol/packp/sideband"
 	"gopkg.in/src-d/go-git.v4/plumbing/transport"
 )
 
@@ -32,6 +33,10 @@ type CloneOptions struct {
 	SingleBranch bool
 	// Limit fetching to the specified number of commits
 	Depth int
+	// Progress is where the human readable information sent by the server is
+	// stored, if nil nothing is stored and the capability (if supported)
+	// no-progress, is sent to the server to avoid send this information
+	Progress sideband.Progress
 }
 
 // Validate validate the fields and set the default values
@@ -63,6 +68,10 @@ type PullOptions struct {
 	Depth int
 	// Auth credentials, if required, to use with the remote repository
 	Auth transport.AuthMethod
+	// Progress is where the human readable information sent by the server is
+	// stored, if nil nothing is stored and the capability (if supported)
+	// no-progress, is sent to the server to avoid send this information
+	Progress sideband.Progress
 }
 
 // Validate validate the fields and set the default values.
@@ -88,6 +97,10 @@ type FetchOptions struct {
 	Depth int
 	// Auth credentials, if required, to use with the remote repository
 	Auth transport.AuthMethod
+	// Progress is where the human readable information sent by the server is
+	// stored, if nil nothing is stored and the capability (if supported)
+	// no-progress, is sent to the server to avoid send this information
+	Progress sideband.Progress
 }
 
 // Validate validate the fields and set the default values

--- a/plumbing/protocol/packp/sideband/demux.go
+++ b/plumbing/protocol/packp/sideband/demux.go
@@ -11,9 +11,8 @@ import (
 // ErrMaxPackedExceeded returned by Read, if the maximum packed size is exceeded
 var ErrMaxPackedExceeded = errors.New("max. packed size exceeded")
 
-// Progress allows to read the progress information
+// Progress where the progress information is stored
 type Progress interface {
-	io.Reader
 	io.Writer
 }
 

--- a/repository_test.go
+++ b/repository_test.go
@@ -45,21 +45,6 @@ func (s *RepositorySuite) TestCreateRemoteAndRemote(c *C) {
 	c.Assert(alt.Config().Name, Equals, "foo")
 }
 
-func (s *RepositorySuite) TestRemoteWithProgress(c *C) {
-	buf := bytes.NewBuffer(nil)
-
-	r := NewMemoryRepository()
-	r.Progress = buf
-
-	remote, err := r.CreateRemote(&config.RemoteConfig{
-		Name: "foo",
-		URL:  "http://foo/foo.git",
-	})
-
-	c.Assert(err, IsNil)
-	c.Assert(remote.p, Equals, buf)
-}
-
 func (s *RepositorySuite) TestCreateRemoteInvalid(c *C) {
 	r := NewMemoryRepository()
 	remote, err := r.CreateRemote(&config.RemoteConfig{})
@@ -266,6 +251,19 @@ func (s *RepositorySuite) TestCloneDetachedHEAD(c *C) {
 	c.Assert(head.Hash().String(), Equals, "6ecf0ef2c2dffb796033e5a02219af86ec6584e5")
 }
 
+func (s *RepositorySuite) TestCloneWithProgress(c *C) {
+	r := NewMemoryRepository()
+
+	buf := bytes.NewBuffer(nil)
+	err := r.Clone(&CloneOptions{
+		URL:      s.GetBasicLocalRepositoryURL(),
+		Progress: buf,
+	})
+
+	c.Assert(err, IsNil)
+	c.Assert(buf.Len(), Not(Equals), 0)
+}
+
 func (s *RepositorySuite) TestPullUpdateReferencesIfNeeded(c *C) {
 	r := NewMemoryRepository()
 	r.CreateRemote(&config.RemoteConfig{
@@ -315,6 +313,23 @@ func (s *RepositorySuite) TestPullSingleBranch(c *C) {
 
 	storage := r.s.(*memory.Storage)
 	c.Assert(storage.Objects, HasLen, 28)
+}
+
+func (s *RepositorySuite) TestPullProgress(c *C) {
+	r := NewMemoryRepository()
+
+	r.CreateRemote(&config.RemoteConfig{
+		Name: DefaultRemoteName,
+		URL:  s.GetBasicLocalRepositoryURL(),
+	})
+
+	buf := bytes.NewBuffer(nil)
+	err := r.Pull(&PullOptions{
+		Progress: buf,
+	})
+
+	c.Assert(err, IsNil)
+	c.Assert(buf.Len(), Not(Equals), 0)
 }
 
 func (s *RepositorySuite) TestPullAdd(c *C) {


### PR DESCRIPTION
This remove the field `Progress` at `Repository` since we are having Clone as a constructors it not time to set this field before do any operation. Also @smola suggested that is much better work a io.Writer and not io.Write and io.Reader as Progress.