### PR TITLE
Fix compile-time error on Windows

### DIFF
--- a/worktree.go
+++ b/worktree.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"syscall"
 
 	"srcd.works/go-git.v4/plumbing"
 	"srcd.works/go-git.v4/plumbing/format/index"
@@ -71,7 +70,7 @@ func (w *Worktree) checkoutFile(f *object.File, idx *index.Index) error {
 	return w.indexFile(f, idx)
 }
 
-var fillSystemInfo func(e *index.Entry, os *syscall.Stat_t)
+var fillSystemInfo func(e *index.Entry, sys interface{})
 
 func (w *Worktree) indexFile(f *object.File, idx *index.Index) error {
 	fi, err := w.fs.Stat(f.Name)
@@ -89,9 +88,8 @@ func (w *Worktree) indexFile(f *object.File, idx *index.Index) error {
 
 	// if the FileInfo.Sys() comes from os the ctime, dev, inode, uid and gid
 	// can be retrieved, otherwise this doesn't apply
-	os, ok := fi.Sys().(*syscall.Stat_t)
-	if ok && fillSystemInfo != nil {
-		fillSystemInfo(&e, os)
+	if fillSystemInfo != nil {
+		fillSystemInfo(&e, fi.Sys())
 	}
 
 	idx.Entries = append(idx.Entries, e)

--- a/worktree_darwin.go
+++ b/worktree_darwin.go
@@ -10,11 +10,13 @@ import (
 )
 
 func init() {
-	fillSystemInfo = func(e *index.Entry, os *syscall.Stat_t) {
-		e.CreatedAt = time.Unix(int64(os.Atimespec.Sec), int64(os.Atimespec.Nsec))
-		e.Dev = uint32(os.Dev)
-		e.Inode = uint32(os.Ino)
-		e.GID = os.Gid
-		e.UID = os.Uid
+	fillSystemInfo = func(e *index.Entry, sys interface{}) {
+		if os, ok := sys.(*syscall.Stat_t); ok {
+			e.CreatedAt = time.Unix(int64(os.Atimespec.Sec), int64(os.Atimespec.Nsec))
+			e.Dev = uint32(os.Dev)
+			e.Inode = uint32(os.Ino)
+			e.GID = os.Gid
+			e.UID = os.Uid
+		}
 	}
 }

--- a/worktree_linux.go
+++ b/worktree_linux.go
@@ -10,11 +10,13 @@ import (
 )
 
 func init() {
-	fillSystemInfo = func(e *index.Entry, os *syscall.Stat_t) {
-		e.CreatedAt = time.Unix(int64(os.Ctim.Sec), int64(os.Ctim.Nsec))
-		e.Dev = uint32(os.Dev)
-		e.Inode = uint32(os.Ino)
-		e.GID = os.Gid
-		e.UID = os.Uid
+	fillSystemInfo = func(e *index.Entry, sys interface{}) {
+		if os, ok := sys.(*syscall.Stat_t); ok {
+			e.CreatedAt = time.Unix(int64(os.Ctim.Sec), int64(os.Ctim.Nsec))
+			e.Dev = uint32(os.Dev)
+			e.Inode = uint32(os.Ino)
+			e.GID = os.Gid
+			e.UID = os.Uid
+		}
 	}
 }


### PR DESCRIPTION
I have encountered this when cross-compiling my program which relies on go-git.

`syscall.Stat_t` it not defined on Windows platform, and hence go-git
won't compile on Windows. It's better to pass more generic output of `FileInfo` `Sys()`
(of type `interface{}`) to `fillSystemInfo` and handle type assertion
separately for each platform.