### PR TITLE
Fix "object not found" exception in ref-deltas

### DIFF
--- a/common_test.go
+++ b/common_test.go
@@ -74,7 +74,7 @@ func (s *BaseSuite) NewRepositoryFromPackfile(f *fixtures.Fixture) *Repository {
 	defer p.Close()
 
 	n := packfile.NewScanner(p)
-	d, err := packfile.NewDecoder(n, storer)
+	d, err := packfile.NewDecoder(n, storer, nil)
 	if err != nil {
 		panic(err)
 	}

--- a/plumbing/difftree/difftree_test.go
+++ b/plumbing/difftree/difftree_test.go
@@ -60,7 +60,7 @@ func (s *DiffTreeSuite) storageFromPackfile(f *fixtures.Fixture) storer.EncodedO
 	defer pf.Close()
 
 	n := packfile.NewScanner(pf)
-	d, err := packfile.NewDecoder(n, sto)
+	d, err := packfile.NewDecoder(n, sto, nil)
 	if err != nil {
 		panic(err)
 	}

--- a/plumbing/format/idxfile/decoder_test.go
+++ b/plumbing/format/idxfile/decoder_test.go
@@ -42,7 +42,7 @@ func (s *IdxfileSuite) TestDecodeCRCs(c *C) {
 	scanner := packfile.NewScanner(f.Packfile())
 	storage := memory.NewStorage()
 
-	pd, err := packfile.NewDecoder(scanner, storage)
+	pd, err := packfile.NewDecoder(scanner, storage, nil)
 	c.Assert(err, IsNil)
 	_, err = pd.Decode()
 	c.Assert(err, IsNil)

--- a/plumbing/format/packfile/common.go
+++ b/plumbing/format/packfile/common.go
@@ -35,7 +35,7 @@ func UpdateObjectStorage(s storer.EncodedObjectStorer, packfile io.Reader) error
 	}
 
 	stream := NewScanner(packfile)
-	d, err := NewDecoder(stream, s)
+	d, err := NewDecoder(stream, s, nil)
 	if err != nil {
 		return err
 	}

--- a/plumbing/format/packfile/decoder.go
+++ b/plumbing/format/packfile/decoder.go
@@ -244,13 +244,6 @@ func (d *Decoder) decodeIfSpecificType(h *ObjectHeader) (plumbing.EncodedObject,
 		realType, err = d.ofsDeltaType(h.OffsetReference)
 	case plumbing.REFDeltaObject:
 		realType, err = d.refDeltaType(h.Reference)
-
-		// If a reference delta is not found, it means that it isn't of
-		// the type we are looking for, because we don't have any reference
-		// and it is not present into the object storer
-		if err == plumbing.ErrObjectNotFound {
-			return nil, nil
-		}
 	default:
 		realType = h.Type
 	}

--- a/plumbing/format/packfile/decoder_test.go
+++ b/plumbing/format/packfile/decoder_test.go
@@ -59,7 +59,14 @@ func (s *ReaderSuite) TestDecodeByType(c *C) {
 		for _, t := range ts {
 			storage := memory.NewStorage()
 			scanner := packfile.NewScanner(f.Packfile())
-			d, err := packfile.NewDecoderForType(scanner, storage, t, nil)
+
+			var offsets map[plumbing.Hash]int64
+			// when the packfile is ref-delta based, the offsets are required
+			if f.Is("ref-delta") {
+				offsets = getOffsetsFromIdx(f.Idx())
+			}
+
+			d, err := packfile.NewDecoderForType(scanner, storage, t, offsets)
 			c.Assert(err, IsNil)
 			defer d.Close()
 

--- a/plumbing/format/packfile/encoder_test.go
+++ b/plumbing/format/packfile/encoder_test.go
@@ -91,7 +91,7 @@ func (s *EncoderSuite) TestDecodeEncodeDecode(c *C) {
 		scanner := NewScanner(f.Packfile())
 		storage := memory.NewStorage()
 
-		d, err := NewDecoder(scanner, storage)
+		d, err := NewDecoder(scanner, storage, nil)
 		c.Assert(err, IsNil)
 
 		ch, err := d.Decode()
@@ -119,7 +119,7 @@ func (s *EncoderSuite) TestDecodeEncodeDecode(c *C) {
 
 		scanner = NewScanner(s.buf)
 		storage = memory.NewStorage()
-		d, err = NewDecoder(scanner, storage)
+		d, err = NewDecoder(scanner, storage, nil)
 		c.Assert(err, IsNil)
 		_, err = d.Decode()
 		c.Assert(err, IsNil)
@@ -185,7 +185,7 @@ func (s *EncoderSuite) simpleDeltaTest(c *C) {
 	scanner := NewScanner(s.buf)
 
 	storage := memory.NewStorage()
-	d, err := NewDecoder(scanner, storage)
+	d, err := NewDecoder(scanner, storage, nil)
 	c.Assert(err, IsNil)
 
 	_, err = d.Decode()
@@ -224,7 +224,7 @@ func (s *EncoderSuite) deltaOverDeltaTest(c *C) {
 
 	scanner := NewScanner(s.buf)
 	storage := memory.NewStorage()
-	d, err := NewDecoder(scanner, storage)
+	d, err := NewDecoder(scanner, storage, nil)
 	c.Assert(err, IsNil)
 
 	_, err = d.Decode()

--- a/plumbing/transport/test/upload_pack.go
+++ b/plumbing/transport/test/upload_pack.go
@@ -204,7 +204,7 @@ func (s *UploadPackSuite) checkObjectNumber(c *C, r io.Reader, n int) {
 	buf := bytes.NewBuffer(b)
 	scanner := packfile.NewScanner(buf)
 	storage := memory.NewStorage()
-	d, err := packfile.NewDecoder(scanner, storage)
+	d, err := packfile.NewDecoder(scanner, storage, nil)
 	c.Assert(err, IsNil)
 	_, err = d.Decode()
 	c.Assert(err, IsNil)

--- a/storage/filesystem/internal/dotgit/writers.go
+++ b/storage/filesystem/internal/dotgit/writers.go
@@ -55,7 +55,7 @@ func newPackWrite(fs billy.Filesystem) (*PackWriter, error) {
 
 func (w *PackWriter) buildIndex() {
 	s := packfile.NewScanner(w.synced)
-	d, err := packfile.NewDecoder(s, nil)
+	d, err := packfile.NewDecoder(s, nil, nil)
 	if err != nil {
 		w.result <- err
 		return

--- a/storage/filesystem/object.go
+++ b/storage/filesystem/object.go
@@ -232,7 +232,7 @@ func (s *ObjectStorage) buildPackfileIters(
 			return nil, err
 		}
 
-		iter, err := newPackfileIter(pack, t, seen, s.index[h])
+		iter, err := newPackfileIter(pack, t, seen, s.index[h], s)
 		if err != nil {
 			return nil, err
 		}
@@ -271,18 +271,18 @@ type packfileIter struct {
 }
 
 func NewPackfileIter(f billy.File, t plumbing.ObjectType) (storer.EncodedObjectIter, error) {
-	return newPackfileIter(f, t, make(map[plumbing.Hash]bool), nil)
+	return newPackfileIter(f, t, make(map[plumbing.Hash]bool), nil, memory.NewStorage())
 }
 
 func newPackfileIter(f billy.File, t plumbing.ObjectType, seen map[plumbing.Hash]bool,
-	index idx) (storer.EncodedObjectIter, error) {
+	index idx, storer storer.EncodedObjectStorer) (storer.EncodedObjectIter, error) {
 	s := packfile.NewScanner(f)
 	_, total, err := s.Header()
 	if err != nil {
 		return nil, err
 	}
 
-	d, err := packfile.NewDecoderForType(s, memory.NewStorage(), t, index)
+	d, err := packfile.NewDecoderForType(s, storer, t, index)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
With this PR we are trying to handle correctly two use cases when we decode various packfiles from a repository.

- **A reference delta is pointing to an object not already parsed:** To handle correctly this case, we added the ability of set the index packfile into the decoder constructor.
- **A reference delta is pointing to an object into another packfile (thin packfile):** This is fixed setting the file system storage, instead of a memory storage. Doing this, if the storage is able to check the indexes of all the packfiles, we will be able to obtain the object from another packfile. 