### PR TITLE
Fix missing objects if they where deltified using ref-delta

### DIFF
--- a/plumbing/format/packfile/decoder.go
+++ b/plumbing/format/packfile/decoder.go
@@ -225,13 +225,6 @@ func (d *Decoder) decodeIfSpecificType(h *ObjectHeader) (plumbing.EncodedObject,
 		realType, err = d.ofsDeltaType(h.OffsetReference)
 	case plumbing.REFDeltaObject:
 		realType, err = d.refDeltaType(h.Reference)
-
-		// If a reference delta is not found, it means that it isn't of
-		// the type we are looking for, because we don't have any reference
-		// and it is not present into the object storer
-		if err == plumbing.ErrObjectNotFound {
-			return nil, nil
-		}
 	default:
 		realType = h.Type
 	}

--- a/storage/filesystem/object.go
+++ b/storage/filesystem/object.go
@@ -233,7 +233,7 @@ func (s *ObjectStorage) buildPackfileIters(
 			return nil, err
 		}
 
-		iter, err := newPackfileIter(pack, t, seen)
+		iter, err := newPackfileIter(pack, t, seen, s.index[h])
 		if err != nil {
 			return nil, err
 		}
@@ -272,10 +272,11 @@ type packfileIter struct {
 }
 
 func NewPackfileIter(f billy.File, t plumbing.ObjectType) (storer.EncodedObjectIter, error) {
-	return newPackfileIter(f, t, make(map[plumbing.Hash]bool))
+	return newPackfileIter(f, t, make(map[plumbing.Hash]bool), nil)
 }
 
-func newPackfileIter(f billy.File, t plumbing.ObjectType, seen map[plumbing.Hash]bool) (storer.EncodedObjectIter, error) {
+func newPackfileIter(f billy.File, t plumbing.ObjectType, seen map[plumbing.Hash]bool,
+	index idx) (storer.EncodedObjectIter, error) {
 	s := packfile.NewScanner(f)
 	_, total, err := s.Header()
 	if err != nil {
@@ -286,6 +287,8 @@ func newPackfileIter(f billy.File, t plumbing.ObjectType, seen map[plumbing.Hash
 	if err != nil {
 		return nil, err
 	}
+
+	d.SetOffsets(index)
 
 	return &packfileIter{
 		f: f,


### PR DESCRIPTION
- Deleted invalid logic that returned nil if an ref-delta was not found into the decoder index. This logic is missing objects if they are deltified using ref-deltas, and the decoder is initialized using a specific type.
- Now, to avoid that problem, index is mandatory to decode correctly a packfile of a specific type. `Decoder.SetOffsets` method now is called into the `EncodedObjectIterator` to avoid this problem.