### PR TITLE
merkletrie: fix const action type fuck up

### DIFF
--- a/utils/merkletrie/change.go
+++ b/utils/merkletrie/change.go
@@ -13,7 +13,7 @@ type Action int
 
 // The set of possible actions in a change.
 const (
-	_ = iota
+	_ Action = iota
 	Insert
 	Delete
 	Modify

--- a/utils/merkletrie/change_test.go
+++ b/utils/merkletrie/change_test.go
@@ -12,6 +12,17 @@ type ChangeSuite struct{}
 
 var _ = Suite(&ChangeSuite{})
 
+func (s *ChangeSuite) TestActionString(c *C) {
+	action := merkletrie.Insert
+	c.Assert(action.String(), Equals, "Insert")
+
+	action = merkletrie.Delete
+	c.Assert(action.String(), Equals, "Delete")
+
+	action = merkletrie.Modify
+	c.Assert(action.String(), Equals, "Modify")
+}
+
 func (s *ChangeSuite) TestUnsupportedAction(c *C) {
 	a := merkletrie.Action(42)
 	c.Assert(a.String, PanicMatches, "unsupported action.*")


### PR DESCRIPTION
Action constants (Insert, Delete, Modify) have type int instead of
Action.  This patch make them Actions again.