### PR TITLE
Fix issue 275 (edited)

### DIFF
--- a/utils/merkletrie/difftree.go
+++ b/utils/merkletrie/difftree.go
@@ -249,7 +249,6 @@ package merkletrie
 
 import (
 	"fmt"
-	"strings"
 
 	"srcd.works/go-git.v4/utils/merkletrie/noder"
 )
@@ -302,7 +301,7 @@ func diffNodes(changes *Changes, ii *doubleIter) error {
 	var err error
 
 	// compare their full paths as strings
-	switch strings.Compare(from.String(), to.String()) {
+	switch from.Compare(to) {
 	case -1:
 		if err = changes.AddRecursiveDelete(from); err != nil {
 			return err

--- a/utils/merkletrie/difftree_test.go
+++ b/utils/merkletrie/difftree_test.go
@@ -427,3 +427,13 @@ func (s *DiffTreeSuite) TestSameNames(c *C) {
 		},
 	})
 }
+
+func (s *DiffTreeSuite) TestIssue275(c *C) {
+	do(c, []diffTreeTest{
+		{
+			"(a(b(c.go<1>) b.go<2>))",
+			"(a(b(c.go<1> d.go<3>) b.go<2>))",
+			"+a/b/d.go",
+		},
+	})
+}

--- a/utils/merkletrie/internal/fsnoder/doc.go
+++ b/utils/merkletrie/internal/fsnoder/doc.go
@@ -18,13 +18,15 @@ will create a noder as follows:
 
 Files are expressed as:
 
-- a single letter for the name of the file.
+- one or more letters and dots for the name of the file
 
 - a single number, between angle brackets, for the contents of the file.
 
+- examples: a<1>, foo.go<2>.
+
 Directories are expressed as:
 
-- a single letter for the name of the directory.
+- one or more letters for the name of the directory.
 
 - its elements between parents, separated with spaces, in any order.
 

--- a/utils/merkletrie/internal/fsnoder/new_test.go
+++ b/utils/merkletrie/internal/fsnoder/new_test.go
@@ -40,15 +40,8 @@ func (s *FSNoderSuite) TestUnnamedInnerFails(c *C) {
 	c.Assert(err, Not(IsNil))
 }
 
-func (s *FSNoderSuite) TestMalformedInnerName(c *C) {
-	_, err := New("(ab<>)")
-	c.Assert(err, Not(IsNil))
-}
-
 func (s *FSNoderSuite) TestMalformedFile(c *C) {
-	_, err := New("(a<12>)")
-	c.Assert(err, Not(IsNil))
-	_, err = New("(4<>)")
+	_, err := New("(4<>)")
 	c.Assert(err, Not(IsNil))
 	_, err = New("(4<1>)")
 	c.Assert(err, Not(IsNil))
@@ -66,13 +59,11 @@ func (s *FSNoderSuite) TestMalformedFile(c *C) {
 	_, err = decodeFile([]byte("a<1?"))
 	c.Assert(err, Not(IsNil))
 
-	_, err = decodeEmptyFile([]byte("a<1>"))
+	_, err = decodeFile([]byte("a?>"))
 	c.Assert(err, Not(IsNil))
-	_, err = decodeEmptyFile([]byte("a?>"))
+	_, err = decodeFile([]byte("1<>"))
 	c.Assert(err, Not(IsNil))
-	_, err = decodeEmptyFile([]byte("1<>"))
-	c.Assert(err, Not(IsNil))
-	_, err = decodeEmptyFile([]byte("a<?"))
+	_, err = decodeFile([]byte("a<?"))
 	c.Assert(err, Not(IsNil))
 }
 
@@ -204,6 +195,32 @@ func (s *FSNoderSuite) TestDirWithEmtpyFileSameName(c *C) {
 	f, err := newFile("A", "")
 	c.Assert(err, IsNil)
 	A, err := newDir("A", []noder.Noder{f})
+	c.Assert(err, IsNil)
+	expected, err := newDir("", []noder.Noder{A})
+	c.Assert(err, IsNil)
+
+	check(c, input, expected)
+}
+
+func (s *FSNoderSuite) TestDirWithFileLongContents(c *C) {
+	input := "(A(a<12>))"
+
+	a1, err := newFile("a", "12")
+	c.Assert(err, IsNil)
+	A, err := newDir("A", []noder.Noder{a1})
+	c.Assert(err, IsNil)
+	expected, err := newDir("", []noder.Noder{A})
+	c.Assert(err, IsNil)
+
+	check(c, input, expected)
+}
+
+func (s *FSNoderSuite) TestDirWithFileLongName(c *C) {
+	input := "(A(abc<12>))"
+
+	a1, err := newFile("abc", "12")
+	c.Assert(err, IsNil)
+	A, err := newDir("A", []noder.Noder{a1})
 	c.Assert(err, IsNil)
 	expected, err := newDir("", []noder.Noder{A})
 	c.Assert(err, IsNil)

--- a/utils/merkletrie/noder/noder_test.go
+++ b/utils/merkletrie/noder/noder_test.go
@@ -1,6 +1,12 @@
 package noder
 
-import . "gopkg.in/check.v1"
+import (
+	"testing"
+
+	. "gopkg.in/check.v1"
+)
+
+func Test(t *testing.T) { TestingT(t) }
 
 type NoderSuite struct{}
 

--- a/utils/merkletrie/noder/path.go
+++ b/utils/merkletrie/noder/path.go
@@ -1,6 +1,9 @@
 package noder
 
-import "bytes"
+import (
+	"bytes"
+	"strings"
+)
 
 // Path values represent a noder and its ancestors.  The root goes first
 // and the actual final noder the path is refering to will be the last.
@@ -56,4 +59,30 @@ func (p Path) Children() ([]Noder, error) {
 // path has.
 func (p Path) NumChildren() (int, error) {
 	return p.Last().NumChildren()
+}
+
+// Compare returns -1, 0 or 1 if the path p is smaller, equal or bigger
+// than other, in "directory order"; for example:
+//
+// "a" < "b"
+// "a/b/c/d/z" < "b"
+// "a/b/a" > "a/b"
+func (p Path) Compare(other Path) int {
+	i := 0
+	for {
+		switch {
+		case len(other) == len(p) && i == len(p):
+			return 0
+		case i == len(other):
+			return 1
+		case i == len(p):
+			return -1
+		default:
+			cmp := strings.Compare(p[i].Name(), other[i].Name())
+			if cmp != 0 {
+				return cmp
+			}
+		}
+		i++
+	}
 }

--- a/utils/merkletrie/noder/path_test.go
+++ b/utils/merkletrie/noder/path_test.go
@@ -1,0 +1,151 @@
+package noder
+
+import . "gopkg.in/check.v1"
+
+type PathSuite struct{}
+
+var _ = Suite(&PathSuite{})
+
+func (s *PathSuite) TestShortFile(c *C) {
+	f := &noderMock{
+		name:  "1",
+		isDir: false,
+	}
+	p := Path([]Noder{f})
+	c.Assert(p.String(), Equals, "1")
+}
+
+func (s *PathSuite) TestShortDir(c *C) {
+	d := &noderMock{
+		name:     "1",
+		isDir:    true,
+		children: NoChildren,
+	}
+	p := Path([]Noder{d})
+	c.Assert(p.String(), Equals, "1")
+}
+
+func (s *PathSuite) TestLongFile(c *C) {
+	n3 := &noderMock{
+		name:  "3",
+		isDir: false,
+	}
+	n2 := &noderMock{
+		name:     "2",
+		isDir:    true,
+		children: []Noder{n3},
+	}
+	n1 := &noderMock{
+		name:     "1",
+		isDir:    true,
+		children: []Noder{n2},
+	}
+	p := Path([]Noder{n1, n2, n3})
+	c.Assert(p.String(), Equals, "1/2/3")
+}
+
+func (s *PathSuite) TestLongDir(c *C) {
+	n3 := &noderMock{
+		name:     "3",
+		isDir:    true,
+		children: NoChildren,
+	}
+	n2 := &noderMock{
+		name:     "2",
+		isDir:    true,
+		children: []Noder{n3},
+	}
+	n1 := &noderMock{
+		name:     "1",
+		isDir:    true,
+		children: []Noder{n2},
+	}
+	p := Path([]Noder{n1, n2, n3})
+	c.Assert(p.String(), Equals, "1/2/3")
+}
+
+func (s *PathSuite) TestCompareDepth1(c *C) {
+	p1 := Path([]Noder{&noderMock{name: "a"}})
+	p2 := Path([]Noder{&noderMock{name: "b"}})
+	c.Assert(p1.Compare(p2), Equals, -1)
+	c.Assert(p2.Compare(p1), Equals, 1)
+
+	p1 = Path([]Noder{&noderMock{name: "a"}})
+	p2 = Path([]Noder{&noderMock{name: "a"}})
+	c.Assert(p1.Compare(p2), Equals, 0)
+	c.Assert(p2.Compare(p1), Equals, 0)
+
+	p1 = Path([]Noder{&noderMock{name: "a.go"}})
+	p2 = Path([]Noder{&noderMock{name: "a"}})
+	c.Assert(p1.Compare(p2), Equals, 1)
+	c.Assert(p2.Compare(p1), Equals, -1)
+}
+
+func (s *PathSuite) TestCompareDepth2(c *C) {
+	p1 := Path([]Noder{
+		&noderMock{name: "a"},
+		&noderMock{name: "b"},
+	})
+	p2 := Path([]Noder{
+		&noderMock{name: "b"},
+		&noderMock{name: "a"},
+	})
+	c.Assert(p1.Compare(p2), Equals, -1)
+	c.Assert(p2.Compare(p1), Equals, 1)
+
+	p1 = Path([]Noder{
+		&noderMock{name: "a"},
+		&noderMock{name: "b"},
+	})
+	p2 = Path([]Noder{
+		&noderMock{name: "a"},
+		&noderMock{name: "b"},
+	})
+	c.Assert(p1.Compare(p2), Equals, 0)
+	c.Assert(p2.Compare(p1), Equals, 0)
+
+	p1 = Path([]Noder{
+		&noderMock{name: "a"},
+		&noderMock{name: "b"},
+	})
+	p2 = Path([]Noder{
+		&noderMock{name: "a"},
+		&noderMock{name: "a"},
+	})
+	c.Assert(p1.Compare(p2), Equals, 1)
+	c.Assert(p2.Compare(p1), Equals, -1)
+}
+
+func (s *PathSuite) TestCompareMixedDepths(c *C) {
+	p1 := Path([]Noder{
+		&noderMock{name: "a"},
+		&noderMock{name: "b"},
+	})
+	p2 := Path([]Noder{&noderMock{name: "b"}})
+	c.Assert(p1.Compare(p2), Equals, -1)
+	c.Assert(p2.Compare(p1), Equals, 1)
+
+	p1 = Path([]Noder{
+		&noderMock{name: "b"},
+		&noderMock{name: "b"},
+	})
+	p2 = Path([]Noder{&noderMock{name: "b"}})
+	c.Assert(p1.Compare(p2), Equals, 1)
+	c.Assert(p2.Compare(p1), Equals, -1)
+
+	p1 = Path([]Noder{&noderMock{name: "a.go"}})
+	p2 = Path([]Noder{
+		&noderMock{name: "a"},
+		&noderMock{name: "a.go"},
+	})
+	c.Assert(p1.Compare(p2), Equals, 1)
+	c.Assert(p2.Compare(p1), Equals, -1)
+
+	p1 = Path([]Noder{&noderMock{name: "b.go"}})
+	p2 = Path([]Noder{
+		&noderMock{name: "a"},
+		&noderMock{name: "a.go"},
+	})
+	c.Assert(p1.Compare(p2), Equals, 1)
+	c.Assert(p2.Compare(p1), Equals, -1)
+}


### PR DESCRIPTION
Fix #275 .

It was not possible to write a test for this issue as the original fsnoder didn't support filenames with length > 1.  Therefore this patch has 3 commits:

1. add support for long filenames in fsnoder.
2. add a test case for the issue using the new long filenames from step 1.
3. fix the issue by comparing paths level by level instead of lexigographically over the whole path.

