### PR TITLE
plumbing/object: move difftree to object package

### DIFF
--- a/plumbing/object/change.go
+++ b/plumbing/object/change.go
@@ -1,11 +1,10 @@
-package difftree
+package object
 
 import (
 	"bytes"
 	"fmt"
 	"strings"
 
-	"srcd.works/go-git.v4/plumbing/object"
 	"srcd.works/go-git.v4/utils/merkletrie"
 )
 
@@ -39,7 +38,7 @@ func (c *Change) Action() (merkletrie.Action, error) {
 
 // Files return the files before and after a change.
 // For insertions from will be nil. For deletions to will be nil.
-func (c *Change) Files() (from, to *object.File, err error) {
+func (c *Change) Files() (from, to *File, err error) {
 	action, err := c.Action()
 	if err != nil {
 		return
@@ -84,9 +83,9 @@ type ChangeEntry struct {
 	// Full path of the node using "/" as separator.
 	Name string
 	// Parent tree of the node that has changed.
-	Tree *object.Tree
+	Tree *Tree
 	// The entry of the node.
-	TreeEntry object.TreeEntry
+	TreeEntry TreeEntry
 }
 
 // Changes represents a collection of changes between two git trees.

--- a/plumbing/object/change_adaptor.go
+++ b/plumbing/object/change_adaptor.go
@@ -1,15 +1,14 @@
-package difftree
-
-// The folowing functions transform changes types form the merkletrie
-// package to changes types from this package.
+package object
 
 import (
 	"fmt"
 
-	"srcd.works/go-git.v4/plumbing/object"
 	"srcd.works/go-git.v4/utils/merkletrie"
 	"srcd.works/go-git.v4/utils/merkletrie/noder"
 )
+
+// The folowing functions transform changes types form the merkletrie
+// package to changes types from this package.
 
 func newChange(c merkletrie.Change) (*Change, error) {
 	ret := &Change{}
@@ -39,7 +38,7 @@ func newChangeEntry(p noder.Path) (ChangeEntry, error) {
 	return ChangeEntry{
 		Name: p.String(),
 		Tree: asTreeNoder.parent,
-		TreeEntry: object.TreeEntry{
+		TreeEntry: TreeEntry{
 			Name: asTreeNoder.name,
 			Mode: asTreeNoder.mode,
 			Hash: asTreeNoder.hash,

--- a/plumbing/object/change_adaptor_test.go
+++ b/plumbing/object/change_adaptor_test.go
@@ -1,11 +1,10 @@
-package difftree
+package object
 
 import (
 	"os"
 	"sort"
 
 	"srcd.works/go-git.v4/plumbing"
-	"srcd.works/go-git.v4/plumbing/object"
 	"srcd.works/go-git.v4/plumbing/storer"
 	"srcd.works/go-git.v4/storage/filesystem"
 	"srcd.works/go-git.v4/utils/merkletrie"
@@ -29,8 +28,8 @@ func (s *ChangeAdaptorSuite) SetUpSuite(c *C) {
 	s.Storer = sto
 }
 
-func (s *ChangeAdaptorSuite) tree(c *C, h plumbing.Hash) *object.Tree {
-	t, err := object.GetTree(s.Storer, h)
+func (s *ChangeAdaptorSuite) tree(c *C, h plumbing.Hash) *Tree {
+	t, err := GetTree(s.Storer, h)
 	c.Assert(err, IsNil)
 	return t
 }
@@ -38,7 +37,7 @@ func (s *ChangeAdaptorSuite) tree(c *C, h plumbing.Hash) *object.Tree {
 var _ = Suite(&ChangeAdaptorSuite{})
 
 // utility function to build Noders from a tree and an tree entry.
-func newNoder(t *object.Tree, e object.TreeEntry) noder.Noder {
+func newNoder(t *Tree, e TreeEntry) noder.Noder {
 	return &treeNoder{
 		parent: t,
 		name:   e.Name,
@@ -52,7 +51,7 @@ func newPath(nn ...noder.Noder) noder.Path { return noder.Path(nn) }
 
 func (s *ChangeAdaptorSuite) TestTreeNoderHashHasMode(c *C) {
 	hash := plumbing.NewHash("aaaa")
-	mode := object.FileMode
+	mode := FileMode
 
 	treeNoder := &treeNoder{
 		hash: hash,
@@ -72,8 +71,8 @@ func (s *ChangeAdaptorSuite) TestTreeNoderHashHasMode(c *C) {
 }
 
 func (s *ChangeAdaptorSuite) TestNewChangeInsert(c *C) {
-	tree := &object.Tree{}
-	entry := object.TreeEntry{
+	tree := &Tree{}
+	entry := TreeEntry{
 		Name: "name",
 		Mode: os.FileMode(42),
 		Hash: plumbing.NewHash("aaaaa"),
@@ -98,8 +97,8 @@ func (s *ChangeAdaptorSuite) TestNewChangeInsert(c *C) {
 }
 
 func (s *ChangeAdaptorSuite) TestNewChangeDelete(c *C) {
-	tree := &object.Tree{}
-	entry := object.TreeEntry{
+	tree := &Tree{}
+	entry := TreeEntry{
 		Name: "name",
 		Mode: os.FileMode(42),
 		Hash: plumbing.NewHash("aaaaa"),
@@ -124,8 +123,8 @@ func (s *ChangeAdaptorSuite) TestNewChangeDelete(c *C) {
 }
 
 func (s *ChangeAdaptorSuite) TestNewChangeModify(c *C) {
-	treeA := &object.Tree{}
-	entryA := object.TreeEntry{
+	treeA := &Tree{}
+	entryA := TreeEntry{
 		Name: "name",
 		Mode: os.FileMode(42),
 		Hash: plumbing.NewHash("aaaaa"),
@@ -134,8 +133,8 @@ func (s *ChangeAdaptorSuite) TestNewChangeModify(c *C) {
 	expectedFrom, err := newChangeEntry(pathA)
 	c.Assert(err, IsNil)
 
-	treeB := &object.Tree{}
-	entryB := object.TreeEntry{
+	treeB := &Tree{}
+	entryB := TreeEntry{
 		Name: "name",
 		Mode: os.FileMode(42),
 		Hash: plumbing.NewHash("bbbb"),
@@ -293,8 +292,8 @@ func (s *ChangeAdaptorSuite) TestChangeEntryFromNilIsZero(c *C) {
 }
 
 func (s *ChangeAdaptorSuite) TestChangeEntryFromSortPath(c *C) {
-	tree := &object.Tree{}
-	entry := object.TreeEntry{
+	tree := &Tree{}
+	entry := TreeEntry{
 		Name: "name",
 		Mode: os.FileMode(42),
 		Hash: plumbing.NewHash("aaaaa"),
@@ -310,15 +309,15 @@ func (s *ChangeAdaptorSuite) TestChangeEntryFromSortPath(c *C) {
 }
 
 func (s *ChangeAdaptorSuite) TestChangeEntryFromLongPath(c *C) {
-	treeA := &object.Tree{}
-	entryA := object.TreeEntry{
+	treeA := &Tree{}
+	entryA := TreeEntry{
 		Name: "nameA",
 		Mode: os.FileMode(42),
 		Hash: plumbing.NewHash("aaaa"),
 	}
 
-	treeB := &object.Tree{}
-	entryB := object.TreeEntry{
+	treeB := &Tree{}
+	entryB := TreeEntry{
 		Name: "nameB",
 		Mode: os.FileMode(24),
 		Hash: plumbing.NewHash("bbbb"),
@@ -352,16 +351,16 @@ func (s *ChangeAdaptorSuite) TestNewChangesEmpty(c *C) {
 }
 
 func (s *ChangeAdaptorSuite) TestNewChanges(c *C) {
-	treeA := &object.Tree{}
-	entryA := object.TreeEntry{Name: "nameA"}
+	treeA := &Tree{}
+	entryA := TreeEntry{Name: "nameA"}
 	pathA := newPath(newNoder(treeA, entryA))
 	changeA := merkletrie.Change{
 		From: nil,
 		To:   pathA,
 	}
 
-	treeB := &object.Tree{}
-	entryB := object.TreeEntry{Name: "nameB"}
+	treeB := &Tree{}
+	entryB := TreeEntry{Name: "nameB"}
 	pathB := newPath(newNoder(treeB, entryB))
 	changeB := merkletrie.Change{
 		From: pathB,

--- a/plumbing/object/change_test.go
+++ b/plumbing/object/change_test.go
@@ -1,11 +1,10 @@
-package difftree
+package object
 
 import (
 	"os"
 	"sort"
 
 	"srcd.works/go-git.v4/plumbing"
-	"srcd.works/go-git.v4/plumbing/object"
 	"srcd.works/go-git.v4/plumbing/storer"
 	"srcd.works/go-git.v4/storage/filesystem"
 	"srcd.works/go-git.v4/utils/merkletrie"
@@ -29,8 +28,8 @@ func (s *ChangeSuite) SetUpSuite(c *C) {
 	s.Storer = sto
 }
 
-func (s *ChangeSuite) tree(c *C, h plumbing.Hash) *object.Tree {
-	t, err := object.GetTree(s.Storer, h)
+func (s *ChangeSuite) tree(c *C, h plumbing.Hash) *Tree {
+	t, err := GetTree(s.Storer, h)
 	c.Assert(err, IsNil)
 	return t
 }
@@ -58,7 +57,7 @@ func (s *ChangeSuite) TestInsert(c *C) {
 		To: ChangeEntry{
 			Name: path,
 			Tree: s.tree(c, tree),
-			TreeEntry: object.TreeEntry{
+			TreeEntry: TreeEntry{
 				Name: name,
 				Mode: mode,
 				Hash: blob,
@@ -103,7 +102,7 @@ func (s *ChangeSuite) TestDelete(c *C) {
 		From: ChangeEntry{
 			Name: path,
 			Tree: s.tree(c, tree),
-			TreeEntry: object.TreeEntry{
+			TreeEntry: TreeEntry{
 				Name: name,
 				Mode: mode,
 				Hash: blob,
@@ -153,7 +152,7 @@ func (s *ChangeSuite) TestModify(c *C) {
 		From: ChangeEntry{
 			Name: path,
 			Tree: s.tree(c, fromTree),
-			TreeEntry: object.TreeEntry{
+			TreeEntry: TreeEntry{
 				Name: name,
 				Mode: mode,
 				Hash: fromBlob,
@@ -162,7 +161,7 @@ func (s *ChangeSuite) TestModify(c *C) {
 		To: ChangeEntry{
 			Name: path,
 			Tree: s.tree(c, toTree),
-			TreeEntry: object.TreeEntry{
+			TreeEntry: TreeEntry{
 				Name: name,
 				Mode: mode,
 				Hash: toBlob,
@@ -226,7 +225,7 @@ func (s *ChangeSuite) TestErrorsFindingChildsAreDetected(c *C) {
 		From: ChangeEntry{
 			Name: path,
 			Tree: s.tree(c, fromTree),
-			TreeEntry: object.TreeEntry{
+			TreeEntry: TreeEntry{
 				Name: name,
 				Mode: mode,
 				Hash: fromBlob,
@@ -243,7 +242,7 @@ func (s *ChangeSuite) TestErrorsFindingChildsAreDetected(c *C) {
 		To: ChangeEntry{
 			Name: path,
 			Tree: s.tree(c, toTree),
-			TreeEntry: object.TreeEntry{
+			TreeEntry: TreeEntry{
 				Name: name,
 				Mode: mode,
 				Hash: toBlob,

--- a/plumbing/object/difftree.go
+++ b/plumbing/object/difftree.go
@@ -1,17 +1,16 @@
-package difftree
+package object
 
 import (
 	"bytes"
 	"os"
 
-	"srcd.works/go-git.v4/plumbing/object"
 	"srcd.works/go-git.v4/utils/merkletrie"
 	"srcd.works/go-git.v4/utils/merkletrie/noder"
 )
 
 // DiffTree compares the content and mode of the blobs found via two
 // tree objects.
-func DiffTree(a, b *object.Tree) ([]*Change, error) {
+func DiffTree(a, b *Tree) (Changes, error) {
 	from := newTreeNoder(a)
 	to := newTreeNoder(b)
 
@@ -50,8 +49,8 @@ func equivalentMode(a, b []byte) bool {
 }
 
 var (
-	file           = modeToBytes(object.FileMode)
-	fileDeprecated = modeToBytes(object.FileModeDeprecated)
+	file           = modeToBytes(FileMode)
+	fileDeprecated = modeToBytes(FileModeDeprecated)
 	// remove this by fixing plumbing.Object mode ASAP
 	fileGoGit = modeToBytes(os.FileMode(0644))
 )

--- a/plumbing/object/difftree_test.go
+++ b/plumbing/object/difftree_test.go
@@ -1,13 +1,11 @@
-package difftree
+package object
 
 import (
 	"os"
 	"sort"
-	"testing"
 
 	"srcd.works/go-git.v4/plumbing"
 	"srcd.works/go-git.v4/plumbing/format/packfile"
-	"srcd.works/go-git.v4/plumbing/object"
 	"srcd.works/go-git.v4/plumbing/storer"
 	"srcd.works/go-git.v4/storage/filesystem"
 	"srcd.works/go-git.v4/storage/memory"
@@ -16,8 +14,6 @@ import (
 	"github.com/src-d/go-git-fixtures"
 	. "gopkg.in/check.v1"
 )
-
-func Test(t *testing.T) { TestingT(t) }
 
 type DiffTreeSuite struct {
 	fixtures.Suite
@@ -36,9 +32,9 @@ func (s *DiffTreeSuite) SetUpSuite(c *C) {
 }
 
 func (s *DiffTreeSuite) commitFromStorer(c *C, sto storer.EncodedObjectStorer,
-	h plumbing.Hash) *object.Commit {
+	h plumbing.Hash) *Commit {
 
-	commit, err := object.GetCommit(sto, h)
+	commit, err := GetCommit(sto, h)
 	c.Assert(err, IsNil)
 	return commit
 }
@@ -328,7 +324,7 @@ func (s *DiffTreeSuite) TestDiffTree(c *C) {
 		f := fixtures.ByURL(t.repository).One()
 		sto := s.storageFromPackfile(f)
 
-		var tree1, tree2 *object.Tree
+		var tree1, tree2 *Tree
 		var err error
 		if t.commit1 != "" {
 			tree1, err = s.commitFromStorer(c, sto,
@@ -347,6 +343,12 @@ func (s *DiffTreeSuite) TestDiffTree(c *C) {
 		obtained, err := DiffTree(tree1, tree2)
 		c.Assert(err, IsNil,
 			Commentf("subtest %d: unable to calculate difftree: %s", i, err))
+		obtainedFromMethod, err := tree1.Diff(tree2)
+		c.Assert(err, IsNil,
+			Commentf("subtest %d: unable to calculate difftree: %s. Result calling Diff method from Tree object returns an error", i, err))
+
+		c.Assert(obtained, DeepEquals, obtainedFromMethod)
+
 		c.Assert(equalChanges(obtained, t.expected, c), Equals, true,
 			Commentf("subtest:%d\nrepo=%s\ncommit1=%s\ncommit2=%s\nexpected=%s\nobtained=%s",
 				i, t.repository, t.commit1, t.commit2, t.expected, obtained))

--- a/plumbing/object/tree.go
+++ b/plumbing/object/tree.go
@@ -299,6 +299,10 @@ func (t *Tree) buildMap() {
 	}
 }
 
+func (from *Tree) Diff(to *Tree) (Changes, error) {
+	return DiffTree(from, to)
+}
+
 // treeEntryIter facilitates iterating through the TreeEntry objects in a Tree.
 type treeEntryIter struct {
 	t   *Tree

--- a/plumbing/object/tree.go
+++ b/plumbing/object/tree.go
@@ -299,6 +299,7 @@ func (t *Tree) buildMap() {
 	}
 }
 
+// Diff returns a list of changes between this tree and the provided one
 func (from *Tree) Diff(to *Tree) (Changes, error) {
 	return DiffTree(from, to)
 }

--- a/plumbing/object/treenoder.go
+++ b/plumbing/object/treenoder.go
@@ -1,4 +1,4 @@
-package difftree
+package object
 
 // A treenoder is a helper type that wraps git trees into merkletrie
 // noders.
@@ -14,19 +14,18 @@ import (
 	"os"
 
 	"srcd.works/go-git.v4/plumbing"
-	"srcd.works/go-git.v4/plumbing/object"
 	"srcd.works/go-git.v4/utils/merkletrie/noder"
 )
 
 type treeNoder struct {
-	parent   *object.Tree // the root node is its own parent
-	name     string       // empty string for the root node
+	parent   *Tree  // the root node is its own parent
+	name     string // empty string for the root node
 	mode     os.FileMode
 	hash     plumbing.Hash
 	children []noder.Noder // memoized
 }
 
-func newTreeNoder(t *object.Tree) *treeNoder {
+func newTreeNoder(t *Tree) *treeNoder {
 	if t == nil {
 		return &treeNoder{}
 	}
@@ -94,9 +93,9 @@ func (t *treeNoder) Children() ([]noder.Noder, error) {
 
 // Returns the children of a tree as treenoders.
 // Efficiency is key here.
-func transformChildren(t *object.Tree) ([]noder.Noder, error) {
+func transformChildren(t *Tree) ([]noder.Noder, error) {
 	var err error
-	var e object.TreeEntry
+	var e TreeEntry
 
 	// there will be more tree entries than children in the tree,
 	// due to submodules and empty directories, but I think it is still
@@ -104,7 +103,7 @@ func transformChildren(t *object.Tree) ([]noder.Noder, error) {
 	// is bigger than needed.
 	ret := make([]noder.Noder, 0, len(t.Entries))
 
-	walker := object.NewTreeWalker(t, false) // don't recurse
+	walker := NewTreeWalker(t, false) // don't recurse
 	// don't defer walker.Close() for efficiency reasons.
 	for {
 		_, e, err = walker.Next()


### PR DESCRIPTION
- To avoid cyclic dependency errors, we move all the difftree files to object package.
- Added Diff method to Tree object.