### PR TITLE
Add fast_finish flag to travis configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ env:
   - GIT_VERSION=v2.11.0
 
 matrix:
+  fast_finish: true
   allow_failures:
     - go: tip
 


### PR DESCRIPTION
This flag allows us to improve the time spent in travis test execution if:

- A build job fails, the build is mark as failed immediately, not waiting to finish the rest of the jobs.
- All Build jobs pass. Travis will not wait to Allowed failures jobs to mark the PR as OK.