### PR TITLE
plumbing/revlist: simplify implementation

### DIFF
--- a/plumbing/revlist/revlist_test.go
+++ b/plumbing/revlist/revlist_test.go
@@ -79,10 +79,10 @@ func (s *RevListSuite) TestRevListObjects(c *C) {
 	initCommit := s.commit(c, plumbing.NewHash(initialCommit))
 	secondCommit := s.commit(c, plumbing.NewHash(secondCommit))
 
-	localHist, err := Objects(s.Storer, []*object.Commit{initCommit}, nil)
+	localHist, err := Objects([]*object.Commit{initCommit}, nil)
 	c.Assert(err, IsNil)
 
-	remoteHist, err := Objects(s.Storer, []*object.Commit{secondCommit}, localHist)
+	remoteHist, err := Objects([]*object.Commit{secondCommit}, localHist)
 	c.Assert(err, IsNil)
 
 	for _, h := range remoteHist {
@@ -95,10 +95,10 @@ func (s *RevListSuite) TestRevListObjectsReverse(c *C) {
 	initCommit := s.commit(c, plumbing.NewHash(initialCommit))
 	secondCommit := s.commit(c, plumbing.NewHash(secondCommit))
 
-	localHist, err := Objects(s.Storer, []*object.Commit{secondCommit}, nil)
+	localHist, err := Objects([]*object.Commit{secondCommit}, nil)
 	c.Assert(err, IsNil)
 
-	remoteHist, err := Objects(s.Storer, []*object.Commit{initCommit}, localHist)
+	remoteHist, err := Objects([]*object.Commit{initCommit}, localHist)
 	c.Assert(err, IsNil)
 
 	c.Assert(len(remoteHist), Equals, 0)
@@ -107,10 +107,10 @@ func (s *RevListSuite) TestRevListObjectsReverse(c *C) {
 func (s *RevListSuite) TestRevListObjectsSameCommit(c *C) {
 	commit := s.commit(c, plumbing.NewHash(secondCommit))
 
-	localHist, err := Objects(s.Storer, []*object.Commit{commit}, nil)
+	localHist, err := Objects([]*object.Commit{commit}, nil)
 	c.Assert(err, IsNil)
 
-	remoteHist, err := Objects(s.Storer, []*object.Commit{commit}, localHist)
+	remoteHist, err := Objects([]*object.Commit{commit}, localHist)
 	c.Assert(err, IsNil)
 
 	c.Assert(len(remoteHist), Equals, 0)
@@ -126,11 +126,11 @@ func (s *RevListSuite) TestRevListObjectsNewBranch(c *C) {
 	someCommitBranch := s.commit(c, plumbing.NewHash(someCommitBranch))
 	someCommitOtherBranch := s.commit(c, plumbing.NewHash(someCommitOtherBranch))
 
-	localHist, err := Objects(s.Storer, []*object.Commit{someCommit}, nil)
+	localHist, err := Objects([]*object.Commit{someCommit}, nil)
 	c.Assert(err, IsNil)
 
 	remoteHist, err := Objects(
-		s.Storer, []*object.Commit{someCommitBranch, someCommitOtherBranch}, localHist)
+		[]*object.Commit{someCommitBranch, someCommitOtherBranch}, localHist)
 	c.Assert(err, IsNil)
 
 	revList := map[string]bool{

--- a/plumbing/transport/server/server.go
+++ b/plumbing/transport/server/server.go
@@ -158,7 +158,7 @@ func (s *upSession) objectsToUpload(req *packp.UploadPackRequest) ([]plumbing.Ha
 		return nil, err
 	}
 
-	return revlist.Objects(s.storer, commits, req.Haves)
+	return revlist.Objects(commits, req.Haves)
 }
 
 func (s *upSession) commitsToUpload(wants []plumbing.Hash) ([]*object.Commit, error) {

--- a/remote.go
+++ b/remote.go
@@ -107,7 +107,7 @@ func (r *Remote) Push(o *PushOptions) (err error) {
 		return err
 	}
 
-	hashesToPush, err := revlist.Objects(r.s, commits, haves)
+	hashesToPush, err := revlist.Objects(commits, haves)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
- Remove unnecesary param Storer
- Remove unnecesary internal error handling
- Remove redundant code