### PR TITLE
git: Repository methods changes

### DIFF
--- a/_examples/clone/main.go
+++ b/_examples/clone/main.go
@@ -28,7 +28,7 @@ func main() {
 	ref, err := r.Head()
 	CheckIfError(err)
 	// ... retrieving the commit object
-	commit, err := r.Commit(ref.Hash())
+	commit, err := r.CommitObject(ref.Hash())
 	CheckIfError(err)
 
 	fmt.Println(commit)

--- a/_examples/log/main.go
+++ b/_examples/log/main.go
@@ -30,7 +30,7 @@ func main() {
 	CheckIfError(err)
 
 	// ... retrieves the commit object
-	commit, err := r.Commit(ref.Hash())
+	commit, err := r.CommitObject(ref.Hash())
 	CheckIfError(err)
 
 	// ... retrieves the commit history

--- a/_examples/open/main.go
+++ b/_examples/open/main.go
@@ -25,7 +25,7 @@ func main() {
 	CheckIfError(err)
 
 	// ... retrieving the commit object
-	commit, err := r.Commit(ref.Hash())
+	commit, err := r.CommitObject(ref.Hash())
 	CheckIfError(err)
 
 	// ... calculating the commit history

--- a/_examples/showcase/main.go
+++ b/_examples/showcase/main.go
@@ -39,7 +39,7 @@ func main() {
 	CheckIfError(err)
 
 	// ... retrieving the commit object
-	commit, err := r.Commit(ref.Hash())
+	commit, err := r.CommitObject(ref.Hash())
 	CheckIfError(err)
 	fmt.Println(commit)
 

--- a/blame_test.go
+++ b/blame_test.go
@@ -26,7 +26,7 @@ func (s *BlameSuite) TestBlame(c *C) {
 		r := s.NewRepositoryFromPackfile(fixtures.ByURL(t.repo).One())
 
 		exp := s.mockBlame(c, t, r)
-		commit, err := r.Commit(plumbing.NewHash(t.rev))
+		commit, err := r.CommitObject(plumbing.NewHash(t.rev))
 		c.Assert(err, IsNil)
 
 		obt, err := Blame(commit, t.path)
@@ -36,7 +36,7 @@ func (s *BlameSuite) TestBlame(c *C) {
 }
 
 func (s *BlameSuite) mockBlame(c *C, t blameTest, r *Repository) (blame *BlameResult) {
-	commit, err := r.Commit(plumbing.NewHash(t.rev))
+	commit, err := r.CommitObject(plumbing.NewHash(t.rev))
 	c.Assert(err, IsNil, Commentf("%v: repo=%s, rev=%s", err, t.repo, t.rev))
 
 	f, err := commit.File(t.path)
@@ -48,7 +48,7 @@ func (s *BlameSuite) mockBlame(c *C, t blameTest, r *Repository) (blame *BlameRe
 
 	blamedLines := make([]*Line, 0, len(t.blames))
 	for i := range t.blames {
-		commit, err := r.Commit(plumbing.NewHash(t.blames[i]))
+		commit, err := r.CommitObject(plumbing.NewHash(t.blames[i]))
 		c.Assert(err, IsNil)
 		l := &Line{
 			Author: commit.Author.Email,

--- a/plumbing/storer/reference.go
+++ b/plumbing/storer/reference.go
@@ -28,6 +28,67 @@ type ReferenceIter interface {
 	Close()
 }
 
+type ReferenceFilteredIter struct {
+	ff   func(r *plumbing.Reference) bool
+	iter ReferenceIter
+}
+
+// NewReferenceFilteredIter returns a reference iterator for the given reference
+// Iterator. This iterator will iterate only references that accomplish the
+// provided function.
+func NewReferenceFilteredIter(
+	ff func(r *plumbing.Reference) bool, iter ReferenceIter) ReferenceIter {
+	return &ReferenceFilteredIter{ff, iter}
+}
+
+// Next returns the next reference from the iterator. If the iterator has reached
+// the end it will return io.EOF as an error.
+func (iter *ReferenceFilteredIter) Next() (*plumbing.Reference, error) {
+	for {
+		r, err := iter.iter.Next()
+		if err != nil {
+			return nil, err
+		}
+
+		if iter.ff(r) {
+			return r, nil
+		}
+
+		continue
+	}
+}
+
+// ForEach call the cb function for each reference contained on this iter until
+// an error happens or the end of the iter is reached. If ErrStop is sent
+// the iteration is stopped but no error is returned. The iterator is closed.
+func (iter *ReferenceFilteredIter) ForEach(cb func(*plumbing.Reference) error) error {
+	defer iter.Close()
+	for {
+		r, err := iter.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return err
+		}
+
+		if err := cb(r); err != nil {
+			if err == ErrStop {
+				break
+			}
+
+			return err
+		}
+	}
+
+	return nil
+}
+
+// Close releases any resources used by the iterator.
+func (iter *ReferenceFilteredIter) Close() {
+	iter.iter.Close()
+}
+
 // ReferenceSliceIter implements ReferenceIter. It iterates over a series of
 // references stored in a slice and yields each one in turn when Next() is
 // called.
@@ -41,7 +102,7 @@ type ReferenceSliceIter struct {
 
 // NewReferenceSliceIter returns a reference iterator for the given slice of
 // objects.
-func NewReferenceSliceIter(series []*plumbing.Reference) *ReferenceSliceIter {
+func NewReferenceSliceIter(series []*plumbing.Reference) ReferenceIter {
 	return &ReferenceSliceIter{
 		series: series,
 	}

--- a/plumbing/storer/reference.go
+++ b/plumbing/storer/reference.go
@@ -28,7 +28,7 @@ type ReferenceIter interface {
 	Close()
 }
 
-type ReferenceFilteredIter struct {
+type referenceFilteredIter struct {
 	ff   func(r *plumbing.Reference) bool
 	iter ReferenceIter
 }
@@ -38,12 +38,12 @@ type ReferenceFilteredIter struct {
 // provided function.
 func NewReferenceFilteredIter(
 	ff func(r *plumbing.Reference) bool, iter ReferenceIter) ReferenceIter {
-	return &ReferenceFilteredIter{ff, iter}
+	return &referenceFilteredIter{ff, iter}
 }
 
 // Next returns the next reference from the iterator. If the iterator has reached
 // the end it will return io.EOF as an error.
-func (iter *ReferenceFilteredIter) Next() (*plumbing.Reference, error) {
+func (iter *referenceFilteredIter) Next() (*plumbing.Reference, error) {
 	for {
 		r, err := iter.iter.Next()
 		if err != nil {
@@ -61,7 +61,7 @@ func (iter *ReferenceFilteredIter) Next() (*plumbing.Reference, error) {
 // ForEach call the cb function for each reference contained on this iter until
 // an error happens or the end of the iter is reached. If ErrStop is sent
 // the iteration is stopped but no error is returned. The iterator is closed.
-func (iter *ReferenceFilteredIter) ForEach(cb func(*plumbing.Reference) error) error {
+func (iter *referenceFilteredIter) ForEach(cb func(*plumbing.Reference) error) error {
 	defer iter.Close()
 	for {
 		r, err := iter.Next()
@@ -85,7 +85,7 @@ func (iter *ReferenceFilteredIter) ForEach(cb func(*plumbing.Reference) error) e
 }
 
 // Close releases any resources used by the iterator.
-func (iter *ReferenceFilteredIter) Close() {
+func (iter *referenceFilteredIter) Close() {
 	iter.iter.Close()
 }
 

--- a/references_test.go
+++ b/references_test.go
@@ -291,7 +291,7 @@ func (s *ReferencesSuite) TestRevList(c *C) {
 	for _, t := range referencesTests {
 		r := s.NewRepositoryFromPackfile(fixtures.ByURL(t.repo).One())
 
-		commit, err := r.Commit(plumbing.NewHash(t.commit))
+		commit, err := r.CommitObject(plumbing.NewHash(t.commit))
 		c.Assert(err, IsNil)
 
 		revs, err := References(commit, t.path)
@@ -300,7 +300,7 @@ func (s *ReferencesSuite) TestRevList(c *C) {
 
 		for i := range revs {
 			if revs[i].Hash.String() != t.revs[i] {
-				commit, err := s.Repository.Commit(plumbing.NewHash(t.revs[i]))
+				commit, err := s.Repository.CommitObject(plumbing.NewHash(t.revs[i]))
 				c.Assert(err, IsNil)
 				equiv, err := equivalent(t.path, revs[i], commit)
 				c.Assert(err, IsNil)
@@ -358,7 +358,7 @@ func (s *ReferencesSuite) commits(c *C, repo string, hs ...string) []*object.Com
 
 	result := make([]*object.Commit, 0, len(hs))
 	for _, h := range hs {
-		commit, err := r.Commit(plumbing.NewHash(h))
+		commit, err := r.CommitObject(plumbing.NewHash(h))
 		c.Assert(err, IsNil)
 
 		result = append(result, commit)

--- a/worktree.go
+++ b/worktree.go
@@ -34,7 +34,7 @@ func (w *Worktree) Checkout(commit plumbing.Hash) error {
 		return ErrWorktreeNotClean
 	}
 
-	c, err := w.r.Commit(commit)
+	c, err := w.r.CommitObject(commit)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
To have a more consistent public API, we decided to rename some methods and add others:

- Commit method renamed to CommitObject
- Commits method renamed to CommitObjects
- Tags method renamed to TagObjects
- Tag method renamed to TagObject
- Added method Tags that returns tag references
- Added method Branches that returns branch references
- Added method Notes that returns note references
- Added BlobObject method
- Added BlobObjects method
- Remove Tree method
- Remove Trees method

Also, we added more functionality related to references:
- Added iterator to iterate References with a specific filter

Some notes:
- #298