### PR TITLE
plumbing: Use ReadBytes() rather than ReadSlice()

### DIFF
--- a/plumbing/object/commit.go
+++ b/plumbing/object/commit.go
@@ -130,7 +130,7 @@ func (c *Commit) Decode(o plumbing.EncodedObject) (err error) {
 
 	var message bool
 	for {
-		line, err := r.ReadSlice('\n')
+		line, err := r.ReadBytes('\n')
 		if err != nil && err != io.EOF {
 			return err
 		}

--- a/plumbing/object/commit_test.go
+++ b/plumbing/object/commit_test.go
@@ -2,6 +2,7 @@ package object
 
 import (
 	"io"
+	"strings"
 	"time"
 
 	"github.com/src-d/go-git-fixtures"
@@ -166,4 +167,20 @@ func (s *SuiteCommit) TestCommitIterNext(c *C) {
 	commit, err = i.Next()
 	c.Assert(err, Equals, io.EOF)
 	c.Assert(commit, IsNil)
+}
+
+func (s *SuiteCommit) TestLongCommitMessageSerialization(c *C) {
+	encoded := &plumbing.MemoryObject{}
+	decoded := &Commit{}
+	commit := *s.Commit
+
+	longMessage := "my message: message\n\n" + strings.Repeat("test", 4096) + "\nOK"
+	commit.Message = longMessage
+
+	err := commit.Encode(encoded)
+	c.Assert(err, IsNil)
+
+	err = decoded.Decode(encoded)
+	c.Assert(err, IsNil)
+	c.Assert(decoded.Message, Equals, longMessage)
 }

--- a/plumbing/object/tag.go
+++ b/plumbing/object/tag.go
@@ -90,7 +90,7 @@ func (t *Tag) Decode(o plumbing.EncodedObject) (err error) {
 
 	r := bufio.NewReader(reader)
 	for {
-		line, err := r.ReadSlice('\n')
+		line, err := r.ReadBytes('\n')
 		if err != nil && err != io.EOF {
 			return err
 		}

--- a/plumbing/object/tag_test.go
+++ b/plumbing/object/tag_test.go
@@ -3,6 +3,7 @@ package object
 import (
 	"fmt"
 	"io"
+	"strings"
 	"time"
 
 	"github.com/src-d/go-git-fixtures"
@@ -268,4 +269,20 @@ func (s *TagSuite) TestTagToTagString(c *C) {
 			"Date:   Mon Jan 01 00:00:00 0001 +0000\n"+
 			"\n"+
 			"\n")
+}
+
+func (s *TagSuite) TestLongTagNameSerialization(c *C) {
+	encoded := &plumbing.MemoryObject{}
+	decoded := &Tag{}
+	tag := s.tag(c, plumbing.NewHash("b742a2a9fa0afcfa9a6fad080980fbc26b007c69"))
+
+	longName := "my tag: name " + strings.Repeat("test", 4096) + " OK"
+	tag.Name = longName
+
+	err := tag.Encode(encoded)
+	c.Assert(err, IsNil)
+
+	err = decoded.Decode(encoded)
+	c.Assert(err, IsNil)
+	c.Assert(decoded.Name, Equals, longName)
 }


### PR DESCRIPTION
Fixes https://github.com/src-d/go-git/issues/249