### PR TITLE
Updated README in-memory example.

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ ref, err := r.Head()
 CheckIfError(err)
 
 // ... retrieves the commit object
-commit, err := r.Commit(ref.Hash())
+commit, err := r.CommitObject(ref.Hash())
 CheckIfError(err)
 
 // ... retrieves the commit history


### PR DESCRIPTION
The README example was out of date, the Commit method no longer exists.