### PR TITLE
references.go: fix Parents from commit iterator

### DIFF
--- a/references_test.go
+++ b/references_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/src-d/go-git-fixtures"
 	"gopkg.in/src-d/go-git.v4/plumbing"
 	"gopkg.in/src-d/go-git.v4/plumbing/object"
+	"gopkg.in/src-d/go-git.v4/storage/memory"
 
 	. "gopkg.in/check.v1"
 )
@@ -285,6 +286,26 @@ var referencesTests = [...]struct {
 			"079e42e7c979541b6fab7343838f7b9fd4a360cd",
 		}},
 	*/
+}
+
+func (s *ReferencesSuite) TestObjectNotFoundError(c *C) {
+	h1 := plumbing.NewHash("af2d6a6954d532f8ffb47615169c8fdf9d383a1a")
+	hParent := plumbing.NewHash("1669dce138d9b841a518c64b10914d88f5e488ea")
+
+	url := fixtures.ByURL("https://github.com/git-fixtures/basic.git").One().DotGit().Base()
+	storer := memory.NewStorage()
+	r, err := Clone(storer, nil, &CloneOptions{
+		URL: "file://" + url,
+	})
+	c.Assert(err, IsNil)
+
+	delete(storer.Objects, hParent)
+
+	commit, err := r.CommitObject(h1)
+	c.Assert(err, IsNil)
+
+	_, err = references(commit, "LICENSE")
+	c.Assert(err, Equals, plumbing.ErrObjectNotFound)
 }
 
 func (s *ReferencesSuite) TestRevList(c *C) {


### PR DESCRIPTION
Avoid a panic when we are iterating parents from a commit. There are more than EOF errors, like Parse errors. Now instead of throw a panic we return the error.