### PR TITLE
Work around a Go bug when parsing timezones

### DIFF
--- a/plumbing/object/object.go
+++ b/plumbing/object/object.go
@@ -138,7 +138,12 @@ func (s *Signature) decodeTimeAndTimeZone(b []byte) {
 		return
 	}
 
-	tl, err := time.Parse("-0700", string(b[tzStart:tzStart+timeZoneLength]))
+	// Include a dummy year in this time.Parse() call to avoid a bug in Go:
+	// https://github.com/golang/go/issues/19750
+	//
+	// Parsing the timezone with no other details causes the tl.Location() call
+	// below to return time.Local instead of the parsed zone in some cases
+	tl, err := time.Parse("2006 -0700", "1970 "+string(b[tzStart:tzStart+timeZoneLength]))
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
On my machine, which has a local time of +0100, commits with a timezone of +0000 adopt the local timezone. This is noted as a bug in https://github.com/golang/go/issues/19750 - assigned to the Go 1.9 milestone.

This workaround fixes commit timezone parsing in the interim.

I don't know a way to reproduce this error in a test case, so there are no spec changes, but I've manually tested the change and it does resolve the issue for me locally. Here's the same test case, before and after:

```
=== RUN   TestIndexingGitlabTest
2017/03/30 19:32:18 Indexing from 0000000000000000000000000000000000000000 to b83d6e391c22777fca1ed3012fce84f633d7fed0
2017/03/30 19:32:18 Index: gitlab-test-1490898738, Project ID: 667
--- FAIL: TestIndexingGitlabTest (0.75s)
        Error Trace:    integration_test.go:163
        Error:          Not equal:
                        expected: map[string]interface {}{"type":"commit", "sha":"b83d6e391c22777fca1ed3012fce84f633d7fed0", "author":map[string]interface {}{"email":"job@gitlab.com", "name":"Job van der Voort", "time":"20160927T143746+0000"}, "committer":map[string]interface {}{"name":"Job van der Voort", "time":"20160927T143746+0000", "email":"job@gitlab.com"}, "rid":"667", "message":"Merge branch 'branch-merged' into 'master'\r\n\r\nadds bar folder and branch-test text file to check Repository merged_to_root_ref method\r\n\r\n\r\n\r\nSee merge request !12"}
                        received: map[string]interface {}{"rid":"667", "message":"Merge branch 'branch-merged' into 'master'\r\n\r\nadds bar folder and branch-test text file to check Repository merged_to_root_ref method\r\n\r\n\r\n\r\nSee merge request !12", "sha":"b83d6e391c22777fca1ed3012fce84f633d7fed0", "type":"commit", "author":map[string]interface {}{"name":"Job van der Voort", "email":"job@gitlab.com", "time":"20160927T153746+0100"}, "committer":map[string]interface {}{"name":"Job van der Voort", "email":"job@gitlab.com", "time":"20160927T153746+0100"}}

                        Diff:
                        --- Expected
                        +++ Actual
                        @@ -4,3 +4,3 @@
                           (string) (len=4) "name": (string) (len=17) "Job van der Voort",
                        -  (string) (len=4) "time": (string) (len=20) "20160927T143746+0000"
                        +  (string) (len=4) "time": (string) (len=20) "20160927T153746+0100"
                          },
                        @@ -9,3 +9,3 @@
                           (string) (len=4) "name": (string) (len=17) "Job van der Voort",
                        -  (string) (len=4) "time": (string) (len=20) "20160927T143746+0000"
                        +  (string) (len=4) "time": (string) (len=20) "20160927T153746+0100"
                          },
FAIL
```

```
=== RUN   TestIndexingGitlabTest
2017/03/30 19:37:34 Indexing from 0000000000000000000000000000000000000000 to b83d6e391c22777fca1ed3012fce84f633d7fed0
2017/03/30 19:37:34 Index: gitlab-test-1490899054, Project ID: 667
--- PASS: TestIndexingGitlabTest (0.78s)
PASS
```

Closes #318