### PR TITLE
object: fix Change.Files() method behavior (fix #317)

### DIFF
--- a/plumbing/object/change.go
+++ b/plumbing/object/change.go
@@ -46,6 +46,10 @@ func (c *Change) Files() (from, to *File, err error) {
 
 	if action == merkletrie.Insert || action == merkletrie.Modify {
 		to, err = c.To.Tree.TreeEntryFile(&c.To.TreeEntry)
+		if !c.To.TreeEntry.Mode.IsFile() {
+			return nil, nil, nil
+		}
+
 		if err != nil {
 			return
 		}
@@ -53,6 +57,10 @@ func (c *Change) Files() (from, to *File, err error) {
 
 	if action == merkletrie.Delete || action == merkletrie.Modify {
 		from, err = c.From.Tree.TreeEntryFile(&c.From.TreeEntry)
+		if !c.From.TreeEntry.Mode.IsFile() {
+			return nil, nil, nil
+		}
+
 		if err != nil {
 			return
 		}

--- a/plumbing/object/change_adaptor_test.go
+++ b/plumbing/object/change_adaptor_test.go
@@ -214,6 +214,7 @@ func (s *ChangeAdaptorSuite) TestChangeFilesInsert(c *C) {
 	change := Change{}
 	change.To.Name = "json/long.json"
 	change.To.Tree = tree
+	change.To.TreeEntry.Mode = filemode.Regular
 	change.To.TreeEntry.Hash = plumbing.NewHash("49c6bb89b17060d7b4deacb7b338fcc6ea2352a9")
 
 	from, to, err := change.Files()
@@ -228,6 +229,7 @@ func (s *ChangeAdaptorSuite) TestChangeFilesInsertNotFound(c *C) {
 	change := Change{}
 	change.To.Name = "json/long.json"
 	change.To.Tree = tree
+	change.To.TreeEntry.Mode = filemode.Regular
 	// there is no object for this hash
 	change.To.TreeEntry.Hash = plumbing.NewHash("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
 
@@ -241,6 +243,7 @@ func (s *ChangeAdaptorSuite) TestChangeFilesDelete(c *C) {
 	change := Change{}
 	change.From.Name = "json/long.json"
 	change.From.Tree = tree
+	change.From.TreeEntry.Mode = filemode.Regular
 	change.From.TreeEntry.Hash = plumbing.NewHash("49c6bb89b17060d7b4deacb7b338fcc6ea2352a9")
 
 	from, to, err := change.Files()
@@ -255,6 +258,7 @@ func (s *ChangeAdaptorSuite) TestChangeFilesDeleteNotFound(c *C) {
 	change := Change{}
 	change.From.Name = "json/long.json"
 	change.From.Tree = tree
+	change.From.TreeEntry.Mode = filemode.Regular
 	// there is no object for this hash
 	change.From.TreeEntry.Hash = plumbing.NewHash("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
 
@@ -268,9 +272,11 @@ func (s *ChangeAdaptorSuite) TestChangeFilesModify(c *C) {
 	change := Change{}
 	change.To.Name = "json/long.json"
 	change.To.Tree = tree
+	change.To.TreeEntry.Mode = filemode.Regular
 	change.To.TreeEntry.Hash = plumbing.NewHash("49c6bb89b17060d7b4deacb7b338fcc6ea2352a9")
 	change.From.Name = "json/long.json"
 	change.From.Tree = tree
+	change.From.TreeEntry.Mode = filemode.Regular
 	change.From.TreeEntry.Hash = plumbing.NewHash("9a48f23120e880dfbe41f7c9b7b708e9ee62a492")
 
 	from, to, err := change.Files()


### PR DESCRIPTION
- If 'from' or 'to' are tree entries that aren't files, Files() method will return nil instead of object not found error.
- Added a test checking this using modules fixture.