### PR TITLE
add git checkout example + housekeeping

### DIFF
--- a/_examples/README.md
+++ b/_examples/README.md
@@ -10,6 +10,7 @@ Here you can find a list of annotated _go-git_ examples:
 - [remotes](remotes/main.go) - Working with remotes: adding, removing, etc
 - [progress](progress/main.go) - Printing the progress information from the sideband
 - [push](push/main.go) - Push repository to default remote (origin)
+- [checkout](checkout/main.go) - check out a specific commit from a repository.
 ### Advanced
 - [custom_http](custom_http/main.go) - Replacing the HTTP client using a custom one
 - [storage](storage/README.md) - Implementing a custom storage system

--- a/_examples/checkout/main.go
+++ b/_examples/checkout/main.go
@@ -15,11 +15,10 @@ func main() {
 	url, directory, commitRef := os.Args[1], os.Args[2], os.Args[3]
 
 	// Clone the given repository to the given directory
-	Info("git clone %s %s --recursive", url, directory)
+	Info("git clone %s %s", url, directory)
 
 	r, err := git.PlainClone(directory, false, &git.CloneOptions{
-		URL:               url,
-		RecurseSubmodules: git.DefaultSubmoduleRecursionDepth,
+		URL: url,
 	})
 
 	CheckIfError(err)

--- a/_examples/checkout/main.go
+++ b/_examples/checkout/main.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"gopkg.in/src-d/go-git.v4"
+	. "gopkg.in/src-d/go-git.v4/_examples"
+	"gopkg.in/src-d/go-git.v4/plumbing"
+)
+
+// Basic example of how to checkout a specific commit.
+func main() {
+	CheckArgs("<url>", "<directory>", "<commit-ref>")
+	url, directory, commitRef := os.Args[1], os.Args[2], os.Args[3]
+
+	// Clone the given repository to the given directory
+	Info("git clone %s %s --recursive", url, directory)
+
+	r, err := git.PlainClone(directory, false, &git.CloneOptions{
+		URL:               url,
+		RecurseSubmodules: git.DefaultSubmoduleRecursionDepth,
+	})
+
+	CheckIfError(err)
+
+	Info("git checkout %s", commitRef)
+
+	w, err := r.Worktree()
+
+	CheckIfError(err)
+
+	CheckIfError(w.Checkout(plumbing.NewHash(commitRef)))
+
+	fmt.Println("voila")
+}

--- a/_examples/common.go
+++ b/_examples/common.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 )
 
-// CheckArgs should be uesed to esnure the right command line arguments are
+// CheckArgs should be used to esnure the right command line arguments are
 // passed before executing an example.
 func CheckArgs(arg ...string) {
 	if len(os.Args) < len(arg)+1 {
@@ -15,7 +15,7 @@ func CheckArgs(arg ...string) {
 	}
 }
 
-// CheckIfError should be used to naiivly panics if an error is not nil.
+// CheckIfError should be used to naively panics if an error is not nil.
 func CheckIfError(err error) {
 	if err == nil {
 		return

--- a/_examples/common.go
+++ b/_examples/common.go
@@ -6,6 +6,8 @@ import (
 	"strings"
 )
 
+// CheckArgs should be uesed to esnure the right command line arguments are
+// passed before executing an example.
 func CheckArgs(arg ...string) {
 	if len(os.Args) < len(arg)+1 {
 		Warning("Usage: %s %s", os.Args[0], strings.Join(arg, " "))
@@ -13,6 +15,7 @@ func CheckArgs(arg ...string) {
 	}
 }
 
+// CheckIfError should be used to naiivly panics if an error is not nil.
 func CheckIfError(err error) {
 	if err == nil {
 		return
@@ -22,10 +25,12 @@ func CheckIfError(err error) {
 	os.Exit(1)
 }
 
+// Info should be used to describe the example commands that are about to run.
 func Info(format string, args ...interface{}) {
 	fmt.Printf("\x1b[34;1m%s\x1b[0m\n", fmt.Sprintf(format, args...))
 }
 
+// Warning should be used to display a warning
 func Warning(format string, args ...interface{}) {
 	fmt.Printf("\x1b[36;1m%s\x1b[0m\n", fmt.Sprintf(format, args...))
 }

--- a/_examples/common_test.go
+++ b/_examples/common_test.go
@@ -16,12 +16,13 @@ var examplesTest = flag.Bool("examples", false, "run the examples tests")
 var defaultURL = "https://github.com/mcuadros/basic.git"
 
 var args = map[string][]string{
-	"showcase":    []string{defaultURL, tempFolder()},
-	"custom_http": []string{defaultURL},
+	"checkout":    []string{defaultURL, tempFolder(), "35e85108805c84807bc66a02d91535e1e24b38b9"},
 	"clone":       []string{defaultURL, tempFolder()},
-	"progress":    []string{defaultURL, tempFolder()},
+	"custom_http": []string{defaultURL},
 	"open":        []string{cloneRepository(defaultURL, tempFolder())},
+	"progress":    []string{defaultURL, tempFolder()},
 	"push":        []string{setEmptyRemote(cloneRepository(defaultURL, tempFolder()))},
+	"showcase":    []string{defaultURL, tempFolder()},
 }
 
 var ignored = map[string]bool{}


### PR DESCRIPTION
Added a `git checkout <ref>` examples. 

One thing that's a bit different from the CLI command, is that when you do `git checkout <ref>` in the git CLI, your repo gets checked out in a detached state. However, go-git keeps you in the same branch with the added difference. Not sure if that's a bug or a feature. Or maybe there's another way to do checkout that mimics the CLI results.