### PR TITLE
Add Repository.Log() method (fix #298)

### DIFF
--- a/_examples/log/main.go
+++ b/_examples/log/main.go
@@ -5,6 +5,7 @@ import (
 
 	"gopkg.in/src-d/go-git.v4"
 	. "gopkg.in/src-d/go-git.v4/_examples"
+	"gopkg.in/src-d/go-git.v4/plumbing/object"
 	"gopkg.in/src-d/go-git.v4/storage/memory"
 )
 
@@ -29,16 +30,15 @@ func main() {
 	ref, err := r.Head()
 	CheckIfError(err)
 
-	// ... retrieves the commit object
-	commit, err := r.CommitObject(ref.Hash())
-	CheckIfError(err)
-
 	// ... retrieves the commit history
-	history, err := commit.History()
+	cIter, err := r.Log(&git.LogOptions{From: ref.Hash()})
 	CheckIfError(err)
 
 	// ... just iterates over the commits, printing it
-	for _, c := range history {
+	err = cIter.ForEach(func(c *object.Commit) error {
 		fmt.Println(c)
-	}
+
+		return nil
+	})
+	CheckIfError(err)
 }

--- a/_examples/open/main.go
+++ b/_examples/open/main.go
@@ -6,6 +6,7 @@ import (
 
 	"gopkg.in/src-d/go-git.v4"
 	. "gopkg.in/src-d/go-git.v4/_examples"
+	"gopkg.in/src-d/go-git.v4/plumbing/object"
 )
 
 // Open an existing repository in a specific folder.
@@ -24,13 +25,18 @@ func main() {
 	ref, err := r.Head()
 	CheckIfError(err)
 
-	// ... retrieving the commit object
-	commit, err := r.CommitObject(ref.Hash())
+	// ... retrieves the commit history
+	cIter, err := r.Log(&git.LogOptions{From: ref.Hash()})
 	CheckIfError(err)
 
-	// ... calculating the commit history
-	commits, err := commit.History()
+	// ... just iterates over the commits
+	var cCount int
+	err = cIter.ForEach(func(c *object.Commit) error {
+		cCount++
+
+		return nil
+	})
 	CheckIfError(err)
 
-	fmt.Println(len(commits))
+	fmt.Println(cCount)
 }

--- a/_examples/showcase/main.go
+++ b/_examples/showcase/main.go
@@ -59,12 +59,15 @@ func main() {
 	// List the history of the repository
 	Info("git log --oneline")
 
-	commits, err := commit.History()
+	commitIter, err := r.Log(&git.LogOptions{From: commit.Hash})
 	CheckIfError(err)
 
-	for _, c := range commits {
+	err = commitIter.ForEach(func(c *object.Commit) error {
 		hash := c.Hash.String()
 		line := strings.Split(c.Message, "\n")
 		fmt.Println(hash[:7], line[0])
-	}
+
+		return nil
+	})
+	CheckIfError(err)
 }

--- a/blame.go
+++ b/blame.go
@@ -142,11 +142,11 @@ type blame struct {
 	graph [][]*object.Commit
 }
 
-// calculte the history of a file "path", starting from commit "from", sorted by commit date.
+// calculate the history of a file "path", starting from commit "from", sorted by commit date.
 func (b *blame) fillRevs() error {
 	var err error
 
-	b.revs, err = References(b.fRev, b.path)
+	b.revs, err = references(b.fRev, b.path)
 	if err != nil {
 		return err
 	}

--- a/options.go
+++ b/options.go
@@ -177,3 +177,11 @@ type SubmoduleUpdateOptions struct {
 	// submodules (and so on). Until the SubmoduleRescursivity is reached.
 	RecurseSubmodules SubmoduleRescursivity
 }
+
+// LogOptions describes how a log action should be performed.
+type LogOptions struct {
+	// When the From option is set the log will only contain commits
+	// reachable from it. If this option is not set, HEAD will be used as
+	// the default From.
+	From plumbing.Hash
+}

--- a/plumbing/object/commit_test.go
+++ b/plumbing/object/commit_test.go
@@ -62,6 +62,8 @@ func (s *SuiteCommit) TestParents(c *C) {
 
 	c.Assert(err, IsNil)
 	c.Assert(output, DeepEquals, expected)
+
+	i.Close()
 }
 
 func (s *SuiteCommit) TestCommitEncodeDecodeIdempotent(c *C) {
@@ -108,14 +110,6 @@ func (s *SuiteCommit) TestFile(c *C) {
 
 func (s *SuiteCommit) TestNumParents(c *C) {
 	c.Assert(s.Commit.NumParents(), Equals, 2)
-}
-
-func (s *SuiteCommit) TestHistory(c *C) {
-	commits, err := s.Commit.History()
-	c.Assert(err, IsNil)
-	c.Assert(commits, HasLen, 5)
-	c.Assert(commits[0].Hash.String(), Equals, s.Commit.Hash.String())
-	c.Assert(commits[len(commits)-1].Hash.String(), Equals, "b029517f6300c2da0f4b651b8642506cd6aaf45d")
 }
 
 func (s *SuiteCommit) TestString(c *C) {

--- a/plumbing/object/commit_walker.go
+++ b/plumbing/object/commit_walker.go
@@ -4,93 +4,150 @@ import (
 	"io"
 
 	"gopkg.in/src-d/go-git.v4/plumbing"
+	"gopkg.in/src-d/go-git.v4/plumbing/storer"
 )
 
-type commitWalker struct {
+type commitPreIterator struct {
 	seen  map[plumbing.Hash]bool
-	stack []*CommitIter
+	stack []CommitIter
 	start *Commit
-	cb    func(*Commit) error
 }
 
-// WalkCommitHistory walks the commit history, starting at the given commit and
-// visiting its parents in pre-order. The given callback will be called for each
-// visited commit. Each commit will be visited only once. If the callback returns
-// an error, walking will stop and will return the error. Other errors might be
-// returned if the history cannot be traversed (e.g. missing objects).
-func WalkCommitHistory(c *Commit, cb func(*Commit) error) error {
-	w := &commitWalker{
+// NewCommitPreIterator returns a CommitIter that walks the commit history,
+// starting at the given commit and visiting its parents in pre-order.
+// The given callback will be called for each visited commit. Each commit will
+// be visited only once. If the callback returns an error, walking will stop
+// and will return the error. Other errors might be returned if the history
+// cannot be traversed (e.g. missing objects).
+func NewCommitPreIterator(c *Commit) CommitIter {
+	return &commitPreIterator{
 		seen:  make(map[plumbing.Hash]bool),
-		stack: make([]*CommitIter, 0),
+		stack: make([]CommitIter, 0),
 		start: c,
-		cb:    cb,
 	}
-
-	return w.walk()
 }
 
-func (w *commitWalker) walk() error {
-	var commit *Commit
+func (w *commitPreIterator) Next() (*Commit, error) {
+	var c *Commit
+	for {
+		if w.start != nil {
+			c = w.start
+			w.start = nil
+		} else {
+			current := len(w.stack) - 1
+			if current < 0 {
+				return nil, io.EOF
+			}
 
-	if w.start != nil {
-		commit = w.start
-		w.start = nil
-	} else {
-		current := len(w.stack) - 1
-		if current < 0 {
-			return nil
+			var err error
+			c, err = w.stack[current].Next()
+			if err == io.EOF {
+				w.stack = w.stack[:current]
+				continue
+			}
+
+			if err != nil {
+				return nil, err
+			}
 		}
 
-		var err error
-		commit, err = w.stack[current].Next()
+		// check and update seen
+		if w.seen[c.Hash] {
+			continue
+		}
+
+		w.seen[c.Hash] = true
+		if c.NumParents() > 0 {
+			w.stack = append(w.stack, c.Parents())
+		}
+
+		return c, nil
+	}
+}
+
+func (w *commitPreIterator) ForEach(cb func(*Commit) error) error {
+	for {
+		c, err := w.Next()
 		if err == io.EOF {
-			w.stack = w.stack[:current]
-			return w.walk()
+			break
+		}
+		if err != nil {
+			return err
 		}
 
+		err = cb(c)
+		if err == storer.ErrStop {
+			break
+		}
 		if err != nil {
 			return err
 		}
 	}
 
-	// check and update seen
-	if w.seen[commit.Hash] {
-		return w.walk()
-	}
-
-	w.seen[commit.Hash] = true
-	if commit.NumParents() > 0 {
-		w.stack = append(w.stack, commit.Parents())
-	}
-
-	if err := w.cb(commit); err != nil {
-		return err
-	}
-
-	return w.walk()
-}
-
-// WalkCommitHistoryPost walks the commit history like WalkCommitHistory
-// but in post-order. This means that after walking a merge commit, the
-// merged commit will be walked before the base it was merged on. This
-// can be useful if you wish to see the history in chronological order.
-func WalkCommitHistoryPost(c *Commit, cb func(*Commit) error) error {
-	stack := []*Commit{c}
-	seen := make(map[plumbing.Hash]bool)
-	for len(stack) > 0 {
-		c := stack[len(stack)-1]
-		stack = stack[:len(stack)-1]
-		if seen[c.Hash] {
-			continue
-		}
-		seen[c.Hash] = true
-		if err := cb(c); err != nil {
-			return err
-		}
-		c.Parents().ForEach(func(pcm *Commit) error {
-			stack = append(stack, pcm)
-			return nil
-		})
-	}
 	return nil
 }
+
+func (w *commitPreIterator) Close() {}
+
+type commitPostIterator struct {
+	stack []*Commit
+	seen  map[plumbing.Hash]bool
+}
+
+// NewCommitPostIterator returns a CommitIter that walks the commit
+// history like WalkCommitHistory but in post-order. This means that after
+// walking a merge commit, the merged commit will be walked before the base
+// it was merged on. This can be useful if you wish to see the history in
+// chronological order.
+func NewCommitPostIterator(c *Commit) CommitIter {
+	return &commitPostIterator{
+		stack: []*Commit{c},
+		seen:  make(map[plumbing.Hash]bool),
+	}
+}
+
+func (w *commitPostIterator) Next() (*Commit, error) {
+	for {
+		if len(w.stack) == 0 {
+			return nil, io.EOF
+		}
+
+		c := w.stack[len(w.stack)-1]
+		w.stack = w.stack[:len(w.stack)-1]
+		if w.seen[c.Hash] {
+			continue
+		}
+		w.seen[c.Hash] = true
+
+		err := c.Parents().ForEach(func(pcm *Commit) error {
+			w.stack = append(w.stack, pcm)
+			return nil
+		})
+
+		return c, err
+	}
+}
+
+func (w *commitPostIterator) ForEach(cb func(*Commit) error) error {
+	for {
+		c, err := w.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return err
+		}
+
+		err = cb(c)
+		if err == storer.ErrStop {
+			break
+		}
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (w *commitPostIterator) Close() {}

--- a/plumbing/object/commit_walker_test.go
+++ b/plumbing/object/commit_walker_test.go
@@ -8,11 +8,12 @@ type CommitWalkerSuite struct {
 
 var _ = Suite(&CommitWalkerSuite{})
 
-func (s *CommitWalkerSuite) TestWalkHistory(c *C) {
+func (s *CommitWalkerSuite) TestCommitPreIterator(c *C) {
 	commit := s.commit(c, s.Fixture.Head)
 
 	var commits []*Commit
-	WalkCommitHistory(commit, func(c *Commit) error {
+	wIter := NewCommitPreIterator(commit)
+	wIter.ForEach(func(c *Commit) error {
 		commits = append(commits, c)
 		return nil
 	})
@@ -34,11 +35,12 @@ func (s *CommitWalkerSuite) TestWalkHistory(c *C) {
 	}
 }
 
-func (s *CommitWalkerSuite) TestWalkHistoryPost(c *C) {
+func (s *CommitWalkerSuite) TestCommitPostIterator(c *C) {
 	commit := s.commit(c, s.Fixture.Head)
 
 	var commits []*Commit
-	WalkCommitHistoryPost(commit, func(c *Commit) error {
+	wIter := NewCommitPostIterator(commit)
+	wIter.ForEach(func(c *Commit) error {
 		commits = append(commits, c)
 		return nil
 	})

--- a/plumbing/revlist/revlist.go
+++ b/plumbing/revlist/revlist.go
@@ -82,20 +82,21 @@ func reachableObjects(
 	commit *object.Commit,
 	seen map[plumbing.Hash]bool,
 	cb func(h plumbing.Hash)) error {
-	return object.WalkCommitHistory(commit, func(commit *object.Commit) error {
-		if seen[commit.Hash] {
-			return nil
-		}
+	return object.NewCommitPreIterator(commit).
+		ForEach(func(commit *object.Commit) error {
+			if seen[commit.Hash] {
+				return nil
+			}
 
-		cb(commit.Hash)
+			cb(commit.Hash)
 
-		tree, err := commit.Tree()
-		if err != nil {
-			return err
-		}
+			tree, err := commit.Tree()
+			if err != nil {
+				return err
+			}
 
-		return iterateCommitTrees(seen, tree, cb)
-	})
+			return iterateCommitTrees(seen, tree, cb)
+		})
 }
 
 // iterateCommitTrees iterate all reachable trees from the given commit

--- a/references_test.go
+++ b/references_test.go
@@ -294,7 +294,7 @@ func (s *ReferencesSuite) TestRevList(c *C) {
 		commit, err := r.CommitObject(plumbing.NewHash(t.commit))
 		c.Assert(err, IsNil)
 
-		revs, err := References(commit, t.path)
+		revs, err := references(commit, t.path)
 		c.Assert(err, IsNil)
 		c.Assert(len(revs), Equals, len(t.revs))
 

--- a/repository.go
+++ b/repository.go
@@ -608,6 +608,26 @@ func (r *Repository) Push(o *PushOptions) error {
 	return remote.Push(o)
 }
 
+// Log returns the commit history from the given LogOptions.
+func (r *Repository) Log(o *LogOptions) (object.CommitIter, error) {
+	h := o.From
+	if o.From == plumbing.ZeroHash {
+		head, err := r.Head()
+		if err != nil {
+			return nil, err
+		}
+
+		h = head.Hash()
+	}
+
+	commit, err := r.CommitObject(h)
+	if err != nil {
+		return nil, err
+	}
+
+	return object.NewCommitPreIterator(commit), nil
+}
+
 // Tags returns all the References from Tags. This method returns all the tag
 // types, lightweight, and annotated ones.
 func (r *Repository) Tags() (storer.ReferenceIter, error) {
@@ -671,7 +691,7 @@ func (r *Repository) CommitObject(h plumbing.Hash) (*object.Commit, error) {
 }
 
 // CommitObjects returns an unsorted CommitIter with all the commits in the repository.
-func (r *Repository) CommitObjects() (*object.CommitIter, error) {
+func (r *Repository) CommitObjects() (object.CommitIter, error) {
 	iter, err := r.Storer.IterEncodedObjects(plumbing.CommitObject)
 	if err != nil {
 		return nil, err
@@ -838,29 +858,28 @@ func (r *Repository) ResolveRevision(rev plumbing.Revision) (*plumbing.Hash, err
 				commit = c
 			}
 		case revision.CaretReg:
-			history, err := commit.History()
-
-			if err != nil {
-				return &plumbing.ZeroHash, err
-			}
+			history := object.NewCommitPreIterator(commit)
 
 			re := item.(revision.CaretReg).Regexp
 			negate := item.(revision.CaretReg).Negate
 
 			var c *object.Commit
 
-			for i := 0; i < len(history); i++ {
-				if !negate && re.MatchString(history[i].Message) {
-					c = history[i]
-
-					break
+			err := history.ForEach(func(hc *object.Commit) error {
+				if !negate && re.MatchString(hc.Message) {
+					c = hc
+					return storer.ErrStop
 				}
 
-				if negate && !re.MatchString(history[i].Message) {
-					c = history[i]
-
-					break
+				if negate && !re.MatchString(hc.Message) {
+					c = hc
+					return storer.ErrStop
 				}
+
+				return nil
+			})
+			if err != nil {
+				return &plumbing.ZeroHash, err
 			}
 
 			if c == nil {
@@ -869,21 +888,21 @@ func (r *Repository) ResolveRevision(rev plumbing.Revision) (*plumbing.Hash, err
 
 			commit = c
 		case revision.AtDate:
-			history, err := commit.History()
-
-			if err != nil {
-				return &plumbing.ZeroHash, err
-			}
+			history := object.NewCommitPreIterator(commit)
 
 			date := item.(revision.AtDate).Date
+
 			var c *object.Commit
-
-			for i := 0; i < len(history); i++ {
-				if date.Equal(history[i].Committer.When.UTC()) || history[i].Committer.When.UTC().Before(date) {
-					c = history[i]
-
-					break
+			err := history.ForEach(func(hc *object.Commit) error {
+				if date.Equal(hc.Committer.When.UTC()) || hc.Committer.When.UTC().Before(date) {
+					c = hc
+					return storer.ErrStop
 				}
+
+				return nil
+			})
+			if err != nil {
+				return &plumbing.ZeroHash, err
 			}
 
 			if c == nil {


### PR DESCRIPTION
- CommitIter is now an interface
- The old CommitIter implementation is now called StorerCommitIter
- CommitWalker and CommitWalkerPost are now iterators (CommitPreIterator and CommitPostIterator).
- Remove Commit.History() method. There are so many ways to iterate a commit history, depending of the use case. Now, instead of use the History() method, you must use CommitPreIterator or CommitPostIterator.
- Move commitSorterer to references.go because is the only place that it is used, and it must not be used into another place.
- Make References method private, it must only be used into blame logic.
- Added a TODO into references method, where the sortCommits is used to remove it in a near future.