### PR TITLE
plumbing: index, Entries converted in a slice of pointers

### DIFF
--- a/plumbing/format/index/decoder.go
+++ b/plumbing/format/index/decoder.go
@@ -82,7 +82,7 @@ func (d *Decoder) readEntries(idx *Index, count int) error {
 		}
 
 		d.lastEntry = e
-		idx.Entries = append(idx.Entries, *e)
+		idx.Entries = append(idx.Entries, e)
 	}
 
 	return nil

--- a/plumbing/format/index/encoder.go
+++ b/plumbing/format/index/encoder.go
@@ -65,7 +65,7 @@ func (e *Encoder) encodeEntries(idx *Index) error {
 	sort.Sort(byName(idx.Entries))
 
 	for _, entry := range idx.Entries {
-		if err := e.encodeEntry(&entry); err != nil {
+		if err := e.encodeEntry(entry); err != nil {
 			return err
 		}
 
@@ -143,7 +143,7 @@ func (e *Encoder) encodeFooter() error {
 	return binary.Write(e.w, e.hash.Sum(nil))
 }
 
-type byName []Entry
+type byName []*Entry
 
 func (l byName) Len() int           { return len(l) }
 func (l byName) Swap(i, j int)      { l[i], l[j] = l[j], l[i] }

--- a/plumbing/format/index/encoder_test.go
+++ b/plumbing/format/index/encoder_test.go
@@ -12,7 +12,7 @@ import (
 func (s *IndexSuite) TestEncode(c *C) {
 	idx := &Index{
 		Version: 2,
-		Entries: []Entry{{
+		Entries: []*Entry{{
 			CreatedAt:  time.Now(),
 			ModifiedAt: time.Now(),
 			Dev:        4242,
@@ -66,7 +66,7 @@ func (s *IndexSuite) TestEncodeUnsuportedVersion(c *C) {
 func (s *IndexSuite) TestEncodeWithIntentToAddUnsuportedVersion(c *C) {
 	idx := &Index{
 		Version: 2,
-		Entries: []Entry{{IntentToAdd: true}},
+		Entries: []*Entry{{IntentToAdd: true}},
 	}
 
 	buf := bytes.NewBuffer(nil)
@@ -78,7 +78,7 @@ func (s *IndexSuite) TestEncodeWithIntentToAddUnsuportedVersion(c *C) {
 func (s *IndexSuite) TestEncodeWithSkipWorktreeUnsuportedVersion(c *C) {
 	idx := &Index{
 		Version: 2,
-		Entries: []Entry{{SkipWorktree: true}},
+		Entries: []*Entry{{SkipWorktree: true}},
 	}
 
 	buf := bytes.NewBuffer(nil)

--- a/plumbing/format/index/index.go
+++ b/plumbing/format/index/index.go
@@ -44,7 +44,7 @@ type Index struct {
 	Version uint32
 	// Entries collection of entries represented by this Index. The order of
 	// this collection is not guaranteed
-	Entries []Entry
+	Entries []*Entry
 	// Cache represents the 'Cached tree' extension
 	Cache *Tree
 	// ResolveUndo represents the 'Resolve undo' extension
@@ -52,14 +52,14 @@ type Index struct {
 }
 
 // Entry returns the entry that match the given path, if any.
-func (i *Index) Entry(path string) (Entry, error) {
+func (i *Index) Entry(path string) (*Entry, error) {
 	for _, e := range i.Entries {
 		if e.Name == path {
 			return e, nil
 		}
 	}
 
-	return Entry{}, ErrEntryNotFound
+	return nil, ErrEntryNotFound
 }
 
 // String is equivalent to `git ls-files --stage --debug`

--- a/plumbing/format/index/index_test.go
+++ b/plumbing/format/index/index_test.go
@@ -6,7 +6,7 @@ import (
 
 func (s *IndexSuite) TestIndexEntry(c *C) {
 	idx := &Index{
-		Entries: []Entry{
+		Entries: []*Entry{
 			{Name: "foo", Size: 42},
 			{Name: "bar", Size: 82},
 		},
@@ -17,6 +17,6 @@ func (s *IndexSuite) TestIndexEntry(c *C) {
 	c.Assert(e.Name, Equals, "foo")
 
 	e, err = idx.Entry("missing")
+	c.Assert(e, IsNil)
 	c.Assert(err, Equals, ErrEntryNotFound)
-	c.Assert(e.Name, Equals, "")
 }

--- a/utils/merkletrie/index/node.go
+++ b/utils/merkletrie/index/node.go
@@ -16,7 +16,7 @@ import (
 // compared with any other noder.Noder implementation inside of go-git
 type node struct {
 	path     string
-	entry    index.Entry
+	entry    *index.Entry
 	children []noder.Noder
 	isDir    bool
 }
@@ -66,6 +66,10 @@ func (n *node) String() string {
 // If the node is computed and not based on a index.Entry the hash is equals
 // to a 24-bytes slices of zero values.
 func (n *node) Hash() []byte {
+	if n.entry == nil {
+		return make([]byte, 24)
+	}
+
 	return append(n.entry.Hash[:], n.entry.Mode.Bytes()...)
 }
 

--- a/utils/merkletrie/index/node_test.go
+++ b/utils/merkletrie/index/node_test.go
@@ -19,7 +19,7 @@ var _ = Suite(&NoderSuite{})
 
 func (s *NoderSuite) TestDiff(c *C) {
 	indexA := &index.Index{
-		Entries: []index.Entry{
+		Entries: []*index.Entry{
 			{Name: "foo", Hash: plumbing.NewHash("8ab686eafeb1f44702738c8b0f24f2567c36da6d")},
 			{Name: "bar/foo", Hash: plumbing.NewHash("8ab686eafeb1f44702738c8b0f24f2567c36da6d")},
 			{Name: "bar/qux", Hash: plumbing.NewHash("8ab686eafeb1f44702738c8b0f24f2567c36da6d")},
@@ -28,7 +28,7 @@ func (s *NoderSuite) TestDiff(c *C) {
 	}
 
 	indexB := &index.Index{
-		Entries: []index.Entry{
+		Entries: []*index.Entry{
 			{Name: "foo", Hash: plumbing.NewHash("8ab686eafeb1f44702738c8b0f24f2567c36da6d")},
 			{Name: "bar/foo", Hash: plumbing.NewHash("8ab686eafeb1f44702738c8b0f24f2567c36da6d")},
 			{Name: "bar/qux", Hash: plumbing.NewHash("8ab686eafeb1f44702738c8b0f24f2567c36da6d")},
@@ -43,13 +43,13 @@ func (s *NoderSuite) TestDiff(c *C) {
 
 func (s *NoderSuite) TestDiffChange(c *C) {
 	indexA := &index.Index{
-		Entries: []index.Entry{
+		Entries: []*index.Entry{
 			{Name: "bar/baz/bar", Hash: plumbing.NewHash("8ab686eafeb1f44702738c8b0f24f2567c36da6d")},
 		},
 	}
 
 	indexB := &index.Index{
-		Entries: []index.Entry{
+		Entries: []*index.Entry{
 			{Name: "bar/baz/foo", Hash: plumbing.NewHash("8ab686eafeb1f44702738c8b0f24f2567c36da6d")},
 		},
 	}
@@ -61,13 +61,13 @@ func (s *NoderSuite) TestDiffChange(c *C) {
 
 func (s *NoderSuite) TestDiffDir(c *C) {
 	indexA := &index.Index{
-		Entries: []index.Entry{
+		Entries: []*index.Entry{
 			{Name: "foo", Hash: plumbing.NewHash("8ab686eafeb1f44702738c8b0f24f2567c36da6d")},
 		},
 	}
 
 	indexB := &index.Index{
-		Entries: []index.Entry{
+		Entries: []*index.Entry{
 			{Name: "foo/bar", Hash: plumbing.NewHash("8ab686eafeb1f44702738c8b0f24f2567c36da6d")},
 		},
 	}
@@ -79,14 +79,14 @@ func (s *NoderSuite) TestDiffDir(c *C) {
 
 func (s *NoderSuite) TestDiffSameRoot(c *C) {
 	indexA := &index.Index{
-		Entries: []index.Entry{
+		Entries: []*index.Entry{
 			{Name: "foo.go", Hash: plumbing.NewHash("aab686eafeb1f44702738c8b0f24f2567c36da6d")},
 			{Name: "foo/bar", Hash: plumbing.NewHash("8ab686eafeb1f44702738c8b0f24f2567c36da6d")},
 		},
 	}
 
 	indexB := &index.Index{
-		Entries: []index.Entry{
+		Entries: []*index.Entry{
 			{Name: "foo/bar", Hash: plumbing.NewHash("8ab686eafeb1f44702738c8b0f24f2567c36da6d")},
 			{Name: "foo.go", Hash: plumbing.NewHash("8ab686eafeb1f44702738c8b0f24f2567c36da6d")},
 		},

--- a/worktree.go
+++ b/worktree.go
@@ -352,7 +352,7 @@ func (w *Worktree) checkoutFile(f *object.File) error {
 }
 
 func (w *Worktree) addIndexFromTreeEntry(name string, f *object.TreeEntry, idx *index.Index) error {
-	idx.Entries = append(idx.Entries, index.Entry{
+	idx.Entries = append(idx.Entries, &index.Entry{
 		Hash: f.Hash,
 		Name: name,
 		Mode: filemode.Submodule,
@@ -372,7 +372,7 @@ func (w *Worktree) addIndexFromFile(name string, h plumbing.Hash, idx *index.Ind
 		return err
 	}
 
-	e := index.Entry{
+	e := &index.Entry{
 		Hash:       h,
 		Name:       name,
 		Mode:       mode,
@@ -383,7 +383,7 @@ func (w *Worktree) addIndexFromFile(name string, h plumbing.Hash, idx *index.Ind
 	// if the FileInfo.Sys() comes from os the ctime, dev, inode, uid and gid
 	// can be retrieved, otherwise this doesn't apply
 	if fillSystemInfo != nil {
-		fillSystemInfo(&e, fi.Sys())
+		fillSystemInfo(e, fi.Sys())
 	}
 
 	idx.Entries = append(idx.Entries, e)

--- a/worktree_status.go
+++ b/worktree_status.go
@@ -234,7 +234,7 @@ func (w *Worktree) addOrUpdateFileToIndex(filename string, h plumbing.Hash) erro
 }
 
 func (w *Worktree) doAddFileToIndex(idx *index.Index, filename string) error {
-	idx.Entries = append(idx.Entries, index.Entry{
+	idx.Entries = append(idx.Entries, &index.Entry{
 		Name: filename,
 	})
 
@@ -247,21 +247,18 @@ func (w *Worktree) doUpdateFileToIndex(idx *index.Index, filename string, h plum
 		return err
 	}
 
-	for i, e := range idx.Entries {
-		if e.Name != filename {
-			continue
-		}
-
-		e.Hash = h
-		e.ModifiedAt = info.ModTime()
-		e.Mode, err = filemode.NewFromOSFileMode(info.Mode())
-		if err != nil {
-			return err
-		}
-
-		fillSystemInfo(&e, info.Sys())
-		idx.Entries[i] = e
+	e, err := idx.Entry(filename)
+	if err != nil {
+		return err
 	}
 
+	e.Hash = h
+	e.ModifiedAt = info.ModTime()
+	e.Mode, err = filemode.NewFromOSFileMode(info.Mode())
+	if err != nil {
+		return err
+	}
+
+	fillSystemInfo(e, info.Sys())
 	return nil
 }


### PR DESCRIPTION
In order to provide a nicer API, index.Entries was converted to `[]*Entry`