### PR TITLE
do not convert local paths to URL

### DIFF
--- a/_examples/common_test.go
+++ b/_examples/common_test.go
@@ -96,7 +96,7 @@ func createBareRepository(dir string) string {
 
 func setEmptyRemote(dir string) string {
 	remote := createBareRepository(tempFolder())
-	setRemote(dir, fmt.Sprintf("file://%s", remote))
+	setRemote(dir, remote)
 	return dir
 }
 

--- a/common_test.go
+++ b/common_test.go
@@ -1,7 +1,6 @@
 package git
 
 import (
-	"fmt"
 	"testing"
 
 	"gopkg.in/src-d/go-git.v4/plumbing"
@@ -95,8 +94,7 @@ func (s *BaseSuite) GetBasicLocalRepositoryURL() string {
 }
 
 func (s *BaseSuite) GetLocalRepositoryURL(f *fixtures.Fixture) string {
-	path := f.DotGit().Base()
-	return fmt.Sprintf("file://%s", path)
+	return f.DotGit().Base()
 }
 
 type SuiteCommon struct{}

--- a/plumbing/transport/common_test.go
+++ b/plumbing/transport/common_test.go
@@ -74,8 +74,56 @@ func (s *SuiteCommon) TestNewEndpointSCPLike(c *C) {
 	c.Assert(e.String(), Equals, "git@github.com:user/repository.git")
 }
 
-func (s *SuiteCommon) TestNewEndpointWrongForgat(c *C) {
-	e, err := NewEndpoint("foo")
+func (s *SuiteCommon) TestNewEndpointFileAbs(c *C) {
+	e, err := NewEndpoint("/foo.git")
+	c.Assert(err, IsNil)
+	c.Assert(e.Protocol(), Equals, "file")
+	c.Assert(e.User(), Equals, "")
+	c.Assert(e.Password(), Equals, "")
+	c.Assert(e.Host(), Equals, "")
+	c.Assert(e.Port(), Equals, 0)
+	c.Assert(e.Path(), Equals, "/foo.git")
+	c.Assert(e.String(), Equals, "/foo.git")
+}
+
+func (s *SuiteCommon) TestNewEndpointFileRel(c *C) {
+	e, err := NewEndpoint("foo.git")
+	c.Assert(err, IsNil)
+	c.Assert(e.Protocol(), Equals, "file")
+	c.Assert(e.User(), Equals, "")
+	c.Assert(e.Password(), Equals, "")
+	c.Assert(e.Host(), Equals, "")
+	c.Assert(e.Port(), Equals, 0)
+	c.Assert(e.Path(), Equals, "foo.git")
+	c.Assert(e.String(), Equals, "foo.git")
+}
+
+func (s *SuiteCommon) TestNewEndpointFileWindows(c *C) {
+	e, err := NewEndpoint("C:\\foo.git")
+	c.Assert(err, IsNil)
+	c.Assert(e.Protocol(), Equals, "file")
+	c.Assert(e.User(), Equals, "")
+	c.Assert(e.Password(), Equals, "")
+	c.Assert(e.Host(), Equals, "")
+	c.Assert(e.Port(), Equals, 0)
+	c.Assert(e.Path(), Equals, "C:\\foo.git")
+	c.Assert(e.String(), Equals, "C:\\foo.git")
+}
+
+func (s *SuiteCommon) TestNewEndpointFileURL(c *C) {
+	e, err := NewEndpoint("file:///foo.git")
+	c.Assert(err, IsNil)
+	c.Assert(e.Protocol(), Equals, "file")
+	c.Assert(e.User(), Equals, "")
+	c.Assert(e.Password(), Equals, "")
+	c.Assert(e.Host(), Equals, "")
+	c.Assert(e.Port(), Equals, 0)
+	c.Assert(e.Path(), Equals, "/foo.git")
+	c.Assert(e.String(), Equals, "file:///foo.git")
+}
+
+func (s *SuiteCommon) TestNewEndpointInvalidURL(c *C) {
+	e, err := NewEndpoint("http://\\")
 	c.Assert(err, NotNil)
 	c.Assert(e, IsNil)
 }

--- a/plumbing/transport/file/client_test.go
+++ b/plumbing/transport/file/client_test.go
@@ -1,9 +1,9 @@
 package file
 
 import (
-	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -20,13 +20,12 @@ filemode = true
 bare = true`
 
 func prepareRepo(c *C, path string) transport.Endpoint {
-	url := fmt.Sprintf("file://%s", path)
-	ep, err := transport.NewEndpoint(url)
+	ep, err := transport.NewEndpoint(path)
 	c.Assert(err, IsNil)
 
 	// git-receive-pack refuses to update refs/heads/master on non-bare repo
 	// so we ensure bare repo config.
-	config := fmt.Sprintf("%s/config", path)
+	config := filepath.Join(path, "config")
 	if _, err := os.Stat(config); err == nil {
 		f, err := os.OpenFile(config, os.O_TRUNC|os.O_WRONLY, 0)
 		c.Assert(err, IsNil)

--- a/plumbing/transport/file/server.go
+++ b/plumbing/transport/file/server.go
@@ -14,7 +14,7 @@ import (
 // and error. This is meant to be used when implementing a git-upload-pack
 // command.
 func ServeUploadPack(path string) error {
-	ep, err := transport.NewEndpoint(fmt.Sprintf("file://%s", path))
+	ep, err := transport.NewEndpoint(path)
 	if err != nil {
 		return err
 	}
@@ -32,7 +32,7 @@ func ServeUploadPack(path string) error {
 // input and error. This is meant to be used when implementing a
 // git-receive-pack command.
 func ServeReceivePack(path string) error {
-	ep, err := transport.NewEndpoint(fmt.Sprintf("file://%s", path))
+	ep, err := transport.NewEndpoint(path)
 	if err != nil {
 		return err
 	}

--- a/plumbing/transport/file/server_test.go
+++ b/plumbing/transport/file/server_test.go
@@ -1,7 +1,6 @@
 package file
 
 import (
-	"fmt"
 	"os"
 	"os/exec"
 
@@ -15,7 +14,6 @@ type ServerSuite struct {
 	RemoteName string
 	SrcPath    string
 	DstPath    string
-	DstURL     string
 }
 
 var _ = Suite(&ServerSuite{})
@@ -30,9 +28,8 @@ func (s *ServerSuite) SetUpSuite(c *C) {
 
 	fixture = fixtures.ByTag("empty").One()
 	s.DstPath = fixture.DotGit().Base()
-	s.DstURL = fmt.Sprintf("file://%s", s.DstPath)
 
-	cmd := exec.Command("git", "remote", "add", s.RemoteName, s.DstURL)
+	cmd := exec.Command("git", "remote", "add", s.RemoteName, s.DstPath)
 	cmd.Dir = s.SrcPath
 	c.Assert(cmd.Run(), IsNil)
 }

--- a/plumbing/transport/file/upload_pack_test.go
+++ b/plumbing/transport/file/upload_pack_test.go
@@ -1,8 +1,8 @@
 package file
 
 import (
-	"fmt"
 	"os"
+	"path/filepath"
 
 	"github.com/src-d/go-git-fixtures"
 	"gopkg.in/src-d/go-git.v4/plumbing/transport"
@@ -25,20 +25,18 @@ func (s *UploadPackSuite) SetUpSuite(c *C) {
 
 	fixture := fixtures.Basic().One()
 	path := fixture.DotGit().Base()
-	url := fmt.Sprintf("file://%s", path)
-	ep, err := transport.NewEndpoint(url)
+	ep, err := transport.NewEndpoint(path)
 	c.Assert(err, IsNil)
 	s.Endpoint = ep
 
 	fixture = fixtures.ByTag("empty").One()
 	path = fixture.DotGit().Base()
-	url = fmt.Sprintf("file://%s", path)
-	ep, err = transport.NewEndpoint(url)
+	ep, err = transport.NewEndpoint(path)
 	c.Assert(err, IsNil)
 	s.EmptyEndpoint = ep
 
-	url = fmt.Sprintf("file://%s/%s", fixtures.DataFolder, "non-existent")
-	ep, err = transport.NewEndpoint(url)
+	path = filepath.Join(fixtures.DataFolder, "non-existent")
+	ep, err = transport.NewEndpoint(path)
 	c.Assert(err, IsNil)
 	s.NonExistentEndpoint = ep
 }

--- a/plumbing/transport/server/loader_test.go
+++ b/plumbing/transport/server/loader_test.go
@@ -1,7 +1,6 @@
 package server
 
 import (
-	"fmt"
 	"os/exec"
 	"path/filepath"
 
@@ -33,7 +32,7 @@ func (s *LoaderSuite) endpoint(c *C, url string) transport.Endpoint {
 }
 
 func (s *LoaderSuite) TestLoadNonExistent(c *C) {
-	sto, err := DefaultLoader.Load(s.endpoint(c, "file:///does-not-exist"))
+	sto, err := DefaultLoader.Load(s.endpoint(c, "does-not-exist"))
 	c.Assert(err, Equals, transport.ErrRepositoryNotFound)
 	c.Assert(sto, IsNil)
 }
@@ -45,13 +44,13 @@ func (s *LoaderSuite) TestLoadNonExistentIgnoreHost(c *C) {
 }
 
 func (s *LoaderSuite) TestLoad(c *C) {
-	sto, err := DefaultLoader.Load(s.endpoint(c, fmt.Sprintf("file://%s", s.RepoPath)))
+	sto, err := DefaultLoader.Load(s.endpoint(c, s.RepoPath))
 	c.Assert(err, IsNil)
 	c.Assert(sto, NotNil)
 }
 
 func (s *LoaderSuite) TestLoadIgnoreHost(c *C) {
-	sto, err := DefaultLoader.Load(s.endpoint(c, fmt.Sprintf("file://%s", s.RepoPath)))
+	sto, err := DefaultLoader.Load(s.endpoint(c, s.RepoPath))
 	c.Assert(err, IsNil)
 	c.Assert(sto, NotNil)
 }

--- a/references_test.go
+++ b/references_test.go
@@ -295,7 +295,7 @@ func (s *ReferencesSuite) TestObjectNotFoundError(c *C) {
 	url := fixtures.ByURL("https://github.com/git-fixtures/basic.git").One().DotGit().Base()
 	storer := memory.NewStorage()
 	r, err := Clone(storer, nil, &CloneOptions{
-		URL: "file://" + url,
+		URL: url,
 	})
 	c.Assert(err, IsNil)
 

--- a/remote_test.go
+++ b/remote_test.go
@@ -2,7 +2,6 @@ package git
 
 import (
 	"bytes"
-	"fmt"
 	"io"
 	"io/ioutil"
 	"os"
@@ -26,9 +25,9 @@ type RemoteSuite struct {
 var _ = Suite(&RemoteSuite{})
 
 func (s *RemoteSuite) TestFetchInvalidEndpoint(c *C) {
-	r := newRemote(nil, &config.RemoteConfig{Name: "foo", URL: "qux"})
-	err := r.Fetch(&FetchOptions{})
-	c.Assert(err, ErrorMatches, ".*invalid endpoint.*")
+	r := newRemote(nil, &config.RemoteConfig{Name: "foo", URL: "http://\\"})
+	err := r.Fetch(&FetchOptions{RemoteName: "foo"})
+	c.Assert(err, ErrorMatches, ".*invalid character.*")
 }
 
 func (s *RemoteSuite) TestFetchNonExistentEndpoint(c *C) {
@@ -215,7 +214,7 @@ func (s *RemoteSuite) TestPushToEmptyRepository(c *C) {
 	c.Assert(err, IsNil)
 
 	dstFs := fixtures.ByTag("empty").One().DotGit()
-	url := fmt.Sprintf("file://%s", dstFs.Base())
+	url := dstFs.Base()
 
 	r := newRemote(sto, &config.RemoteConfig{
 		Name: DefaultRemoteName,
@@ -255,7 +254,7 @@ func (s *RemoteSuite) TestPushTags(c *C) {
 	c.Assert(err, IsNil)
 
 	dstFs := fixtures.ByTag("empty").One().DotGit()
-	url := fmt.Sprintf("file://%s", dstFs.Base())
+	url := dstFs.Base()
 
 	r := newRemote(sto, &config.RemoteConfig{
 		Name: DefaultRemoteName,
@@ -298,7 +297,7 @@ func (s *RemoteSuite) TestPushNoErrAlreadyUpToDate(c *C) {
 	f := fixtures.Basic().One()
 	sto, err := filesystem.NewStorage(f.DotGit())
 	c.Assert(err, IsNil)
-	url := fmt.Sprintf("file://%s", f.DotGit().Base())
+	url := f.DotGit().Base()
 	r := newRemote(sto, &config.RemoteConfig{
 		Name: DefaultRemoteName,
 		URL:  url,
@@ -320,7 +319,7 @@ func (s *RemoteSuite) TestPushRejectNonFastForward(c *C) {
 	dstSto, err := filesystem.NewStorage(dstFs)
 	c.Assert(err, IsNil)
 
-	url := fmt.Sprintf("file://%s", dstFs.Base())
+	url := dstFs.Base()
 	r := newRemote(sto, &config.RemoteConfig{
 		Name: DefaultRemoteName,
 		URL:  url,
@@ -349,7 +348,7 @@ func (s *RemoteSuite) TestPushForce(c *C) {
 	dstSto, err := filesystem.NewStorage(dstFs)
 	c.Assert(err, IsNil)
 
-	url := fmt.Sprintf("file://%s", dstFs.Base())
+	url := dstFs.Base()
 	r := newRemote(sto, &config.RemoteConfig{
 		Name: DefaultRemoteName,
 		URL:  url,
@@ -378,7 +377,7 @@ func (s *RemoteSuite) TestPushNewReference(c *C) {
 	dstSto, err := filesystem.NewStorage(dstFs)
 	c.Assert(err, IsNil)
 
-	url := fmt.Sprintf("file://%s", dstFs.Base())
+	url := dstFs.Base()
 	r := newRemote(sto, &config.RemoteConfig{
 		Name: DefaultRemoteName,
 		URL:  url,
@@ -399,9 +398,9 @@ func (s *RemoteSuite) TestPushNewReference(c *C) {
 }
 
 func (s *RemoteSuite) TestPushInvalidEndpoint(c *C) {
-	r := newRemote(nil, &config.RemoteConfig{Name: "foo", URL: "qux"})
-	err := r.Push(&PushOptions{})
-	c.Assert(err, ErrorMatches, ".*invalid endpoint.*")
+	r := newRemote(nil, &config.RemoteConfig{Name: "foo", URL: "http://\\"})
+	err := r.Push(&PushOptions{RemoteName: "foo"})
+	c.Assert(err, ErrorMatches, ".*invalid character.*")
 }
 
 func (s *RemoteSuite) TestPushNonExistentEndpoint(c *C) {
@@ -426,7 +425,7 @@ func (s *RemoteSuite) TestPushInvalidFetchOptions(c *C) {
 func (s *RemoteSuite) TestPushInvalidRefSpec(c *C) {
 	r := newRemote(nil, &config.RemoteConfig{
 		Name: DefaultRemoteName,
-		URL:  "file:///some-url",
+		URL:  "some-url",
 	})
 
 	rs := config.RefSpec("^*$**")
@@ -439,7 +438,7 @@ func (s *RemoteSuite) TestPushInvalidRefSpec(c *C) {
 func (s *RemoteSuite) TestPushWrongRemoteName(c *C) {
 	r := newRemote(nil, &config.RemoteConfig{
 		Name: DefaultRemoteName,
-		URL:  "file:///some-url",
+		URL:  "some-url",
 	})
 
 	err := r.Push(&PushOptions{

--- a/repository_test.go
+++ b/repository_test.go
@@ -388,7 +388,7 @@ func (s *RepositorySuite) TestPlainCloneWithRecurseSubmodules(c *C) {
 
 	path := fixtures.ByTag("submodule").One().Worktree().Base()
 	r, err := PlainClone(dir, false, &CloneOptions{
-		URL:               fmt.Sprintf("file://%s", path),
+		URL:               path,
 		RecurseSubmodules: DefaultSubmoduleRecursionDepth,
 	})
 
@@ -678,7 +678,7 @@ func (s *RepositorySuite) TestPullProgressWithRecursion(c *C) {
 	r, _ := PlainInit(dir, false)
 	r.CreateRemote(&config.RemoteConfig{
 		Name: DefaultRemoteName,
-		URL:  fmt.Sprintf("file://%s", path),
+		URL:  path,
 	})
 
 	err = r.Pull(&PullOptions{
@@ -694,7 +694,7 @@ func (s *RepositorySuite) TestPullAdd(c *C) {
 	path := fixtures.Basic().ByTag("worktree").One().Worktree().Base()
 
 	r, err := Clone(memory.NewStorage(), nil, &CloneOptions{
-		URL: fmt.Sprintf("file://%s", filepath.Join(path, ".git")),
+		URL: filepath.Join(path, ".git"),
 	})
 
 	c.Assert(err, IsNil)
@@ -729,7 +729,7 @@ func (s *RepositorySuite) TestPushToEmptyRepository(c *C) {
 	c.Assert(err, IsNil)
 
 	dstFs := fixtures.ByTag("empty").One().DotGit()
-	url := fmt.Sprintf("file://%s", dstFs.Base())
+	url := dstFs.Base()
 
 	r, err := Open(sto, srcFs)
 	c.Assert(err, IsNil)

--- a/submodule_test.go
+++ b/submodule_test.go
@@ -1,15 +1,14 @@
 package git
 
 import (
-	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 
 	"github.com/src-d/go-git-fixtures"
+	"gopkg.in/src-d/go-git.v4/plumbing"
 
 	. "gopkg.in/check.v1"
-	"gopkg.in/src-d/go-git.v4/plumbing"
 )
 
 type SubmoduleSuite struct {
@@ -27,7 +26,7 @@ func (s *SubmoduleSuite) SetUpTest(c *C) {
 	c.Assert(err, IsNil)
 
 	r, err := PlainClone(filepath.Join(dir, "worktree"), false, &CloneOptions{
-		URL: fmt.Sprintf("file://%s", path),
+		URL: path,
 	})
 
 	c.Assert(err, IsNil)


### PR DESCRIPTION
* Do not convert local paths to URLs, just keep them as they
  are.
* This way we add support for Windows without taking care of
  Windows path-to-URL conversion.