### PR TITLE
transport/server: use Endpoint string representation as a map key.

### DIFF
--- a/plumbing/transport/server/loader.go
+++ b/plumbing/transport/server/loader.go
@@ -44,13 +44,13 @@ func (l *fsLoader) Load(ep transport.Endpoint) (storer.Storer, error) {
 
 // MapLoader is a Loader that uses a lookup map of storer.Storer by
 // transport.Endpoint.
-type MapLoader map[transport.Endpoint]storer.Storer
+type MapLoader map[string]storer.Storer
 
 // Load returns a storer.Storer for given a transport.Endpoint by looking it up
 // in the map. Returns transport.ErrRepositoryNotFound if the endpoint does not
 // exist.
 func (l MapLoader) Load(ep transport.Endpoint) (storer.Storer, error) {
-	s, ok := l[ep]
+	s, ok := l[ep.String()]
 	if !ok {
 		return nil, transport.ErrRepositoryNotFound
 	}

--- a/plumbing/transport/server/loader_test.go
+++ b/plumbing/transport/server/loader_test.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 
 	"gopkg.in/src-d/go-git.v4/plumbing/transport"
+	"gopkg.in/src-d/go-git.v4/storage/memory"
 
 	. "gopkg.in/check.v1"
 )
@@ -53,4 +54,19 @@ func (s *LoaderSuite) TestLoadIgnoreHost(c *C) {
 	sto, err := DefaultLoader.Load(s.endpoint(c, s.RepoPath))
 	c.Assert(err, IsNil)
 	c.Assert(sto, NotNil)
+}
+
+func (s *LoaderSuite) TestMapLoader(c *C) {
+	ep, err := transport.NewEndpoint("file://test")
+	sto := memory.NewStorage()
+	c.Assert(err, IsNil)
+
+	loader := MapLoader{ep.String(): sto}
+
+	ep, err = transport.NewEndpoint("file://test")
+	c.Assert(err, IsNil)
+
+	loaderSto, err := loader.Load(ep)
+	c.Assert(err, IsNil)
+	c.Assert(sto, Equals, loaderSto)
 }

--- a/plumbing/transport/server/server_test.go
+++ b/plumbing/transport/server/server_test.go
@@ -53,14 +53,14 @@ func (s *BaseSuite) prepareRepositories(c *C, basic *transport.Endpoint,
 	*basic = ep
 	sto, err := filesystem.NewStorage(fs)
 	c.Assert(err, IsNil)
-	s.loader[ep] = sto
+	s.loader[ep.String()] = sto
 
 	path = "/empty.git"
 	url = fmt.Sprintf("%s://%s", inprocScheme, path)
 	ep, err = transport.NewEndpoint(url)
 	c.Assert(err, IsNil)
 	*empty = ep
-	s.loader[ep] = memory.NewStorage()
+	s.loader[ep.String()] = memory.NewStorage()
 
 	path = "/non-existent.git"
 	url = fmt.Sprintf("%s://%s", inprocScheme, path)


### PR DESCRIPTION
Two endpoints are not equals between them, even if they were generated using the same url or path.