### PR TITLE
storage: filesystem, initialize the default folder scaffolding

### DIFF
--- a/repository.go
+++ b/repository.go
@@ -201,6 +201,14 @@ func PlainOpen(path string) (*Repository, error) {
 		return nil, err
 	}
 
+	if _, err := dot.Stat(""); err != nil {
+		if os.IsNotExist(err) {
+			return nil, ErrRepositoryNotExists
+		}
+
+		return nil, err
+	}
+
 	s, err := filesystem.NewStorage(dot)
 	if err != nil {
 		return nil, err

--- a/storage/filesystem/internal/dotgit/dotgit.go
+++ b/storage/filesystem/internal/dotgit/dotgit.go
@@ -66,6 +66,33 @@ func New(fs billy.Filesystem) *DotGit {
 	return &DotGit{fs: fs}
 }
 
+// Initialize creates all the folder scaffolding.
+func (d *DotGit) Initialize() error {
+	mustExists := []string{
+		d.fs.Join("objects", "info"),
+		d.fs.Join("objects", "pack"),
+		d.fs.Join("refs", "heads"),
+		d.fs.Join("refs", "tags"),
+	}
+
+	for _, path := range mustExists {
+		_, err := d.fs.Stat(path)
+		if err == nil {
+			continue
+		}
+
+		if !os.IsNotExist(err) {
+			return err
+		}
+
+		if err := d.fs.MkdirAll(path, os.ModeDir|os.ModePerm); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
 // ConfigWriter returns a file pointer for write to the config file
 func (d *DotGit) ConfigWriter() (billy.File, error) {
 	return d.fs.Create(configPath)

--- a/storage/filesystem/internal/dotgit/dotgit_test.go
+++ b/storage/filesystem/internal/dotgit/dotgit_test.go
@@ -23,6 +23,30 @@ type SuiteDotGit struct {
 
 var _ = Suite(&SuiteDotGit{})
 
+func (s *SuiteDotGit) TestInitialize(c *C) {
+	tmp, err := ioutil.TempDir("", "dot-git")
+	c.Assert(err, IsNil)
+	defer os.RemoveAll(tmp)
+
+	fs := osfs.New(tmp)
+	dir := New(fs)
+
+	err = dir.Initialize()
+	c.Assert(err, IsNil)
+
+	_, err = fs.Stat(fs.Join("objects", "info"))
+	c.Assert(err, IsNil)
+
+	_, err = fs.Stat(fs.Join("objects", "pack"))
+	c.Assert(err, IsNil)
+
+	_, err = fs.Stat(fs.Join("refs", "heads"))
+	c.Assert(err, IsNil)
+
+	_, err = fs.Stat(fs.Join("refs", "tags"))
+	c.Assert(err, IsNil)
+}
+
 func (s *SuiteDotGit) TestSetRefs(c *C) {
 	tmp, err := ioutil.TempDir("", "dot-git")
 	c.Assert(err, IsNil)
@@ -95,6 +119,7 @@ func (s *SuiteDotGit) TestRefsFromPackedRefs(c *C) {
 	c.Assert(ref.Hash().String(), Equals, "e8d3ffab552895c19b9fcf7aa264d277cde33881")
 
 }
+
 func (s *SuiteDotGit) TestRefsFromReferenceFile(c *C) {
 	fs := fixtures.Basic().ByTag(".git").One().DotGit()
 	dir := New(fs)

--- a/storage/filesystem/storage.go
+++ b/storage/filesystem/storage.go
@@ -24,6 +24,10 @@ type Storage struct {
 // NewStorage returns a new Storage backed by a given `fs.Filesystem`
 func NewStorage(fs billy.Filesystem) (*Storage, error) {
 	dir := dotgit.New(fs)
+	if err := dir.Initialize(); err != nil {
+		return nil, err
+	}
+
 	o, err := newObjectStorage(dir)
 	if err != nil {
 		return nil, err

--- a/storage/filesystem/storage_test.go
+++ b/storage/filesystem/storage_test.go
@@ -25,6 +25,16 @@ func (s *StorageSuite) SetUpTest(c *C) {
 	s.BaseStorageSuite = test.NewBaseStorageSuite(storage)
 }
 
+func (s *StorageSuite) TestNewStorage(c *C) {
+	fs := memfs.New()
+	storage, err := NewStorage(fs)
+	c.Assert(err, IsNil)
+	c.Assert(storage, NotNil)
+
+	_, err = fs.Stat("refs/tags")
+	c.Assert(err, IsNil)
+}
+
 func (s *StorageSuite) TestFilesystem(c *C) {
 	fs := memfs.New()
 	storage, err := NewStorage(fs)


### PR DESCRIPTION
It creates the default scaffolding for a `.git` folder exactly as cgit does 

/cc @osklyar