### PR TITLE
Support SSH Agent Auth on Windows

### DIFF
--- a/plumbing/transport/ssh/auth_method_test.go
+++ b/plumbing/transport/ssh/auth_method_test.go
@@ -94,6 +94,16 @@ func (s *SuiteCommon) TestPublicKeysCallbackString(c *C) {
 	c.Assert(a.String(), Equals, fmt.Sprintf("user: test, name: %s", PublicKeysCallbackName))
 }
 func (s *SuiteCommon) TestNewSSHAgentAuth(c *C) {
+	if os.Getenv("SSH_AUTH_SOCK") == "" {
+		c.Skip("SSH_AUTH_SOCK or SSH_TEST_PRIVATE_KEY are required")
+	}
+
+	auth, err := NewSSHAgentAuth("foo")
+	c.Assert(err, IsNil)
+	c.Assert(auth, NotNil)
+}
+
+func (s *SuiteCommon) TestNewSSHAgentAuthNoAgent(c *C) {
 	addr := os.Getenv("SSH_AUTH_SOCK")
 	err := os.Unsetenv("SSH_AUTH_SOCK")
 	c.Assert(err, IsNil)
@@ -105,7 +115,7 @@ func (s *SuiteCommon) TestNewSSHAgentAuth(c *C) {
 
 	k, err := NewSSHAgentAuth("foo")
 	c.Assert(k, IsNil)
-	c.Assert(err, Equals, ErrEmptySSHAgentAddr)
+	c.Assert(err, ErrorMatches, ".*SSH_AUTH_SOCK.*")
 }
 
 func (*SuiteCommon) TestNewPublicKeys(c *C) {


### PR DESCRIPTION
Fixes #404. I used xanzy/ssh-agent to create the ssh agent correctly based on os based on this PR in terraform that fixed a similar issue in that product.

https://github.com/hashicorp/terraform/pull/4323