### PR TITLE
Fix fetch tags

### DIFF
--- a/remote.go
+++ b/remote.go
@@ -377,7 +377,7 @@ func getWants(
 				return err
 			}
 		} else {
-			exists = tagInList(hash, tags)
+			exists = hashInList(hash, tags)
 		}
 
 		if !exists {
@@ -398,7 +398,7 @@ func getWants(
 	return result, nil
 }
 
-func tagInList(h plumbing.Hash, list []plumbing.Hash) bool {
+func hashInList(h plumbing.Hash, list []plumbing.Hash) bool {
 	for _, value := range list {
 		if value == h {
 			return true

--- a/remote.go
+++ b/remote.go
@@ -329,8 +329,9 @@ func getWants(
 		}
 	}
 
-	var tags []plumbing.Hash
+	tags := make(map[string]plumbing.Hash, 0)
 	localIter, err := localStorer.IterReferences()
+
 	if err != nil {
 		return nil, err
 	}
@@ -340,7 +341,7 @@ func getWants(
 			return nil
 		}
 
-		tags = append(tags, ref.Hash())
+		tags[ref.Name().String()] = ref.Hash()
 		return nil
 	})
 
@@ -381,7 +382,8 @@ func getWants(
 				return err
 			}
 		} else {
-			exists = hashInList(hash, tags)
+			value, inMap := tags[ref.Name().String()]
+			exists = inMap && value == ref.Hash()
 		}
 
 		if !exists {
@@ -400,16 +402,6 @@ func getWants(
 	}
 
 	return result, nil
-}
-
-func hashInList(h plumbing.Hash, list []plumbing.Hash) bool {
-	for _, value := range list {
-		if value == h {
-			return true
-		}
-	}
-
-	return false
 }
 
 func objectExists(s storer.EncodedObjectStorer, h plumbing.Hash) (bool, error) {

--- a/remote.go
+++ b/remote.go
@@ -329,13 +329,13 @@ func getWants(
 		}
 	}
 
-	tags := []plumbing.Hash{}
+	var tags []plumbing.Hash
 	localIter, err := localStorer.IterReferences()
 	if err != nil {
 		return nil, err
 	}
 
-	localIter.ForEach(func(ref *plumbing.Reference) error {
+	err = localIter.ForEach(func(ref *plumbing.Reference) error {
 		if !ref.IsTag() {
 			return nil
 		}
@@ -343,6 +343,10 @@ func getWants(
 		tags = append(tags, ref.Hash())
 		return nil
 	})
+
+	if err != nil {
+		return nil, err
+	}
 
 	iter, err := remoteRefs.IterReferences()
 	if err != nil {

--- a/remote_test.go
+++ b/remote_test.go
@@ -81,7 +81,6 @@ func (s *RemoteSuite) TestFetchTags(c *C) {
 	refspec := config.RefSpec("+refs/tags/*:refs/remotes/origin/*")
 	err := r.Fetch(&FetchOptions{
 		RefSpecs: []config.RefSpec{refspec},
-		Depth:    1,
 	})
 
 	c.Assert(err, IsNil)

--- a/remote_test.go
+++ b/remote_test.go
@@ -73,6 +73,20 @@ func (s *RemoteSuite) TestFetch(c *C) {
 	}
 }
 
+func (s *RemoteSuite) TestFetchTags(c *C) {
+	url := s.GetBasicLocalRepositoryURL()
+	sto := memory.NewStorage()
+	r := newRemote(sto, &config.RemoteConfig{Name: "foo", URL: url})
+
+	refspec := config.RefSpec("+refs/tags/*:refs/remotes/origin/*")
+	err := r.Fetch(&FetchOptions{
+		RefSpecs: []config.RefSpec{refspec},
+		Depth:    1,
+	})
+
+	c.Assert(err, IsNil)
+}
+
 func (s *RemoteSuite) TestFetchDepth(c *C) {
 	url := s.GetBasicLocalRepositoryURL()
 	sto := memory.NewStorage()


### PR DESCRIPTION
Quick fix for #371.
Not sure it's the best way, but this bug is very disturbing to me, so I fixed it quickly.

In tags we do not need to check hash, we need to check if it's name exists in the local storer, so I saved all local tags in slice and then if the reference is a tag, I say it's exists if it's in the slice.

Better idea? 