### PR TITLE
plumbing/transport/http: add callback based basic auth

### DIFF
--- a/plumbing/transport/http/common.go
+++ b/plumbing/transport/http/common.go
@@ -113,6 +113,34 @@ func (a *BasicAuth) String() string {
 	return fmt.Sprintf("%s - %s:%s", a.Name(), a.username, masked)
 }
 
+// BasicAuthCallback represent a HTTP basic auth with a password callback
+type BasicAuthCallback struct {
+	username string
+	callback func() (password string)
+}
+
+// NewBasicAuthCallback returns a basicAuthCallback based on the callback function
+func NewBasicAuthCallback(username string, callback func() (password string)) *BasicAuthCallback {
+	return &BasicAuthCallback{username, callback}
+}
+
+func (a *BasicAuthCallback) setAuth(r *http.Request) {
+	if a == nil || a.callback == nil {
+		return
+	}
+
+	r.SetBasicAuth(a.username, a.callback())
+}
+
+// Name is name of the auth
+func (a *BasicAuthCallback) Name() string {
+	return "http-basic-auth-callback"
+}
+
+func (a *BasicAuthCallback) String() string {
+	return fmt.Sprintf("%s - %s", a.Name(), a.username)
+}
+
 // Err is a dedicated error to return errors based on status code
 type Err struct {
 	Response *http.Response

--- a/plumbing/transport/http/common_test.go
+++ b/plumbing/transport/http/common_test.go
@@ -44,6 +44,13 @@ func (s *ClientSuite) TestNewBasicAuth(c *C) {
 	c.Assert(a.String(), Equals, "http-basic-auth - foo:*******")
 }
 
+func (s *ClientSuite) TestNewBasicAuthCallback(c *C) {
+	a := NewBasicAuthCallback("foo", func() string { return "qux" })
+
+	c.Assert(a.Name(), Equals, "http-basic-auth-callback")
+	c.Assert(a.String(), Equals, "http-basic-auth-callback - foo")
+}
+
 func (s *ClientSuite) TestNewErrOK(c *C) {
 	res := &http.Response{StatusCode: http.StatusOK}
 	err := NewErr(res)


### PR DESCRIPTION
Hey - great work. 

I'm using go-git in a Github app which uses dynamic credentials, so having http basic auth backed by a callback function is really useful. Let me know what you think of this.