### PR TITLE
Adds support for .gitignore at repository root

### DIFF
--- a/utils/merkletrie/filesystem/node_test.go
+++ b/utils/merkletrie/filesystem/node_test.go
@@ -41,6 +41,29 @@ func (s *NoderSuite) TestDiff(c *C) {
 	c.Assert(ch, HasLen, 0)
 }
 
+func (s *NoderSuite) TestGitignore(c *C) {
+	fsA := memfs.New()
+	WriteFile(fsA, "foo", []byte("foo"), 0644)
+	WriteFile(fsA, ".gitignore", []byte("bar"), 0644)
+	WriteFile(fsA, "qux/bar", []byte("somevalue"), 0644)
+	WriteFile(fsA, "qux/qux", []byte("foo"), 0644)
+
+	fsB := memfs.New()
+	WriteFile(fsB, "foo", []byte("foo"), 0644)
+	WriteFile(fsB, ".gitignore", []byte("bar"), 0644)
+	WriteFile(fsB, "qux/bar", []byte("mismatch"), 0644)
+	WriteFile(fsB, "qux/qux", []byte("foo"), 0644)
+
+	ch, err := merkletrie.DiffTree(
+		NewRootNode(fsA, nil),
+		NewRootNode(fsB, nil),
+		IsEquals,
+	)
+
+	c.Assert(err, IsNil)
+	c.Assert(ch, HasLen, 0)
+}
+
 func (s *NoderSuite) TestDiffChangeContent(c *C) {
 	fsA := memfs.New()
 	WriteFile(fsA, "foo", []byte("foo"), 0644)


### PR DESCRIPTION
This PR adds basic support for `.gitignore` files. The code uses `github.com/monochromegane/go-gitignore`, which, however, could be easily ported into a local package to avoid an additional external dependency.

The PR covers 99% of the normal `.gitignore` usage, however, the following limitations as compared to the standard git client exist:
* only `.gitignore` files at the root of the repository are considered, files located deeper in the tree structure are not taken into account
* files matching the exclusion pattern in the `.gitignore` will be considered not present on the file system, so if forcefully committed, they may be shown as a change (has not been investigated).

The effect of the change is easily seen in the following example using the `go-git` based client from [github.com/silvertern/geat](https://github.com/silvertern/geat) (WIP):

Older state, without the PR:
```
➜  geat git:(01172b3) geat status
.: git@github.com:silvertern/geat.git [origin] HEAD Changed
?? .idea/workspace.xml
?? .idea/geat.iml
?? .idea/modules.xml
?? .idea/vcs.xml
?? .idea/libraries/GOPATH__geat_.xml
?? .idea/misc.xml
?? vendor/github.com/caarlos0/spin/.gitignore
?? vendor/github.com/caarlos0/spin/.travis.yml
?? vendor/github.com/caarlos0/spin/README.md
?? vendor/github.com/caarlos0/spin/spin_test.go
?? vendor/github.com/caarlos0/spin/Makefile
?? vendor/github.com/caarlos0/spin/spin.go
?? Gopkg.lock
```

With the PR:
```
➜  geat git:(master) dep ensure
➜  geat git:(master) go install
➜  geat git:(master) geat status
.: git@github.com:silvertern/geat.git [origin] master Clean

➜  geat git:(master) echo "change" >> Gopkg.toml 
➜  geat git:(master) ✗ geat status                
.: git@github.com:silvertern/geat.git [origin] master Changed
 M Gopkg.toml
```

Addresses #307, #340