### PR TITLE
fix naming of NewCommit{Pre,Post}Iterator

### DIFF
--- a/plumbing/object/commit_walker.go
+++ b/plumbing/object/commit_walker.go
@@ -13,13 +13,13 @@ type commitPreIterator struct {
 	start *Commit
 }
 
-// NewCommitPreIterator returns a CommitIter that walks the commit history,
+// NewCommitPreorderIter returns a CommitIter that walks the commit history,
 // starting at the given commit and visiting its parents in pre-order.
 // The given callback will be called for each visited commit. Each commit will
 // be visited only once. If the callback returns an error, walking will stop
 // and will return the error. Other errors might be returned if the history
 // cannot be traversed (e.g. missing objects).
-func NewCommitPreIterator(c *Commit) CommitIter {
+func NewCommitPreorderIter(c *Commit) CommitIter {
 	return &commitPreIterator{
 		seen:  make(map[plumbing.Hash]bool),
 		stack: make([]CommitIter, 0),
@@ -94,12 +94,12 @@ type commitPostIterator struct {
 	seen  map[plumbing.Hash]bool
 }
 
-// NewCommitPostIterator returns a CommitIter that walks the commit
+// NewCommitPostorderIter returns a CommitIter that walks the commit
 // history like WalkCommitHistory but in post-order. This means that after
 // walking a merge commit, the merged commit will be walked before the base
 // it was merged on. This can be useful if you wish to see the history in
 // chronological order.
-func NewCommitPostIterator(c *Commit) CommitIter {
+func NewCommitPostorderIter(c *Commit) CommitIter {
 	return &commitPostIterator{
 		stack: []*Commit{c},
 		seen:  make(map[plumbing.Hash]bool),

--- a/plumbing/object/commit_walker_test.go
+++ b/plumbing/object/commit_walker_test.go
@@ -12,7 +12,7 @@ func (s *CommitWalkerSuite) TestCommitPreIterator(c *C) {
 	commit := s.commit(c, s.Fixture.Head)
 
 	var commits []*Commit
-	wIter := NewCommitPreIterator(commit)
+	wIter := NewCommitPreorderIter(commit)
 	wIter.ForEach(func(c *Commit) error {
 		commits = append(commits, c)
 		return nil
@@ -39,7 +39,7 @@ func (s *CommitWalkerSuite) TestCommitPostIterator(c *C) {
 	commit := s.commit(c, s.Fixture.Head)
 
 	var commits []*Commit
-	wIter := NewCommitPostIterator(commit)
+	wIter := NewCommitPostorderIter(commit)
 	wIter.ForEach(func(c *Commit) error {
 		commits = append(commits, c)
 		return nil

--- a/plumbing/revlist/revlist.go
+++ b/plumbing/revlist/revlist.go
@@ -82,7 +82,7 @@ func reachableObjects(
 	commit *object.Commit,
 	seen map[plumbing.Hash]bool,
 	cb func(h plumbing.Hash)) error {
-	return object.NewCommitPreIterator(commit).
+	return object.NewCommitPreorderIter(commit).
 		ForEach(func(commit *object.Commit) error {
 			if seen[commit.Hash] {
 				return nil

--- a/remote.go
+++ b/remote.go
@@ -420,7 +420,7 @@ func isFastForward(s storer.EncodedObjectStorer, old, new plumbing.Hash) (bool, 
 	}
 
 	found := false
-	iter := object.NewCommitPreIterator(c)
+	iter := object.NewCommitPreorderIter(c)
 	return found, iter.ForEach(func(c *object.Commit) error {
 		if c.Hash != old {
 			return nil

--- a/repository.go
+++ b/repository.go
@@ -694,7 +694,7 @@ func (r *Repository) Log(o *LogOptions) (object.CommitIter, error) {
 		return nil, err
 	}
 
-	return object.NewCommitPreIterator(commit), nil
+	return object.NewCommitPreorderIter(commit), nil
 }
 
 // Tags returns all the References from Tags. This method returns all the tag
@@ -927,7 +927,7 @@ func (r *Repository) ResolveRevision(rev plumbing.Revision) (*plumbing.Hash, err
 				commit = c
 			}
 		case revision.CaretReg:
-			history := object.NewCommitPreIterator(commit)
+			history := object.NewCommitPreorderIter(commit)
 
 			re := item.(revision.CaretReg).Regexp
 			negate := item.(revision.CaretReg).Negate
@@ -957,7 +957,7 @@ func (r *Repository) ResolveRevision(rev plumbing.Revision) (*plumbing.Hash, err
 
 			commit = c
 		case revision.AtDate:
-			history := object.NewCommitPreIterator(commit)
+			history := object.NewCommitPreorderIter(commit)
 
 			date := item.(revision.AtDate).Date
 


### PR DESCRIPTION
Use Iter suffix, just as all other iterators in the project.
Use Preorder and Postorder to be more clear.