### PR TITLE
Update local remote references during fetch even if no pack needs to be received

### DIFF
--- a/remote.go
+++ b/remote.go
@@ -47,7 +47,7 @@ func (r *Remote) String() string {
 
 // Fetch fetches references from the remote to the local repository.
 // Returns nil if the operation is successful, NoErrAlreadyUpToDate if there are
-// no changes to be fetched, or an error.
+// no changes to be fetched and no local references to update, or an error.
 func (r *Remote) Fetch(o *FetchOptions) error {
 	_, err := r.fetch(o)
 	return err
@@ -156,24 +156,26 @@ func (r *Remote) fetch(o *FetchOptions) (refs storer.ReferenceStorer, err error)
 	}
 
 	req.Wants, err = getWants(o.RefSpecs, r.s, remoteRefs)
+	if len(req.Wants) > 0 {
+		req.Haves, err = getHaves(r.s)
+		if err != nil {
+			return nil, err
+		}
+
+		if err := r.fetchPack(o, s, req); err != nil {
+			return nil, err
+		}
+	}
+
+	err = r.updateLocalReferenceStorage(o.RefSpecs, remoteRefs)
+	if err != nil && err != NoErrAlreadyUpToDate {
+		return nil, err
+	}
+
 	if len(req.Wants) == 0 {
-		return remoteRefs, NoErrAlreadyUpToDate
+		return remoteRefs, err
 	}
-
-	req.Haves, err = getHaves(r.s)
-	if err != nil {
-		return nil, err
-	}
-
-	if err := r.fetchPack(o, s, req); err != nil {
-		return nil, err
-	}
-
-	if err := r.updateLocalReferenceStorage(o.RefSpecs, remoteRefs); err != nil {
-		return nil, err
-	}
-
-	return remoteRefs, err
+	return remoteRefs, nil
 }
 
 func newUploadPackSession(url string, auth transport.AuthMethod) (transport.UploadPackSession, error) {
@@ -473,6 +475,7 @@ func buildSidebandIfSupported(l *capability.List, reader io.Reader, p sideband.P
 }
 
 func (r *Remote) updateLocalReferenceStorage(specs []config.RefSpec, refs memory.ReferenceStorage) error {
+	updated := false
 	for _, spec := range specs {
 		for _, ref := range refs {
 			if !spec.Match(ref.Name()) {
@@ -484,38 +487,55 @@ func (r *Remote) updateLocalReferenceStorage(specs []config.RefSpec, refs memory
 			}
 
 			name := spec.Dst(ref.Name())
-			n := plumbing.NewHashReference(name, ref.Hash())
-			if err := r.s.SetReference(n); err != nil {
+			sref, err := r.s.Reference(name)
+			if err != nil && err != plumbing.ErrReferenceNotFound {
 				return err
+			}
+			if err == plumbing.ErrReferenceNotFound || sref.Hash() != ref.Hash() {
+				n := plumbing.NewHashReference(name, ref.Hash())
+				if err := r.s.SetReference(n); err != nil {
+					return err
+				}
+				updated = true
 			}
 		}
 	}
 
-	return r.buildFetchedTags(refs)
-}
-
-func (r *Remote) buildFetchedTags(refs storer.ReferenceStorer) error {
-	iter, err := refs.IterReferences()
-	if err != nil {
+	if err := r.buildFetchedTags(refs); err != nil {
 		return err
 	}
 
-	return iter.ForEach(func(ref *plumbing.Reference) error {
+	if !updated {
+		return NoErrAlreadyUpToDate
+	}
+	return nil
+}
+
+func (r *Remote) buildFetchedTags(refs memory.ReferenceStorage) error {
+	updated := false
+	for _, ref := range refs {
 		if !ref.IsTag() {
-			return nil
+			continue
 		}
 
 		_, err := r.s.EncodedObject(plumbing.AnyObject, ref.Hash())
 		if err == plumbing.ErrObjectNotFound {
-			return nil
+			continue
 		}
 
 		if err != nil {
 			return err
 		}
 
-		return r.s.SetReference(ref)
-	})
+		if err = r.s.SetReference(ref); err != nil {
+			return err
+		}
+		updated = true
+	}
+	if !updated {
+		return NoErrAlreadyUpToDate
+	}
+	return nil
 }
 
 func objectsToPush(commands []*packp.Command) ([]plumbing.Hash, error) {


### PR DESCRIPTION
I recently ran into some behavior that was not consistent with the standard git tooling.

It seems that doing a `(*Remote).Fetch()` will not update the local remote refs (i.e. `refs/remotes/origin/*`) if we already have all the new commit objects locally. The standard git tooling will continue to update the local remote refs even if it doesn't need to fetch a pack file with new commit objects.

You can see an example below where we are in a repository that already has both `7a58be` and `2d8e82`.

    $ git show-ref
    7a58be863cf6c431619df28b709b3bc87f2a2e29 refs/heads/master
    2d8e82007fa1df7f9e203d56543f95388cac9449 refs/remotes/origin/HEAD
    2d8e82007fa1df7f9e203d56543f95388cac9449 refs/remotes/origin/master

But the current remote references are out of date:

    $ git ls-remote origin
    7a58be863cf6c431619df28b709b3bc87f2a2e29  HEAD
    7a58be863cf6c431619df28b709b3bc87f2a2e29  refs/heads/master

The fetch will not pull down any new commit objects, but will proceed with updating the remote refs in the local repository.

    $ git fetch origin
    From github.com:orirawlings/test
       2d8e820..7a58be8  master     -> origin/master
    $ git show-ref
    7a58be863cf6c431619df28b709b3bc87f2a2e29 refs/heads/master
    7a58be863cf6c431619df28b709b3bc87f2a2e29 refs/remotes/origin/HEAD
    7a58be863cf6c431619df28b709b3bc87f2a2e29 refs/remotes/origin/master


I'm not really sure from an API design side if we want to continue to return the `NoErrAlreadyUpToDate` error, but the current PR changes preserve this in the response.