### PR TITLE
Fixes checkout not possible with (untracked) files under gitignore

### DIFF
--- a/worktree_status.go
+++ b/worktree_status.go
@@ -68,8 +68,6 @@ func (w *Worktree) status(commit plumbing.Hash) (Status, error) {
 		return nil, err
 	}
 
-	right = w.excludeIgnoredChanges(right)
-
 	for _, ch := range right {
 		a, err := ch.Action()
 		if err != nil {
@@ -117,7 +115,11 @@ func (w *Worktree) diffStagingWithWorktree() (merkletrie.Changes, error) {
 	}
 
 	to := filesystem.NewRootNode(w.fs, submodules)
-	return merkletrie.DiffTree(from, to, diffTreeIsEquals)
+	res, err := merkletrie.DiffTree(from, to, diffTreeIsEquals)
+	if err == nil {
+		res = w.excludeIgnoredChanges(res)
+	}
+	return res, err
 }
 
 func (w *Worktree) excludeIgnoredChanges(changes merkletrie.Changes) merkletrie.Changes {


### PR DESCRIPTION
This is a follow up for #429. The original implementation was based on the assumption that `Worktree.Status` is used to check differences between the index and the worktree. However, the `Worktree.Checkout` uses `Worktree.diffStagingWithWorktree` (via `Worktree.cointainsUnstagedChanges`), which is also used by the `Status`. This has prevented a checkout of a branch due to "unstaged changes" even when the status shows clean. 

In this PR the application of ignores is moved from `Status` directly into `diffStagingWithWorktree`, so the `Status` logic remains unchanged, but now the same logic applies to `Checkout`. With this change `Checkout` proceeds as there are no unstaged changes any longer (listed in ignores).