### PR TITLE
WIP: Improves gitignore performance & adds (future) option for force-commit of gitignored files

### DIFF
--- a/worktree_test.go
+++ b/worktree_test.go
@@ -546,10 +546,7 @@ func (s *WorktreeSuite) TestStatusForceIgnored(c *C) {
 	setForcedIgnored(true)
 	defer setForcedIgnored(false)
 
-	dir, _ := ioutil.TempDir("", "status")
-	defer os.RemoveAll(dir)
-
-	fs := osfs.New(filepath.Join(dir, "worktree"))
+	fs := memfs.New()
 	w := &Worktree{
 		r:  s.Repository,
 		fs: fs,
@@ -586,7 +583,7 @@ func (s *WorktreeSuite) TestStatusForceIgnored(c *C) {
 	c.Assert(err, Equals, nil)
 	status, _ = w.Status()
 	c.Assert(len(status), Equals, 5)
-	_, ok = status["vendor/gopkg.in/file"]
+	_, ok := status["vendor/gopkg.in/file"]
 	c.Assert(ok, Equals, true)
 
 	_, err = w.Commit("test", &CommitOptions{Author:&object.Signature{Name: "test", Email: "test@test.com", When: time.Now()}})

--- a/worktree_test.go
+++ b/worktree_test.go
@@ -4,6 +4,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"time"
 
 	"gopkg.in/src-d/go-git.v4/plumbing"
 	"gopkg.in/src-d/go-git.v4/plumbing/filemode"
@@ -478,14 +479,18 @@ func (s *WorktreeSuite) TestStatusIgnored(c *C) {
 	fs.MkdirAll("vendor/gopkg.in", os.ModePerm)
 	f, _ = fs.Create("vendor/gopkg.in/file")
 	f.Close()
+	f, _ = fs.Create("vendor/gopkg.in/another")
+	f.Close()
 
 	status, _ := w.Status()
-	c.Assert(len(status), Equals, 3)
+	c.Assert(len(status), Equals, 4)
 	_, ok := status["another/file"]
 	c.Assert(ok, Equals, true)
 	_, ok = status["vendor/github.com/file"]
 	c.Assert(ok, Equals, true)
 	_, ok = status["vendor/gopkg.in/file"]
+	c.Assert(ok, Equals, true)
+	_, ok = status["vendor/gopkg.in/another"]
 	c.Assert(ok, Equals, true)
 
 	f, _ = fs.Create(".gitignore")
@@ -504,6 +509,72 @@ func (s *WorktreeSuite) TestStatusIgnored(c *C) {
 	_, ok = status["vendor/.gitignore"]
 	c.Assert(ok, Equals, true)
 	_, ok = status["vendor/github.com/file"]
+	c.Assert(ok, Equals, true)
+}
+
+func setForcedIgnored(v bool) {
+	forceIgnored = v
+}
+
+func (s *WorktreeSuite) TestStatusForceIgnored(c *C) {
+	setForcedIgnored(true)
+	defer setForcedIgnored(false)
+
+	dir, _ := ioutil.TempDir("", "status")
+	defer os.RemoveAll(dir)
+
+	fs := osfs.New(filepath.Join(dir, "worktree"))
+	w := &Worktree{
+		r:  s.Repository,
+		fs: fs,
+	}
+
+	w.Checkout(&CheckoutOptions{})
+
+	fs.MkdirAll("another", os.ModePerm)
+	f, _ := fs.Create("another/file")
+	f.Close()
+	fs.MkdirAll("vendor/github.com", os.ModePerm)
+	f, _ = fs.Create("vendor/github.com/file")
+	f.Close()
+	fs.MkdirAll("vendor/gopkg.in", os.ModePerm)
+	f, _ = fs.Create("vendor/gopkg.in/file")
+	f.Close()
+	f, _ = fs.Create("vendor/gopkg.in/another")
+	f.Close()
+
+	status, _ := w.Status()
+	c.Assert(len(status), Equals, 4)
+
+	f, _ = fs.Create(".gitignore")
+	f.Write([]byte("vendor/g*/"))
+	f.Close()
+	f, _ = fs.Create("vendor/.gitignore")
+	f.Write([]byte("!github.com/\n"))
+	f.Close()
+
+	status, _ = w.Status()
+	c.Assert(len(status), Equals, 4)
+
+	_, err := w.Add("vendor/gopkg.in/file")
+	c.Assert(err, Equals, nil)
+	status, _ = w.Status()
+	c.Assert(len(status), Equals, 5)
+	_, ok = status["vendor/gopkg.in/file"]
+	c.Assert(ok, Equals, true)
+
+	_, err = w.Commit("test", &CommitOptions{Author:&object.Signature{Name: "test", Email: "test@test.com", When: time.Now()}})
+	c.Assert(err, Equals, nil)
+
+	status, _ = w.Status()
+	c.Assert(len(status), Equals, 4)
+
+	_, err = w.Remove("vendor/gopkg.in/file")
+	c.Assert(err, Equals, nil)
+
+	status, _ = w.Status()
+	c.Assert(len(status), Equals, 5)
+	_, ok = status["vendor/gopkg.in/file"]
 	c.Assert(ok, Equals, true)
 }
 


### PR DESCRIPTION
This PR contains #444 and builds upon it. 

Changed to WIP: testing on a collection of large repositories with nested .gitignore some inconsistencies have been identified

*The problem*: having gitignore matcher acting in the worktree on the diffs results in traversing over potentially massive trees of file names of directories which are fully excluded (think e.g. of a `vendor/` gitignore record for Go modules). This is noticeably slow. 

*Solution*: Unless forcing an ignored file into the commit, one could exclude these files at the file system level in the noder (as originally suggested), so the noder would not dive into the directory at all and save uncovering and then removing thousands of files. This PR combines the two approaches: if force disabled, then files are ignored at the file system level, if force is enabled, file system delivers the full tree and files are ignored in the diff, however those marked M or D in the worktree are forced through, along with all in staging. The point here was not to implement the force, but to speed up the normal case, and force comes as an added value, albeit _not_ integrated into Status or Commit. Currently it is just a var flag set to false and only reset to true in the test to demo that force would work this way if added to Status and Commit.