### PR TITLE
capability: accept unknown capabilities, fixes #450

### DIFF
--- a/plumbing/protocol/packp/capability/list.go
+++ b/plumbing/protocol/packp/capability/list.go
@@ -8,8 +8,6 @@ import (
 )
 
 var (
-	// ErrUnknownCapability is returned if a unknown capability is given
-	ErrUnknownCapability = errors.New("unknown capability")
 	// ErrArgumentsRequired is returned if no arguments are giving with a
 	// capability that requires arguments
 	ErrArgumentsRequired = errors.New("arguments required")
@@ -119,10 +117,6 @@ func (l *List) Add(c Capability, values ...string) error {
 }
 
 func (l *List) validate(c Capability, values []string) error {
-	if _, ok := valid[c]; !ok {
-		return ErrUnknownCapability
-	}
-
 	if requiresArgument[c] && len(values) == 0 {
 		return ErrArgumentsRequired
 	}

--- a/plumbing/protocol/packp/capability/list_test.go
+++ b/plumbing/protocol/packp/capability/list_test.go
@@ -58,10 +58,11 @@ func (s *SuiteCapabilities) TestDecodeWithEqual(c *check.C) {
 	c.Assert(cap.Get(Agent), check.DeepEquals, []string{"foo=bar"})
 }
 
-func (s *SuiteCapabilities) TestDecodeWithErrUnknownCapability(c *check.C) {
+func (s *SuiteCapabilities) TestDecodeWithUnknownCapability(c *check.C) {
 	cap := NewList()
 	err := cap.Decode([]byte("foo"))
-	c.Assert(err, check.Equals, ErrUnknownCapability)
+	c.Assert(err, check.IsNil)
+	c.Assert(cap.Supports(Capability("foo")), check.Equals, true)
 }
 
 func (s *SuiteCapabilities) TestString(c *check.C) {
@@ -133,10 +134,11 @@ func (s *SuiteCapabilities) TestAdd(c *check.C) {
 	c.Assert(cap.String(), check.Equals, "symref=foo symref=qux thin-pack")
 }
 
-func (s *SuiteCapabilities) TestAddErrUnknownCapability(c *check.C) {
+func (s *SuiteCapabilities) TestAddUnknownCapability(c *check.C) {
 	cap := NewList()
 	err := cap.Add(Capability("foo"))
-	c.Assert(err, check.Equals, ErrUnknownCapability)
+	c.Assert(err, check.IsNil)
+	c.Assert(cap.Supports(Capability("foo")), check.Equals, true)
 }
 
 func (s *SuiteCapabilities) TestAddErrArgumentsRequired(c *check.C) {


### PR DESCRIPTION
GitHub has started using a non-standard capability `early-capabilities`
with `agent=git/github-g3daa19f21`. This is breaking all go-git operations
on GitHub.

This commit removes validation for known capabilities, so that we can
use non-standard capabilities safely.