### PR TITLE
fix reference shortening

### DIFF
--- a/plumbing/reference_test.go
+++ b/plumbing/reference_test.go
@@ -23,6 +23,11 @@ func (s *ReferenceSuite) TestReferenceNameWithSlash(c *C) {
 	c.Assert(r.Short(), Equals, "origin/feature/AllowSlashes")
 }
 
+func (s *ReferenceSuite) TestReferenceNameNote(c *C) {
+	r := ReferenceName("refs/notes/foo")
+	c.Assert(r.Short(), Equals, "notes/foo")
+}
+
 func (s *ReferenceSuite) TestNewReferenceFromStrings(c *C) {
 	r := NewReferenceFromStrings("refs/heads/v4", "6ecf0ef2c2dffb796033e5a02219af86ec6584e5")
 	c.Assert(r.Type(), Equals, HashReference)


### PR DESCRIPTION
Implemented according to git shorten_unambiguous_ref.
See: https://github.com/git/git/blob/e0aaa1b6532cfce93d87af9bc813fb2e7a7ce9d7/refs.c#L1030