### PR TITLE
plumbing: protocol, fix handling multiple ACK on upload-pack

### DIFF
--- a/plumbing/protocol/packp/srvresp_test.go
+++ b/plumbing/protocol/packp/srvresp_test.go
@@ -1,6 +1,7 @@
 package packp
 
 import (
+	"bufio"
 	"bytes"
 
 	"gopkg.in/src-d/go-git.v4/plumbing"
@@ -16,7 +17,7 @@ func (s *ServerResponseSuite) TestDecodeNAK(c *C) {
 	raw := "0008NAK\n"
 
 	sr := &ServerResponse{}
-	err := sr.Decode(bytes.NewBufferString(raw), false)
+	err := sr.Decode(bufio.NewReader(bytes.NewBufferString(raw)), false)
 	c.Assert(err, IsNil)
 
 	c.Assert(sr.ACKs, HasLen, 0)
@@ -26,7 +27,18 @@ func (s *ServerResponseSuite) TestDecodeACK(c *C) {
 	raw := "0031ACK 6ecf0ef2c2dffb796033e5a02219af86ec6584e5\n"
 
 	sr := &ServerResponse{}
-	err := sr.Decode(bytes.NewBufferString(raw), false)
+	err := sr.Decode(bufio.NewReader(bytes.NewBufferString(raw)), false)
+	c.Assert(err, IsNil)
+
+	c.Assert(sr.ACKs, HasLen, 1)
+	c.Assert(sr.ACKs[0], Equals, plumbing.NewHash("6ecf0ef2c2dffb796033e5a02219af86ec6584e5"))
+}
+
+func (s *ServerResponseSuite) TestDecodeMultipleACK(c *C) {
+	raw := "0031ACK 6ecf0ef2c2dffb796033e5a02219af86ec6584e5\n0031ACK 6ecf0ef2c2dffb796033e5a02219af86ec6584e5\n"
+
+	sr := &ServerResponse{}
+	err := sr.Decode(bufio.NewReader(bytes.NewBufferString(raw)), false)
 	c.Assert(err, IsNil)
 
 	c.Assert(sr.ACKs, HasLen, 1)
@@ -37,12 +49,12 @@ func (s *ServerResponseSuite) TestDecodeMalformed(c *C) {
 	raw := "0029ACK 6ecf0ef2c2dffb796033e5a02219af86ec6584e\n"
 
 	sr := &ServerResponse{}
-	err := sr.Decode(bytes.NewBufferString(raw), false)
+	err := sr.Decode(bufio.NewReader(bytes.NewBufferString(raw)), false)
 	c.Assert(err, NotNil)
 }
 
 func (s *ServerResponseSuite) TestDecodeMultiACK(c *C) {
 	sr := &ServerResponse{}
-	err := sr.Decode(bytes.NewBuffer(nil), true)
+	err := sr.Decode(bufio.NewReader(bytes.NewBuffer(nil)), true)
 	c.Assert(err, NotNil)
 }

--- a/plumbing/protocol/packp/uppackresp_test.go
+++ b/plumbing/protocol/packp/uppackresp_test.go
@@ -15,7 +15,7 @@ type UploadPackResponseSuite struct{}
 var _ = Suite(&UploadPackResponseSuite{})
 
 func (s *UploadPackResponseSuite) TestDecodeNAK(c *C) {
-	raw := "0008NAK\n[PACK]"
+	raw := "0008NAK\nPACK"
 
 	req := NewUploadPackRequest()
 	res := NewUploadPackResponse(req)
@@ -26,11 +26,11 @@ func (s *UploadPackResponseSuite) TestDecodeNAK(c *C) {
 
 	pack, err := ioutil.ReadAll(res)
 	c.Assert(err, IsNil)
-	c.Assert(pack, DeepEquals, []byte("[PACK]"))
+	c.Assert(pack, DeepEquals, []byte("PACK"))
 }
 
 func (s *UploadPackResponseSuite) TestDecodeDepth(c *C) {
-	raw := "00000008NAK\n[PACK]"
+	raw := "00000008NAK\nPACK"
 
 	req := NewUploadPackRequest()
 	req.Depth = DepthCommits(1)
@@ -43,11 +43,11 @@ func (s *UploadPackResponseSuite) TestDecodeDepth(c *C) {
 
 	pack, err := ioutil.ReadAll(res)
 	c.Assert(err, IsNil)
-	c.Assert(pack, DeepEquals, []byte("[PACK]"))
+	c.Assert(pack, DeepEquals, []byte("PACK"))
 }
 
 func (s *UploadPackResponseSuite) TestDecodeMalformed(c *C) {
-	raw := "00000008ACK\n[PACK]"
+	raw := "00000008ACK\nPACK"
 
 	req := NewUploadPackRequest()
 	req.Depth = DepthCommits(1)
@@ -96,7 +96,7 @@ func (s *UploadPackResponseSuite) TestEncodeNAK(c *C) {
 }
 
 func (s *UploadPackResponseSuite) TestEncodeDepth(c *C) {
-	pf := ioutil.NopCloser(bytes.NewBuffer([]byte("[PACK]")))
+	pf := ioutil.NopCloser(bytes.NewBuffer([]byte("PACK")))
 	req := NewUploadPackRequest()
 	req.Depth = DepthCommits(1)
 
@@ -106,7 +106,7 @@ func (s *UploadPackResponseSuite) TestEncodeDepth(c *C) {
 	b := bytes.NewBuffer(nil)
 	c.Assert(res.Encode(b), IsNil)
 
-	expected := "00000008NAK\n[PACK]"
+	expected := "00000008NAK\nPACK"
 	c.Assert(string(b.Bytes()), Equals, expected)
 }
 


### PR DESCRIPTION
Due to an issue at the git upload-request service, multiples ACK messages are sent in some cases. This fix  makes this a supported thing. 