### PR TITLE
improve delete support on push

### DIFF
--- a/plumbing/protocol/packp/updreq.go
+++ b/plumbing/protocol/packp/updreq.go
@@ -42,6 +42,7 @@ func NewReferenceUpdateRequest() *ReferenceUpdateRequest {
 //   - report-status
 //   - ofs-delta
 //   - ref-delta
+//   - delete-refs
 // It leaves up to the user to add the following capabilities later:
 //   - atomic
 //   - ofs-delta

--- a/plumbing/transport/server/receive_pack_test.go
+++ b/plumbing/transport/server/receive_pack_test.go
@@ -27,11 +27,6 @@ func (s *ReceivePackSuite) TearDownTest(c *C) {
 	s.Suite.TearDownSuite(c)
 }
 
-// TODO
-func (s *ReceivePackSuite) TestSendPackAddDeleteReference(c *C) {
-	c.Skip("delete reference not supported yet")
-}
-
 // Overwritten, server returns error earlier.
 func (s *ReceivePackSuite) TestAdvertisedReferencesNotExists(c *C) {
 	r, err := s.Client.NewReceivePackSession(s.NonExistentEndpoint, s.EmptyAuth)

--- a/plumbing/transport/test/receive_pack.go
+++ b/plumbing/transport/test/receive_pack.go
@@ -308,6 +308,10 @@ func (s *ReceivePackSuite) testSendPackDeleteReference(c *C) {
 		req.Capabilities.Set(capability.ReportStatus)
 	}
 
+	if !ar.Capabilities.Supports(capability.DeleteRefs) {
+		c.Fatal("capability delete-refs not supported")
+	}
+
 	c.Assert(r.Close(), IsNil)
 
 	s.receivePack(c, s.Endpoint, req, nil, false)

--- a/remote.go
+++ b/remote.go
@@ -21,7 +21,10 @@ import (
 	"gopkg.in/src-d/go-git.v4/utils/ioutil"
 )
 
-var NoErrAlreadyUpToDate = errors.New("already up-to-date")
+var (
+	NoErrAlreadyUpToDate     = errors.New("already up-to-date")
+	ErrDeleteRefNotSupported = errors.New("server does not support delete-refs")
+)
 
 // Remote represents a connection to a remote repository.
 type Remote struct {
@@ -56,7 +59,6 @@ func (r *Remote) Fetch(o *FetchOptions) error {
 // Push performs a push to the remote. Returns NoErrAlreadyUpToDate if the
 // remote was already up-to-date.
 func (r *Remote) Push(o *PushOptions) (err error) {
-	// TODO: Support deletes.
 	// TODO: Sideband support
 
 	if o.RemoteName == "" {
@@ -86,6 +88,18 @@ func (r *Remote) Push(o *PushOptions) (err error) {
 	remoteRefs, err := ar.AllReferences()
 	if err != nil {
 		return err
+	}
+
+	isDelete := false
+	for _, rs := range o.RefSpecs {
+		if rs.IsDelete() {
+			isDelete = true
+			break
+		}
+	}
+
+	if isDelete && !ar.Capabilities.Supports(capability.DeleteRefs) {
+		return ErrDeleteRefNotSupported
 	}
 
 	req := packp.NewReferenceUpdateRequestFromCapabilities(ar.Capabilities)
@@ -284,8 +298,8 @@ func (r *Remote) deleteReferences(rs config.RefSpec,
 
 		cmd := &packp.Command{
 			Name: ref.Name(),
-			Old: ref.Hash(),
-			New: plumbing.ZeroHash,
+			Old:  ref.Hash(),
+			New:  plumbing.ZeroHash,
 		}
 		req.Commands = append(req.Commands, cmd)
 		return nil


### PR DESCRIPTION
* server: implement delete-refs and announce it.
* remote: check if server announced delete-refs before trying
   to delete and fail fast if it does not.
    
Note that the client does not need no send 'delete-refs' back
to the server to be able to delete references:

 ```
delete-refs
-----------
    
If the server sends back the 'delete-refs' capability, it means that
it is capable of accepting a zero-id value as the target
value of a reference update.  It is not sent back by the client, it
simply informs the client that it can be sent zero-id values
to delete references.
```
    
So our server implementation does not check if the client sent
delete-refs back, it just accepts deletes if it receives them.
