### PR TITLE
Use buffered IO for decoding index files.

### DIFF
--- a/plumbing/format/idxfile/decoder.go
+++ b/plumbing/format/idxfile/decoder.go
@@ -1,6 +1,7 @@
 package idxfile
 
 import (
+	"bufio"
 	"bytes"
 	"errors"
 	"io"
@@ -19,12 +20,12 @@ var (
 
 // Decoder reads and decodes idx files from an input stream.
 type Decoder struct {
-	io.Reader
+	*bufio.Reader
 }
 
 // NewDecoder builds a new idx stream decoder, that reads from r.
 func NewDecoder(r io.Reader) *Decoder {
-	return &Decoder{r}
+	return &Decoder{bufio.NewReader(r)}
 }
 
 // Decode reads from the stream and decode the content into the Idxfile struct.


### PR DESCRIPTION
This reduces syscall CPU time from >40% to <10% in my local repository.