### PR TITLE
transport/server: add asClient parameter

### DIFF
--- a/plumbing/transport/server/server_test.go
+++ b/plumbing/transport/server/server_test.go
@@ -20,12 +20,18 @@ type BaseSuite struct {
 	loader       server.MapLoader
 	client       transport.Transport
 	clientBackup transport.Transport
+	asClient     bool
 }
 
 func (s *BaseSuite) SetUpSuite(c *C) {
 	s.Suite.SetUpSuite(c)
 	s.loader = server.MapLoader{}
-	s.client = server.NewServer(s.loader)
+	if s.asClient {
+		s.client = server.NewClient(s.loader)
+	} else {
+		s.client = server.NewServer(s.loader)
+	}
+
 	s.clientBackup = client.Protocols["file"]
 	client.Protocols["file"] = s.client
 }

--- a/plumbing/transport/server/upload_pack_test.go
+++ b/plumbing/transport/server/upload_pack_test.go
@@ -38,3 +38,20 @@ func (s *UploadPackSuite) TestAdvertisedReferencesNotExists(c *C) {
 	c.Assert(err, Equals, transport.ErrRepositoryNotFound)
 	c.Assert(r, IsNil)
 }
+
+// Tests server with `asClient = true`. This is recommended when using a server
+// registered directly with `client.InstallProtocol`.
+type ClientLikeUploadPackSuite struct {
+	UploadPackSuite
+}
+
+var _ = Suite(&ClientLikeUploadPackSuite{})
+
+func (s *ClientLikeUploadPackSuite) SetUpSuite(c *C) {
+	s.asClient = true
+	s.UploadPackSuite.SetUpSuite(c)
+}
+
+func (s *ClientLikeUploadPackSuite) TestAdvertisedReferencesEmpty(c *C) {
+	s.UploadPackSuite.UploadPackSuite.TestAdvertisedReferencesEmpty(c)
+}


### PR DESCRIPTION
Now server.NewServer takes a second parameter `asClient`.
When `asClient` is true, the returned instance behaves exactly
as a client from any other protocol. This makes it working
seamlessly when registering a server directly with
`client.InstallProtocol`.