### PR TITLE
remote: avoid duplicate haves

### DIFF
--- a/remote.go
+++ b/remote.go
@@ -356,20 +356,30 @@ func getHaves(localRefs storer.ReferenceStorer) ([]plumbing.Hash, error) {
 		return nil, err
 	}
 
-	var haves []plumbing.Hash
+	haves := map[plumbing.Hash]bool{}
 	err = iter.ForEach(func(ref *plumbing.Reference) error {
+		if haves[ref.Hash()] == true {
+			return nil
+		}
+
 		if ref.Type() != plumbing.HashReference {
 			return nil
 		}
 
-		haves = append(haves, ref.Hash())
+		haves[ref.Hash()] = true
 		return nil
 	})
+
 	if err != nil {
 		return nil, err
 	}
 
-	return haves, nil
+	var result []plumbing.Hash
+	for h := range haves {
+		result = append(result, h)
+	}
+
+	return result, nil
 }
 
 func getWants(

--- a/remote_test.go
+++ b/remote_test.go
@@ -499,6 +499,25 @@ func (s *RemoteSuite) TestPushWrongRemoteName(c *C) {
 	c.Assert(err, ErrorMatches, ".*remote names don't match.*")
 }
 
+func (s *RemoteSuite) TestGetHaves(c *C) {
+	st := memory.NewStorage()
+	st.SetReference(plumbing.NewReferenceFromStrings(
+		"foo", "f7b877701fbf855b44c0a9e86f3fdce2c298b07f",
+	))
+
+	st.SetReference(plumbing.NewReferenceFromStrings(
+		"bar", "fe6cb94756faa81e5ed9240f9191b833db5f40ae",
+	))
+
+	st.SetReference(plumbing.NewReferenceFromStrings(
+		"qux", "f7b877701fbf855b44c0a9e86f3fdce2c298b07f",
+	))
+
+	l, err := getHaves(st)
+	c.Assert(err, IsNil)
+	c.Assert(l, HasLen, 2)
+}
+
 const bareConfig = `[core]
 repositoryformatversion = 0
 filemode = true


### PR DESCRIPTION
avoid duplicated haves on request, to avoid posible errors with the git server