### PR TITLE
remote: fix Worktree.Status on empty repository

### DIFF
--- a/utils/merkletrie/iter.go
+++ b/utils/merkletrie/iter.go
@@ -83,6 +83,10 @@ func newIter(root noder.Noder, base noder.Path) (*Iter, error) {
 		base: base,
 	}
 
+	if root == nil {
+		return ret, nil
+	}
+
 	frame, err := frame.New(root)
 	if err != nil {
 		return nil, err

--- a/utils/merkletrie/iter_test.go
+++ b/utils/merkletrie/iter_test.go
@@ -19,13 +19,13 @@ var _ = Suite(&IterSuite{})
 // A test is a list of operations we want to perform on an iterator and
 // their expected results.
 //
-// The operations are expresed as a sequence of `n` and `s`,
+// The operations are expressed as a sequence of `n` and `s`,
 // representing the amount of next and step operations we want to call
 // on the iterator and their order.  For example, an operations value of
 // "nns" means: call a `n`ext, then another `n`ext and finish with a
 // `s`tep.
 //
-// The expeced is the full path of the noders returned by the
+// The expected is the full path of the noders returned by the
 // operations, separated by spaces.
 //
 // For instance:
@@ -444,6 +444,13 @@ type errorNoder struct{ noder.Noder }
 
 func (e *errorNoder) Children() ([]noder.Noder, error) {
 	return nil, fmt.Errorf("mock error")
+}
+
+func (s *IterSuite) TestNewIterNil(c *C) {
+	i, err := merkletrie.NewIter(nil)
+	c.Assert(err, IsNil)
+	_, err = i.Next()
+	c.Assert(err, Equals, io.EOF)
 }
 
 func (s *IterSuite) TestNewIterFailsOnChildrenErrors(c *C) {

--- a/worktree_status.go
+++ b/worktree_status.go
@@ -24,16 +24,18 @@ var ErrDestinationExists = errors.New("destination exists")
 
 // Status returns the working tree status.
 func (w *Worktree) Status() (Status, error) {
-	ref, err := w.r.Head()
-	if err == plumbing.ErrReferenceNotFound {
-		return make(Status, 0), nil
-	}
+	var hash plumbing.Hash
 
-	if err != nil {
+	ref, err := w.r.Head()
+	if err != nil && err != plumbing.ErrReferenceNotFound {
 		return nil, err
 	}
 
-	return w.status(ref.Hash())
+	if err == nil {
+		hash = ref.Hash()
+	}
+
+	return w.status(hash)
 }
 
 func (w *Worktree) status(commit plumbing.Hash) (Status, error) {
@@ -182,19 +184,22 @@ func (w *Worktree) diffCommitWithStaging(commit plumbing.Hash, reverse bool) (me
 		return nil, err
 	}
 
-	c, err := w.r.CommitObject(commit)
-	if err != nil {
-		return nil, err
-	}
+	var from noder.Noder
+	if !commit.IsZero() {
+		c, err := w.r.CommitObject(commit)
+		if err != nil {
+			return nil, err
+		}
 
-	t, err := c.Tree()
-	if err != nil {
-		return nil, err
+		t, err := c.Tree()
+		if err != nil {
+			return nil, err
+		}
+
+		from = object.NewTreeRootNode(t)
 	}
 
 	to := mindex.NewRootNode(idx)
-	from := object.NewTreeRootNode(t)
-
 	if reverse {
 		return merkletrie.DiffTree(to, from, diffTreeIsEquals)
 	}

--- a/worktree_test.go
+++ b/worktree_test.go
@@ -344,6 +344,25 @@ func (s *WorktreeSuite) TestStatusEmpty(c *C) {
 	c.Assert(status, NotNil)
 }
 
+func (s *WorktreeSuite) TestStatusEmptyDirty(c *C) {
+	fs := memfs.New()
+	err := util.WriteFile(fs, "foo", []byte("foo"), 0755)
+	c.Assert(err, IsNil)
+
+	storage := memory.NewStorage()
+
+	r, err := Init(storage, fs)
+	c.Assert(err, IsNil)
+
+	w, err := r.Worktree()
+	c.Assert(err, IsNil)
+
+	status, err := w.Status()
+	c.Assert(err, IsNil)
+	c.Assert(status.IsClean(), Equals, false)
+	c.Assert(status, HasLen, 1)
+}
+
 func (s *WorktreeSuite) TestReset(c *C) {
 	fs := memfs.New()
 	w := &Worktree{


### PR DESCRIPTION
Fix https://github.com/src-d/go-git/issues/459
