### PR TITLE
Repository API for creating references

### DIFF
--- a/options.go
+++ b/options.go
@@ -2,6 +2,7 @@ package git
 
 import (
 	"errors"
+	"strings"
 
 	"gopkg.in/src-d/go-git.v4/config"
 	"gopkg.in/src-d/go-git.v4/plumbing"
@@ -308,5 +309,41 @@ func (o *CommitOptions) Validate(r *Repository) error {
 		}
 	}
 
+	return nil
+}
+
+const (
+	refPrefix     = "refs/"
+	refHeadPrefix = refPrefix + "heads/"
+)
+
+var (
+	ErrBranchNameNotProvided = errors.New("branch name should be provided")
+)
+
+// BranchOptions describes how a branch operation should be performed.
+type BranchOptions struct {
+	// Name of the branch.
+	Name string
+	// Start point of the branch, by default is repository HEAD
+	StartPoint plumbing.Hash
+}
+
+// Validate validates the fields and sets the default values.
+func (o *BranchOptions) Validate(r *Repository) error {
+	if o.Name == "" {
+		return ErrBranchNameNotProvided
+	}
+	if !strings.HasPrefix(o.Name, refHeadPrefix) {
+		o.Name = refHeadPrefix + o.Name
+	}
+
+	if o.StartPoint == plumbing.ZeroHash {
+		head, err := r.Reference(plumbing.HEAD, true)
+		if err != nil {
+			return err
+		}
+		o.StartPoint = head.Hash()
+	}
 	return nil
 }

--- a/repository.go
+++ b/repository.go
@@ -719,6 +719,16 @@ func (r *Repository) Branches() (storer.ReferenceIter, error) {
 		}, refIter), nil
 }
 
+// CreateBranch creates a new branch.
+func (r *Repository) CreateBranch(o *BranchOptions) (*plumbing.Reference, error) {
+	if err := o.Validate(r); err != nil {
+		return nil, err
+	}
+	n := plumbing.ReferenceName(o.Name)
+	b := plumbing.NewHashReference(n, o.StartPoint)
+	return b, r.Storer.SetReference(b)
+}
+
 // Notes returns all the References that are Branches.
 func (r *Repository) Notes() (storer.ReferenceIter, error) {
 	refIter, err := r.Storer.IterReferences()


### PR DESCRIPTION
A few issues have been reported recently (#481 and #430) that relate to some API confusion around creating new references for a repository.

I'm curious if there is some benefit to providing some high level API in Repository to enable the creation of branches and/or tags.

I threw together this patch to gather some quick feedback on whether this is something beneficial for the project, and to see if the API makes sense. I started with `CreateBranch` for now. Tests, further documentation, and demo examples are pending.

I figured that sticking to the options pattern for the arguments to CreateBranch would give us the ability to extend this easily in the future to support other features available in the standard `git branch` tool. Such features include configuring an upstream branches, tracking branches, editing description, etc.