### PR TITLE
move Repository.Pull to Worktree.Pull

### DIFF
--- a/_examples/remotes/main.go
+++ b/_examples/remotes/main.go
@@ -42,9 +42,9 @@ func main() {
 		fmt.Println(r)
 	}
 
-	// Pull using the create repository
-	Info("git pull example")
-	err = r.Pull(&git.PullOptions{
+	// Fetch using the new remote
+	Info("git fetch example")
+	err = r.Fetch(&git.FetchOptions{
 		RemoteName: "example",
 	})
 


### PR DESCRIPTION
This PR moves the method `Pull` from the `Repository` to `Worktree`, this method should be there because is only useful when the repository is not bare. This is the behavior at `cgit`:

```
> git clone git clone git@github.com:git-fixtures/basic.git --bare
....     
> git pull                            
fatal: This operation must be run in a work tree
````