### PR TITLE
Add AuthMethod based on HTTP Authorization header

### DIFF
--- a/plumbing/revlist/revlist.go
+++ b/plumbing/revlist/revlist.go
@@ -24,6 +24,14 @@ func Objects(
 	seen := hashListToSet(ignore)
 	result := make(map[plumbing.Hash]bool)
 
+	cleanerFunc := func(h plumbing.Hash) {
+		seen[h] = true
+	}
+
+	for _, h := range ignore {
+		processObject(s, h, hashListToSet([]plumbing.Hash{}), cleanerFunc)
+	}
+
 	walkerFunc := func(h plumbing.Hash) {
 		if !seen[h] {
 			result[h] = true

--- a/plumbing/transport/http/common.go
+++ b/plumbing/transport/http/common.go
@@ -145,6 +145,34 @@ type AuthMethod interface {
 	setAuth(r *http.Request)
 }
 
+// TokenAuthMethod is concrete implementation of common.AuthMethod for HTTP services
+// Allow Bearer Token used in git authentication.
+type TokenAuth struct {
+	token string
+}
+
+// NewTokenAuth returns a tokenAuth on the given authrorization token.
+func NewTokenAuth(token string) *TokenAuth {
+	return &TokenAuth{token}
+}
+
+func (a *TokenAuth) setAuth(r *http.Request) {
+	if a == nil {
+		return
+	}
+
+	r.Header.Set("Authorization", a.token)
+}
+
+// Name is name of the auth
+func (a *TokenAuth) Name() string {
+	return "http-token-auth"
+}
+
+func (a *TokenAuth) String() string {
+	return fmt.Sprintf("%s...", a.token[:10])
+}
+
 func basicAuthFromEndpoint(ep transport.Endpoint) *BasicAuth {
 	u := ep.User()
 	if u == "" {


### PR DESCRIPTION
This allows us to use `Authorization: Bearer XXXXX` to authenticate Git HTTP requests.