### PR TITLE
Dedup hashes that have already been tracked by remote refs

### DIFF
--- a/plumbing/revlist/revlist.go
+++ b/plumbing/revlist/revlist.go
@@ -24,6 +24,14 @@ func Objects(
 	seen := hashListToSet(ignore)
 	result := make(map[plumbing.Hash]bool)
 
+	cleanerFunc := func(h plumbing.Hash) {
+		seen[h] = true
+	}
+
+	for _, h := range ignore {
+		processObject(s, h, hashListToSet([]plumbing.Hash{}), cleanerFunc)
+	}
+
 	walkerFunc := func(h plumbing.Hash) {
 		if !seen[h] {
 			result[h] = true


### PR DESCRIPTION
An attempt to solve issue #505 

Based on my educated guess about the way git works. Need someone more experienced to double check this.