### PR TITLE
*: package context support in Repository, Remote and Submodule

### DIFF
--- a/submodule.go
+++ b/submodule.go
@@ -2,10 +2,11 @@ package git
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"fmt"
 
-	billy "gopkg.in/src-d/go-billy.v3"
+	"gopkg.in/src-d/go-billy.v3"
 	"gopkg.in/src-d/go-git.v4/config"
 	"gopkg.in/src-d/go-git.v4/plumbing"
 	"gopkg.in/src-d/go-git.v4/plumbing/format/index"
@@ -139,10 +140,21 @@ func (s *Submodule) Repository() (*Repository, error) {
 // submodule should be initialized first calling the Init method or setting in
 // the options SubmoduleUpdateOptions.Init equals true
 func (s *Submodule) Update(o *SubmoduleUpdateOptions) error {
-	return s.update(o, plumbing.ZeroHash)
+	return s.UpdateContext(context.Background(), o)
 }
 
-func (s *Submodule) update(o *SubmoduleUpdateOptions, forceHash plumbing.Hash) error {
+// UpdateContext the registered submodule to match what the superproject
+// expects, the submodule should be initialized first calling the Init method or
+// setting in the options SubmoduleUpdateOptions.Init equals true.
+//
+// The provided Context must be non-nil. If the context expires before the
+// operation is complete, an error is returned. The context only affects to the
+// transport operations.
+func (s *Submodule) UpdateContext(ctx context.Context, o *SubmoduleUpdateOptions) error {
+	return s.update(ctx, o, plumbing.ZeroHash)
+}
+
+func (s *Submodule) update(ctx context.Context, o *SubmoduleUpdateOptions, forceHash plumbing.Hash) error {
 	if !s.initialized && !o.Init {
 		return ErrSubmoduleNotInitialized
 	}
@@ -173,7 +185,7 @@ func (s *Submodule) update(o *SubmoduleUpdateOptions, forceHash plumbing.Hash) e
 		return err
 	}
 
-	if err := s.fetchAndCheckout(r, o, hash); err != nil {
+	if err := s.fetchAndCheckout(ctx, r, o, hash); err != nil {
 		return err
 	}
 
@@ -202,9 +214,11 @@ func (s *Submodule) doRecursiveUpdate(r *Repository, o *SubmoduleUpdateOptions) 
 	return l.Update(new)
 }
 
-func (s *Submodule) fetchAndCheckout(r *Repository, o *SubmoduleUpdateOptions, hash plumbing.Hash) error {
+func (s *Submodule) fetchAndCheckout(
+	ctx context.Context, r *Repository, o *SubmoduleUpdateOptions, hash plumbing.Hash,
+) error {
 	if !o.NoFetch {
-		err := r.Fetch(&FetchOptions{})
+		err := r.FetchContext(ctx, &FetchOptions{})
 		if err != nil && err != NoErrAlreadyUpToDate {
 			return err
 		}
@@ -239,8 +253,17 @@ func (s Submodules) Init() error {
 
 // Update updates all the submodules in this list.
 func (s Submodules) Update(o *SubmoduleUpdateOptions) error {
+	return s.UpdateContext(context.Background(), o)
+}
+
+// UpdateContext updates all the submodules in this list.
+//
+// The provided Context must be non-nil. If the context expires before the
+// operation is complete, an error is returned. The context only affects to the
+// transport operations.
+func (s Submodules) UpdateContext(ctx context.Context, o *SubmoduleUpdateOptions) error {
 	for _, sub := range s {
-		if err := sub.Update(o); err != nil {
+		if err := sub.UpdateContext(ctx, o); err != nil {
 			return err
 		}
 	}

--- a/submodule_test.go
+++ b/submodule_test.go
@@ -1,6 +1,7 @@
 package git
 
 import (
+	"context"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -189,4 +190,15 @@ func (s *SubmoduleSuite) TestSubmodulesStatus(c *C) {
 	status, err := sm.Status()
 	c.Assert(err, IsNil)
 	c.Assert(status, HasLen, 2)
+}
+
+func (s *SubmoduleSuite) TestSubmodulesUpdateContext(c *C) {
+	sm, err := s.Worktree.Submodules()
+	c.Assert(err, IsNil)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err = sm.UpdateContext(ctx, &SubmoduleUpdateOptions{Init: true})
+	c.Assert(err, NotNil)
 }

--- a/worktree_test.go
+++ b/worktree_test.go
@@ -2,6 +2,7 @@ package git
 
 import (
 	"bytes"
+	"context"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -83,7 +84,7 @@ func (s *WorktreeSuite) TestPullUpdateReferencesIfNeeded(c *C) {
 
 func (s *WorktreeSuite) TestPullInSingleBranch(c *C) {
 	r, _ := Init(memory.NewStorage(), memfs.New())
-	err := r.clone(&CloneOptions{
+	err := r.clone(context.Background(), &CloneOptions{
 		URL:          s.GetBasicLocalRepositoryURL(),
 		SingleBranch: true,
 	})


### PR DESCRIPTION
The following method has being added in order to support contexts in the main package, following the standard library pattern, instead of modifying the current methods, the following `*Context` were added:

```
type Remote
    func (r *Remote) FetchContext(ctx context.Context, o *FetchOptions) error
    func (r *Remote) PushContext(ctx context.Context, o *PushOptions) error
```
```
type Repository
    func CloneContext(ctx context.Context, s storage.Storer, worktree billy.Filesystem, o *CloneOptions) 
    func PlainCloneContext(ctx context.Context, path string, isBare bool, o *CloneOptions) (*Repository, error)
    func (r *Repository) PushContext(ctx context.Context, o *PushOptions) error
    func (r *Repository) FetchContext(ctx context.Context, o *FetchOptions) error
```

```
type Submodule
    func (s *Submodule) UpdateContext(ctx context.Context, o *SubmoduleUpdateOptions) error
```
```
type Worktree
    func (w *Worktree) PullContext(ctx context.Context, o *PullOptions) error
```

@JoshuaSjoding PTAL