### PR TITLE
worktree: expose underlying filesystem

### DIFF
--- a/repository.go
+++ b/repository.go
@@ -844,7 +844,7 @@ func (r *Repository) Worktree() (*Worktree, error) {
 		return nil, ErrIsBareRepository
 	}
 
-	return &Worktree{r: r, fs: r.wt}, nil
+	return &Worktree{r: r, Filesystem: r.wt}, nil
 }
 
 // ResolveRevision resolves revision to corresponding hash.

--- a/repository_test.go
+++ b/repository_test.go
@@ -1138,7 +1138,7 @@ func (s *RepositorySuite) TestWorktree(c *C) {
 	r, _ := Init(memory.NewStorage(), def)
 	w, err := r.Worktree()
 	c.Assert(err, IsNil)
-	c.Assert(w.fs, Equals, def)
+	c.Assert(w.Filesystem, Equals, def)
 }
 
 func (s *RepositorySuite) TestWorktreeBare(c *C) {

--- a/submodule.go
+++ b/submodule.go
@@ -115,7 +115,7 @@ func (s *Submodule) Repository() (*Repository, error) {
 	}
 
 	var worktree billy.Filesystem
-	if worktree, err = s.w.fs.Chroot(s.c.Path); err != nil {
+	if worktree, err = s.w.Filesystem.Chroot(s.c.Path); err != nil {
 		return nil, err
 	}
 

--- a/submodule_test.go
+++ b/submodule_test.go
@@ -128,7 +128,7 @@ func (s *SubmoduleSuite) TestUpdateWithRecursion(c *C) {
 
 	c.Assert(err, IsNil)
 
-	fs := s.Worktree.fs
+	fs := s.Worktree.Filesystem
 	_, err = fs.Stat(fs.Join("itself", "basic", "LICENSE"))
 	c.Assert(err, IsNil)
 }

--- a/worktree_commit.go
+++ b/worktree_commit.go
@@ -32,7 +32,7 @@ func (w *Worktree) Commit(msg string, opts *CommitOptions) (plumbing.Hash, error
 	}
 
 	h := &buildTreeHelper{
-		fs: w.fs,
+		fs: w.Filesystem,
 		s:  w.r.Storer,
 	}
 

--- a/worktree_commit_test.go
+++ b/worktree_commit_test.go
@@ -54,8 +54,8 @@ func (s *WorktreeSuite) TestCommitParent(c *C) {
 
 	fs := memfs.New()
 	w := &Worktree{
-		r:  s.Repository,
-		fs: fs,
+		r:          s.Repository,
+		Filesystem: fs,
 	}
 
 	err := w.Checkout(&CheckoutOptions{})
@@ -78,8 +78,8 @@ func (s *WorktreeSuite) TestCommitAll(c *C) {
 
 	fs := memfs.New()
 	w := &Worktree{
-		r:  s.Repository,
-		fs: fs,
+		r:          s.Repository,
+		Filesystem: fs,
 	}
 
 	err := w.Checkout(&CheckoutOptions{})

--- a/worktree_status.go
+++ b/worktree_status.go
@@ -116,7 +116,7 @@ func (w *Worktree) diffStagingWithWorktree() (merkletrie.Changes, error) {
 		return nil, err
 	}
 
-	to := filesystem.NewRootNode(w.fs, submodules)
+	to := filesystem.NewRootNode(w.Filesystem, submodules)
 	res, err := merkletrie.DiffTree(from, to, diffTreeIsEquals)
 	if err == nil {
 		res = w.excludeIgnoredChanges(res)
@@ -125,7 +125,7 @@ func (w *Worktree) diffStagingWithWorktree() (merkletrie.Changes, error) {
 }
 
 func (w *Worktree) excludeIgnoredChanges(changes merkletrie.Changes) merkletrie.Changes {
-	patterns, err := gitignore.ReadPatterns(w.fs, nil)
+	patterns, err := gitignore.ReadPatterns(w.Filesystem, nil)
 	if err != nil || len(patterns) == 0 {
 		return changes
 	}
@@ -251,7 +251,7 @@ func (w *Worktree) Add(path string) (plumbing.Hash, error) {
 }
 
 func (w *Worktree) copyFileToStorage(path string) (hash plumbing.Hash, err error) {
-	fi, err := w.fs.Lstat(path)
+	fi, err := w.Filesystem.Lstat(path)
 	if err != nil {
 		return plumbing.ZeroHash, err
 	}
@@ -281,7 +281,7 @@ func (w *Worktree) copyFileToStorage(path string) (hash plumbing.Hash, err error
 }
 
 func (w *Worktree) fillEncodedObjectFromFile(dst io.Writer, path string, fi os.FileInfo) (err error) {
-	src, err := w.fs.Open(path)
+	src, err := w.Filesystem.Open(path)
 	if err != nil {
 		return err
 	}
@@ -296,7 +296,7 @@ func (w *Worktree) fillEncodedObjectFromFile(dst io.Writer, path string, fi os.F
 }
 
 func (w *Worktree) fillEncodedObjectFromSymlink(dst io.Writer, path string, fi os.FileInfo) error {
-	target, err := w.fs.Readlink(path)
+	target, err := w.Filesystem.Readlink(path)
 	if err != nil {
 		return err
 	}
@@ -337,7 +337,7 @@ func (w *Worktree) doAddFileToIndex(idx *index.Index, filename string, h plumbin
 }
 
 func (w *Worktree) doUpdateFileToIndex(e *index.Entry, filename string, h plumbing.Hash) error {
-	info, err := w.fs.Lstat(filename)
+	info, err := w.Filesystem.Lstat(filename)
 	if err != nil {
 		return err
 	}
@@ -382,7 +382,7 @@ func (w *Worktree) deleteFromIndex(path string) (plumbing.Hash, error) {
 }
 
 func (w *Worktree) deleteFromFilesystem(path string) error {
-	err := w.fs.Remove(path)
+	err := w.Filesystem.Remove(path)
 	if os.IsNotExist(err) {
 		return nil
 	}
@@ -393,11 +393,11 @@ func (w *Worktree) deleteFromFilesystem(path string) error {
 // Move moves or rename a file in the worktree and the index, directories are
 // not supported.
 func (w *Worktree) Move(from, to string) (plumbing.Hash, error) {
-	if _, err := w.fs.Lstat(from); err != nil {
+	if _, err := w.Filesystem.Lstat(from); err != nil {
 		return plumbing.ZeroHash, err
 	}
 
-	if _, err := w.fs.Lstat(to); err == nil {
+	if _, err := w.Filesystem.Lstat(to); err == nil {
 		return plumbing.ZeroHash, ErrDestinationExists
 	}
 
@@ -406,7 +406,7 @@ func (w *Worktree) Move(from, to string) (plumbing.Hash, error) {
 		return plumbing.ZeroHash, err
 	}
 
-	if err := w.fs.Rename(from, to); err != nil {
+	if err := w.Filesystem.Rename(from, to); err != nil {
 		return hash, err
 	}
 

--- a/worktree_test.go
+++ b/worktree_test.go
@@ -192,8 +192,8 @@ func (s *RepositorySuite) TestPullAdd(c *C) {
 func (s *WorktreeSuite) TestCheckout(c *C) {
 	fs := memfs.New()
 	w := &Worktree{
-		r:  s.Repository,
-		fs: fs,
+		r:          s.Repository,
+		Filesystem: fs,
 	}
 
 	err := w.Checkout(&CheckoutOptions{})
@@ -225,12 +225,12 @@ func (s *WorktreeSuite) TestCheckoutSymlink(c *C) {
 	w, err := r.Worktree()
 	c.Assert(err, IsNil)
 
-	w.fs.Symlink("not-exists", "bar")
+	w.Filesystem.Symlink("not-exists", "bar")
 	w.Add("bar")
 	w.Commit("foo", &CommitOptions{Author: defaultSignature()})
 
 	r.Storer.SetIndex(&index.Index{Version: 2})
-	w.fs = osfs.New(filepath.Join(dir, "worktree-empty"))
+	w.Filesystem = osfs.New(filepath.Join(dir, "worktree-empty"))
 
 	err = w.Checkout(&CheckoutOptions{})
 	c.Assert(err, IsNil)
@@ -239,7 +239,7 @@ func (s *WorktreeSuite) TestCheckoutSymlink(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(status.IsClean(), Equals, true)
 
-	target, err := w.fs.Readlink("bar")
+	target, err := w.Filesystem.Readlink("bar")
 	c.Assert(target, Equals, "not-exists")
 	c.Assert(err, IsNil)
 }
@@ -280,8 +280,8 @@ func (s *WorktreeSuite) TestCheckoutSubmoduleInitialized(c *C) {
 func (s *WorktreeSuite) TestCheckoutIndexMem(c *C) {
 	fs := memfs.New()
 	w := &Worktree{
-		r:  s.Repository,
-		fs: fs,
+		r:          s.Repository,
+		Filesystem: fs,
 	}
 
 	err := w.Checkout(&CheckoutOptions{})
@@ -310,8 +310,8 @@ func (s *WorktreeSuite) TestCheckoutIndexOS(c *C) {
 
 	fs := osfs.New(filepath.Join(dir, "worktree"))
 	w := &Worktree{
-		r:  s.Repository,
-		fs: fs,
+		r:          s.Repository,
+		Filesystem: fs,
 	}
 
 	err = w.Checkout(&CheckoutOptions{})
@@ -335,8 +335,8 @@ func (s *WorktreeSuite) TestCheckoutIndexOS(c *C) {
 
 func (s *WorktreeSuite) TestCheckoutBranch(c *C) {
 	w := &Worktree{
-		r:  s.Repository,
-		fs: memfs.New(),
+		r:          s.Repository,
+		Filesystem: memfs.New(),
 	}
 
 	err := w.Checkout(&CheckoutOptions{
@@ -355,8 +355,8 @@ func (s *WorktreeSuite) TestCheckoutBranch(c *C) {
 
 func (s *WorktreeSuite) TestCheckoutCreateWithHash(c *C) {
 	w := &Worktree{
-		r:  s.Repository,
-		fs: memfs.New(),
+		r:          s.Repository,
+		Filesystem: memfs.New(),
 	}
 
 	err := w.Checkout(&CheckoutOptions{
@@ -378,8 +378,8 @@ func (s *WorktreeSuite) TestCheckoutCreateWithHash(c *C) {
 
 func (s *WorktreeSuite) TestCheckoutCreate(c *C) {
 	w := &Worktree{
-		r:  s.Repository,
-		fs: memfs.New(),
+		r:          s.Repository,
+		Filesystem: memfs.New(),
 	}
 
 	err := w.Checkout(&CheckoutOptions{
@@ -400,8 +400,8 @@ func (s *WorktreeSuite) TestCheckoutCreate(c *C) {
 
 func (s *WorktreeSuite) TestCheckoutBranchAndHash(c *C) {
 	w := &Worktree{
-		r:  s.Repository,
-		fs: memfs.New(),
+		r:          s.Repository,
+		Filesystem: memfs.New(),
 	}
 
 	err := w.Checkout(&CheckoutOptions{
@@ -414,8 +414,8 @@ func (s *WorktreeSuite) TestCheckoutBranchAndHash(c *C) {
 
 func (s *WorktreeSuite) TestCheckoutCreateMissingBranch(c *C) {
 	w := &Worktree{
-		r:  s.Repository,
-		fs: memfs.New(),
+		r:          s.Repository,
+		Filesystem: memfs.New(),
 	}
 
 	err := w.Checkout(&CheckoutOptions{
@@ -497,8 +497,8 @@ func (s *WorktreeSuite) testCheckoutBisect(c *C, url string) {
 func (s *WorktreeSuite) TestCheckoutWithGitignore(c *C) {
 	fs := memfs.New()
 	w := &Worktree{
-		r:  s.Repository,
-		fs: fs,
+		r:          s.Repository,
+		Filesystem: fs,
 	}
 
 	err := w.Checkout(&CheckoutOptions{})
@@ -526,8 +526,8 @@ func (s *WorktreeSuite) TestCheckoutWithGitignore(c *C) {
 func (s *WorktreeSuite) TestStatus(c *C) {
 	fs := memfs.New()
 	w := &Worktree{
-		r:  s.Repository,
-		fs: fs,
+		r:          s.Repository,
+		Filesystem: fs,
 	}
 
 	status, err := w.Status()
@@ -575,8 +575,8 @@ func (s *WorktreeSuite) TestStatusEmptyDirty(c *C) {
 func (s *WorktreeSuite) TestReset(c *C) {
 	fs := memfs.New()
 	w := &Worktree{
-		r:  s.Repository,
-		fs: fs,
+		r:          s.Repository,
+		Filesystem: fs,
 	}
 
 	commit := plumbing.NewHash("35e85108805c84807bc66a02d91535e1e24b38b9")
@@ -599,8 +599,8 @@ func (s *WorktreeSuite) TestReset(c *C) {
 func (s *WorktreeSuite) TestResetMerge(c *C) {
 	fs := memfs.New()
 	w := &Worktree{
-		r:  s.Repository,
-		fs: fs,
+		r:          s.Repository,
+		Filesystem: fs,
 	}
 
 	commit := plumbing.NewHash("35e85108805c84807bc66a02d91535e1e24b38b9")
@@ -626,8 +626,8 @@ func (s *WorktreeSuite) TestResetMerge(c *C) {
 func (s *WorktreeSuite) TestResetHard(c *C) {
 	fs := memfs.New()
 	w := &Worktree{
-		r:  s.Repository,
-		fs: fs,
+		r:          s.Repository,
+		Filesystem: fs,
 	}
 
 	commit := plumbing.NewHash("35e85108805c84807bc66a02d91535e1e24b38b9")
@@ -653,8 +653,8 @@ func (s *WorktreeSuite) TestResetHard(c *C) {
 func (s *WorktreeSuite) TestStatusAfterCheckout(c *C) {
 	fs := memfs.New()
 	w := &Worktree{
-		r:  s.Repository,
-		fs: fs,
+		r:          s.Repository,
+		Filesystem: fs,
 	}
 
 	err := w.Checkout(&CheckoutOptions{Force: true})
@@ -672,8 +672,8 @@ func (s *WorktreeSuite) TestStatusModified(c *C) {
 
 	fs := osfs.New(filepath.Join(dir, "worktree"))
 	w := &Worktree{
-		r:  s.Repository,
-		fs: fs,
+		r:          s.Repository,
+		Filesystem: fs,
 	}
 
 	err = w.Checkout(&CheckoutOptions{})
@@ -695,8 +695,8 @@ func (s *WorktreeSuite) TestStatusModified(c *C) {
 func (s *WorktreeSuite) TestStatusIgnored(c *C) {
 	fs := memfs.New()
 	w := &Worktree{
-		r:  s.Repository,
-		fs: fs,
+		r:          s.Repository,
+		Filesystem: fs,
 	}
 
 	w.Checkout(&CheckoutOptions{})
@@ -742,14 +742,14 @@ func (s *WorktreeSuite) TestStatusIgnored(c *C) {
 func (s *WorktreeSuite) TestStatusUntracked(c *C) {
 	fs := memfs.New()
 	w := &Worktree{
-		r:  s.Repository,
-		fs: fs,
+		r:          s.Repository,
+		Filesystem: fs,
 	}
 
 	err := w.Checkout(&CheckoutOptions{Force: true})
 	c.Assert(err, IsNil)
 
-	f, err := w.fs.Create("foo")
+	f, err := w.Filesystem.Create("foo")
 	c.Assert(err, IsNil)
 	c.Assert(f.Close(), IsNil)
 
@@ -765,8 +765,8 @@ func (s *WorktreeSuite) TestStatusDeleted(c *C) {
 
 	fs := osfs.New(filepath.Join(dir, "worktree"))
 	w := &Worktree{
-		r:  s.Repository,
-		fs: fs,
+		r:          s.Repository,
+		Filesystem: fs,
 	}
 
 	err = w.Checkout(&CheckoutOptions{})
@@ -812,8 +812,8 @@ func (s *WorktreeSuite) TestSubmodules(c *C) {
 func (s *WorktreeSuite) TestAddUntracked(c *C) {
 	fs := memfs.New()
 	w := &Worktree{
-		r:  s.Repository,
-		fs: fs,
+		r:          s.Repository,
+		Filesystem: fs,
 	}
 
 	err := w.Checkout(&CheckoutOptions{Force: true})
@@ -823,7 +823,7 @@ func (s *WorktreeSuite) TestAddUntracked(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(idx.Entries, HasLen, 9)
 
-	err = util.WriteFile(w.fs, "foo", []byte("FOO"), 0755)
+	err = util.WriteFile(w.Filesystem, "foo", []byte("FOO"), 0755)
 	c.Assert(err, IsNil)
 
 	hash, err := w.Add("foo")
@@ -856,8 +856,8 @@ func (s *WorktreeSuite) TestAddUntracked(c *C) {
 func (s *WorktreeSuite) TestAddModified(c *C) {
 	fs := memfs.New()
 	w := &Worktree{
-		r:  s.Repository,
-		fs: fs,
+		r:          s.Repository,
+		Filesystem: fs,
 	}
 
 	err := w.Checkout(&CheckoutOptions{Force: true})
@@ -867,7 +867,7 @@ func (s *WorktreeSuite) TestAddModified(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(idx.Entries, HasLen, 9)
 
-	err = util.WriteFile(w.fs, "LICENSE", []byte("FOO"), 0644)
+	err = util.WriteFile(w.Filesystem, "LICENSE", []byte("FOO"), 0644)
 	c.Assert(err, IsNil)
 
 	hash, err := w.Add("LICENSE")
@@ -895,8 +895,8 @@ func (s *WorktreeSuite) TestAddModified(c *C) {
 func (s *WorktreeSuite) TestAddUnmodified(c *C) {
 	fs := memfs.New()
 	w := &Worktree{
-		r:  s.Repository,
-		fs: fs,
+		r:          s.Repository,
+		Filesystem: fs,
 	}
 
 	err := w.Checkout(&CheckoutOptions{Force: true})
@@ -938,8 +938,8 @@ func (s *WorktreeSuite) TestAddSymlink(c *C) {
 func (s *WorktreeSuite) TestRemove(c *C) {
 	fs := memfs.New()
 	w := &Worktree{
-		r:  s.Repository,
-		fs: fs,
+		r:          s.Repository,
+		Filesystem: fs,
 	}
 
 	err := w.Checkout(&CheckoutOptions{Force: true})
@@ -958,8 +958,8 @@ func (s *WorktreeSuite) TestRemove(c *C) {
 func (s *WorktreeSuite) TestRemoveNotExistentEntry(c *C) {
 	fs := memfs.New()
 	w := &Worktree{
-		r:  s.Repository,
-		fs: fs,
+		r:          s.Repository,
+		Filesystem: fs,
 	}
 
 	err := w.Checkout(&CheckoutOptions{Force: true})
@@ -973,8 +973,8 @@ func (s *WorktreeSuite) TestRemoveNotExistentEntry(c *C) {
 func (s *WorktreeSuite) TestRemoveDeletedFromWorktree(c *C) {
 	fs := memfs.New()
 	w := &Worktree{
-		r:  s.Repository,
-		fs: fs,
+		r:          s.Repository,
+		Filesystem: fs,
 	}
 
 	err := w.Checkout(&CheckoutOptions{Force: true})
@@ -996,8 +996,8 @@ func (s *WorktreeSuite) TestRemoveDeletedFromWorktree(c *C) {
 func (s *WorktreeSuite) TestMove(c *C) {
 	fs := memfs.New()
 	w := &Worktree{
-		r:  s.Repository,
-		fs: fs,
+		r:          s.Repository,
+		Filesystem: fs,
 	}
 
 	err := w.Checkout(&CheckoutOptions{Force: true})
@@ -1018,8 +1018,8 @@ func (s *WorktreeSuite) TestMove(c *C) {
 func (s *WorktreeSuite) TestMoveNotExistentEntry(c *C) {
 	fs := memfs.New()
 	w := &Worktree{
-		r:  s.Repository,
-		fs: fs,
+		r:          s.Repository,
+		Filesystem: fs,
 	}
 
 	err := w.Checkout(&CheckoutOptions{Force: true})
@@ -1033,8 +1033,8 @@ func (s *WorktreeSuite) TestMoveNotExistentEntry(c *C) {
 func (s *WorktreeSuite) TestMoveToExistent(c *C) {
 	fs := memfs.New()
 	w := &Worktree{
-		r:  s.Repository,
-		fs: fs,
+		r:          s.Repository,
+		Filesystem: fs,
 	}
 
 	err := w.Checkout(&CheckoutOptions{Force: true})


### PR DESCRIPTION
This PRs exposes the underlying filesystem at `Worktree` in order to be able to manage all the repositories in the same way, without required keep track how a repository was open or cloned. 