### PR TITLE
Normalize filenames before comparing.

### DIFF
--- a/utils/merkletrie/noder/path.go
+++ b/utils/merkletrie/noder/path.go
@@ -3,6 +3,8 @@ package noder
 import (
 	"bytes"
 	"strings"
+
+	"golang.org/x/text/unicode/norm"
 )
 
 // Path values represent a noder and its ancestors.  The root goes first
@@ -78,7 +80,11 @@ func (p Path) Compare(other Path) int {
 		case i == len(p):
 			return -1
 		default:
-			cmp := strings.Compare(p[i].Name(), other[i].Name())
+			form := norm.Form(norm.NFC)
+			this := form.String(p[i].Name())
+			that := form.String(other[i].Name())
+
+			cmp := strings.Compare(this, that)
 			if cmp != 0 {
 				return cmp
 			}

--- a/utils/merkletrie/noder/path_test.go
+++ b/utils/merkletrie/noder/path_test.go
@@ -1,6 +1,9 @@
 package noder
 
-import . "gopkg.in/check.v1"
+import (
+	"golang.org/x/text/unicode/norm"
+	. "gopkg.in/check.v1"
+)
 
 type PathSuite struct{}
 
@@ -148,4 +151,11 @@ func (s *PathSuite) TestCompareMixedDepths(c *C) {
 	})
 	c.Assert(p1.Compare(p2), Equals, 1)
 	c.Assert(p2.Compare(p1), Equals, -1)
+}
+
+func (s *PathSuite) TestCompareNormalization(c *C) {
+	p1 := Path([]Noder{&noderMock{name: norm.Form(norm.NFKC).String("페")}})
+	p2 := Path([]Noder{&noderMock{name: norm.Form(norm.NFKD).String("페")}})
+	c.Assert(p1.Compare(p2), Equals, 0)
+	c.Assert(p2.Compare(p1), Equals, 0)
 }


### PR DESCRIPTION
Some multibyte characters can have multiple representations. Before
comparing strings, we need to normalize them. In this case we're
normalizing to normalized form C, but it shouldn't matter as long as
both strings are normalized to the same form.

Fixes https://github.com/src-d/go-git/issues/495