### PR TITLE
plumbing: moved `Reference.Is*` methods to `ReferenceName.Is*`

### DIFF
--- a/plumbing/reference.go
+++ b/plumbing/reference.go
@@ -55,6 +55,26 @@ func (r ReferenceType) String() string {
 // ReferenceName reference name's
 type ReferenceName string
 
+// IsBranch check if a reference is a branch
+func (r ReferenceName) IsBranch() bool {
+	return strings.HasPrefix(string(r), refHeadPrefix)
+}
+
+// IsNote check if a reference is a note
+func (r ReferenceName) IsNote() bool {
+	return strings.HasPrefix(string(r), refNotePrefix)
+}
+
+// IsRemote check if a reference is a remote
+func (r ReferenceName) IsRemote() bool {
+	return strings.HasPrefix(string(r), refRemotePrefix)
+}
+
+// IsTag check if a reference is a tag
+func (r ReferenceName) IsTag() bool {
+	return strings.HasPrefix(string(r), refTagPrefix)
+}
+
 func (r ReferenceName) String() string {
 	return string(r)
 }
@@ -136,26 +156,6 @@ func (r *Reference) Hash() Hash {
 // Target return the target of a symbolic reference
 func (r *Reference) Target() ReferenceName {
 	return r.target
-}
-
-// IsBranch check if a reference is a branch
-func (r *Reference) IsBranch() bool {
-	return strings.HasPrefix(string(r.n), refHeadPrefix)
-}
-
-// IsNote check if a reference is a note
-func (r *Reference) IsNote() bool {
-	return strings.HasPrefix(string(r.n), refNotePrefix)
-}
-
-// IsRemote check if a reference is a remote
-func (r *Reference) IsRemote() bool {
-	return strings.HasPrefix(string(r.n), refRemotePrefix)
-}
-
-// IsTag check if a reference is a tag
-func (r *Reference) IsTag() bool {
-	return strings.HasPrefix(string(r.n), refTagPrefix)
 }
 
 // Strings dump a reference as a [2]string

--- a/plumbing/reference_test.go
+++ b/plumbing/reference_test.go
@@ -55,21 +55,21 @@ func (s *ReferenceSuite) TestNewHashReference(c *C) {
 }
 
 func (s *ReferenceSuite) TestIsBranch(c *C) {
-	r := NewHashReference(ExampleReferenceName, ZeroHash)
+	r := ExampleReferenceName
 	c.Assert(r.IsBranch(), Equals, true)
 }
 
 func (s *ReferenceSuite) TestIsNote(c *C) {
-	r := NewHashReference(ReferenceName("refs/notes/foo"), ZeroHash)
+	r := ReferenceName("refs/notes/foo")
 	c.Assert(r.IsNote(), Equals, true)
 }
 
 func (s *ReferenceSuite) TestIsRemote(c *C) {
-	r := NewHashReference(ReferenceName("refs/remotes/origin/master"), ZeroHash)
+	r := ReferenceName("refs/remotes/origin/master")
 	c.Assert(r.IsRemote(), Equals, true)
 }
 
 func (s *ReferenceSuite) TestIsTag(c *C) {
-	r := NewHashReference(ReferenceName("refs/tags/v3.1."), ZeroHash)
+	r := ReferenceName("refs/tags/v3.1.")
 	c.Assert(r.IsTag(), Equals, true)
 }

--- a/remote.go
+++ b/remote.go
@@ -464,7 +464,7 @@ func calculateRefs(spec []config.RefSpec,
 	refs := make(memory.ReferenceStorage, 0)
 	return refs, iter.ForEach(func(ref *plumbing.Reference) error {
 		if !config.MatchAny(spec, ref.Name()) {
-			if !ref.IsTag() || tags != AllTags {
+			if !ref.Name().IsTag() || tags != AllTags {
 				return nil
 			}
 		}
@@ -663,7 +663,7 @@ func (r *Remote) updateLocalReferenceStorage(
 
 func (r *Remote) buildFetchedTags(refs memory.ReferenceStorage) (updated bool, err error) {
 	for _, ref := range refs {
-		if !ref.IsTag() {
+		if !ref.Name().IsTag() {
 			continue
 		}
 

--- a/remote_test.go
+++ b/remote_test.go
@@ -345,7 +345,7 @@ func (s *RemoteSuite) TestPushToEmptyRepository(c *C) {
 
 	expected := make(map[string]string)
 	iter.ForEach(func(ref *plumbing.Reference) error {
-		if !ref.IsBranch() {
+		if !ref.Name().IsBranch() {
 			return nil
 		}
 

--- a/repository.go
+++ b/repository.go
@@ -538,7 +538,7 @@ func (r *Repository) fetchAndUpdateReferences(
 func (r *Repository) updateReferences(spec []config.RefSpec,
 	resolvedHead *plumbing.Reference) (updated bool, err error) {
 
-	if !resolvedHead.IsBranch() {
+	if !resolvedHead.Name().IsBranch() {
 		// Detached HEAD mode
 		head := plumbing.NewHashReference(plumbing.HEAD, resolvedHead.Hash())
 		return updateReferenceStorerIfNeeded(r.Storer, head)
@@ -698,7 +698,7 @@ func (r *Repository) Tags() (storer.ReferenceIter, error) {
 
 	return storer.NewReferenceFilteredIter(
 		func(r *plumbing.Reference) bool {
-			return r.IsTag()
+			return r.Name().IsTag()
 		}, refIter), nil
 }
 
@@ -711,7 +711,7 @@ func (r *Repository) Branches() (storer.ReferenceIter, error) {
 
 	return storer.NewReferenceFilteredIter(
 		func(r *plumbing.Reference) bool {
-			return r.IsBranch()
+			return r.Name().IsBranch()
 		}, refIter), nil
 }
 
@@ -724,7 +724,7 @@ func (r *Repository) Notes() (storer.ReferenceIter, error) {
 
 	return storer.NewReferenceFilteredIter(
 		func(r *plumbing.Reference) bool {
-			return r.IsNote()
+			return r.Name().IsNote()
 		}, refIter), nil
 }
 

--- a/repository_test.go
+++ b/repository_test.go
@@ -623,7 +623,6 @@ func (s *RepositorySuite) TestCloneDetachedHEAD(c *C) {
 
 func (s *RepositorySuite) TestPush(c *C) {
 	url := c.MkDir()
-	fmt.Println(url)
 	server, err := PlainInit(url, true)
 	c.Assert(err, IsNil)
 
@@ -651,7 +650,6 @@ func (s *RepositorySuite) TestPush(c *C) {
 
 func (s *RepositorySuite) TestPushContext(c *C) {
 	url := c.MkDir()
-	fmt.Println(url)
 	_, err := PlainInit(url, true)
 	c.Assert(err, IsNil)
 
@@ -923,7 +921,7 @@ func (s *RepositorySuite) TestTags(c *C) {
 	tags.ForEach(func(tag *plumbing.Reference) error {
 		count++
 		c.Assert(tag.Hash().IsZero(), Equals, false)
-		c.Assert(tag.IsTag(), Equals, true)
+		c.Assert(tag.Name().IsTag(), Equals, true)
 		return nil
 	})
 
@@ -944,7 +942,7 @@ func (s *RepositorySuite) TestBranches(c *C) {
 	branches.ForEach(func(branch *plumbing.Reference) error {
 		count++
 		c.Assert(branch.Hash().IsZero(), Equals, false)
-		c.Assert(branch.IsBranch(), Equals, true)
+		c.Assert(branch.Name().IsBranch(), Equals, true)
 		return nil
 	})
 
@@ -968,7 +966,7 @@ func (s *RepositorySuite) TestNotes(c *C) {
 	notes.ForEach(func(note *plumbing.Reference) error {
 		count++
 		c.Assert(note.Hash().IsZero(), Equals, false)
-		c.Assert(note.IsNote(), Equals, true)
+		c.Assert(note.Name().IsNote(), Equals, true)
 		return nil
 	})
 

--- a/worktree.go
+++ b/worktree.go
@@ -209,7 +209,7 @@ func (w *Worktree) getCommitFromCheckoutOptions(opts *CheckoutOptions) (plumbing
 		return plumbing.ZeroHash, err
 	}
 
-	if !b.IsTag() {
+	if !b.Name().IsTag() {
 		return b.Hash(), nil
 	}
 
@@ -244,7 +244,7 @@ func (w *Worktree) setHEADToBranch(branch plumbing.ReferenceName, commit plumbin
 	}
 
 	var head *plumbing.Reference
-	if target.IsBranch() {
+	if target.Name().IsBranch() {
 		head = plumbing.NewSymbolicReference(plumbing.HEAD, target.Name())
 	} else {
 		head = plumbing.NewHashReference(plumbing.HEAD, commit)
@@ -323,7 +323,7 @@ func (w *Worktree) setHEADCommit(commit plumbing.Hash) error {
 		return err
 	}
 
-	if !branch.IsBranch() {
+	if !branch.Name().IsBranch() {
 		return fmt.Errorf("invalid HEAD target should be a branch, found %s", branch.Type())
 	}
 


### PR DESCRIPTION
I just move the `Reference.Is*` methods to `ReferenceName.Is*` since, sometime you need to assert what kind of ref is without having the reference. 