### PR TITLE
*: windows support, some more fixes

### DIFF
--- a/plumbing/transport/file/receive_pack_test.go
+++ b/plumbing/transport/file/receive_pack_test.go
@@ -70,6 +70,6 @@ func (s *ReceivePackSuite) TestNonExistentCommand(c *C) {
 	cmd := "/non-existent-git"
 	client := NewClient(cmd, cmd)
 	session, err := client.NewReceivePackSession(s.Endpoint, s.EmptyAuth)
-	c.Assert(err, ErrorMatches, ".*no such file or directory.*")
+	c.Assert(err, ErrorMatches, ".*(no such file or directory.*|.*file does not exist)*.")
 	c.Assert(session, IsNil)
 }

--- a/plumbing/transport/test/receive_pack.go
+++ b/plumbing/transport/test/receive_pack.go
@@ -61,6 +61,7 @@ func (s *ReceivePackSuite) TestAdvertisedReferencesNotExists(c *C) {
 
 func (s *ReceivePackSuite) TestCallAdvertisedReferenceTwice(c *C) {
 	r, err := s.Client.NewReceivePackSession(s.Endpoint, s.EmptyAuth)
+	defer func() { c.Assert(r.Close(), IsNil) }()
 	c.Assert(err, IsNil)
 	ar1, err := r.AdvertisedReferences()
 	c.Assert(err, IsNil)

--- a/repository.go
+++ b/repository.go
@@ -286,7 +286,7 @@ func dotGitFileToOSFilesystem(path string, fs billy.Filesystem) (billy.Filesyste
 		return nil, fmt.Errorf(".git file has no %s prefix", prefix)
 	}
 
-	gitdir := line[len(prefix):]
+	gitdir := strings.Split(line[len(prefix):], "\n")[0]
 	gitdir = strings.TrimSpace(gitdir)
 	if filepath.IsAbs(gitdir) {
 		return osfs.New(gitdir), nil

--- a/repository_test.go
+++ b/repository_test.go
@@ -348,7 +348,7 @@ func (s *RepositorySuite) TestPlainOpenBareRelativeGitDirFileTrailingGarbage(c *
 
 	altDir, err := ioutil.TempDir("", "plain-open")
 	c.Assert(err, IsNil)
-	err = ioutil.WriteFile(filepath.Join(altDir, ".git"), []byte(fmt.Sprintf("gitdir: %s\nTRAILING", dir)), 0644)
+	err = ioutil.WriteFile(filepath.Join(altDir, ".git"), []byte(fmt.Sprintf("gitdir: %s\nTRAILING", altDir)), 0644)
 	c.Assert(err, IsNil)
 
 	r, err = PlainOpen(altDir)

--- a/worktree_test.go
+++ b/worktree_test.go
@@ -279,6 +279,10 @@ func (s *WorktreeSuite) TestCheckout(c *C) {
 }
 
 func (s *WorktreeSuite) TestCheckoutSymlink(c *C) {
+	if runtime.GOOS == "windows" {
+		c.Skip("git doesn't support symlinks by default in windows")
+	}
+
 	dir, err := ioutil.TempDir("", "checkout")
 	defer os.RemoveAll(dir)
 

--- a/worktree_test.go
+++ b/worktree_test.go
@@ -6,6 +6,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"runtime"
 
 	"golang.org/x/text/unicode/norm"
 
@@ -430,10 +431,12 @@ func (s *WorktreeSuite) TestCheckoutIndexOS(c *C) {
 	c.Assert(idx.Entries[0].Size, Equals, uint32(189))
 
 	c.Assert(idx.Entries[0].CreatedAt.IsZero(), Equals, false)
-	c.Assert(idx.Entries[0].Dev, Not(Equals), uint32(0))
-	c.Assert(idx.Entries[0].Inode, Not(Equals), uint32(0))
-	c.Assert(idx.Entries[0].UID, Not(Equals), uint32(0))
-	c.Assert(idx.Entries[0].GID, Not(Equals), uint32(0))
+	if runtime.GOOS != "windows" {
+		c.Assert(idx.Entries[0].Dev, Not(Equals), uint32(0))
+		c.Assert(idx.Entries[0].Inode, Not(Equals), uint32(0))
+		c.Assert(idx.Entries[0].UID, Not(Equals), uint32(0))
+		c.Assert(idx.Entries[0].GID, Not(Equals), uint32(0))
+	}
 }
 
 func (s *WorktreeSuite) TestCheckoutBranch(c *C) {


### PR DESCRIPTION
The following bugs related to [this log](https://ci.appveyor.com/project/mcarmonaa/go-git/build/50) have been addressed:
* "152 FAIL: worktree_test.go:278: WorktreeSuite.TestCheckoutSymlink"
* "296 FAIL: receive_pack_test.go:36: ReceivePackSuite.TearDownTest"
* "143 FAIL: worktree_test.go:367: WorktreeSuite.TestCheckoutIndexOS"
* "134 FAIL: repository_test.go:340: RepositorySuite.TestPlainOpenBareRelativeGitDirFileTrailingGarbage"