### PR TITLE
plumbing: object, commit.Parent() method

### DIFF
--- a/plumbing/object/commit.go
+++ b/plumbing/object/commit.go
@@ -3,6 +3,7 @@ package object
 import (
 	"bufio"
 	"bytes"
+	"errors"
 	"fmt"
 	"io"
 	"strings"
@@ -89,6 +90,16 @@ func (c *Commit) Parents() CommitIter {
 // NumParents returns the number of parents in a commit.
 func (c *Commit) NumParents() int {
 	return len(c.ParentHashes)
+}
+
+var ErrNoParents = errors.New("commit has no parents")
+
+// FirstParent returns the first parent of c.
+func (c *Commit) FirstParent() (*Commit, error) {
+	if len(c.ParentHashes) == 0 {
+		return nil, ErrNoParents
+	}
+	return GetCommit(c.s, c.ParentHashes[0])
 }
 
 // File returns the file with the specified "path" in the commit and a

--- a/plumbing/object/commit.go
+++ b/plumbing/object/commit.go
@@ -92,14 +92,15 @@ func (c *Commit) NumParents() int {
 	return len(c.ParentHashes)
 }
 
-var ErrNoParents = errors.New("commit has no parents")
+var ErrParentNotFound = errors.New("commit parent not found")
 
-// FirstParent returns the first parent of c.
-func (c *Commit) FirstParent() (*Commit, error) {
-	if len(c.ParentHashes) == 0 {
-		return nil, ErrNoParents
+// Parent returns the ith parent of a commit.
+func (c *Commit) Parent(i int) (*Commit, error) {
+	if len(c.ParentHashes) == 0 || i > len(c.ParentHashes)-1 {
+		return nil, ErrParentNotFound
 	}
-	return GetCommit(c.s, c.ParentHashes[0])
+
+	return GetCommit(c.s, c.ParentHashes[i])
 }
 
 // File returns the file with the specified "path" in the commit and a

--- a/plumbing/object/commit_test.go
+++ b/plumbing/object/commit_test.go
@@ -67,6 +67,18 @@ func (s *SuiteCommit) TestParents(c *C) {
 	i.Close()
 }
 
+func (s *SuiteCommit) TestParent(c *C) {
+	commit, err := s.Commit.Parent(1)
+	c.Assert(err, IsNil)
+	c.Assert(commit.Hash.String(), Equals, "a5b8b09e2f8fcb0bb99d3ccb0958157b40890d69")
+}
+
+func (s *SuiteCommit) TestParentNotFound(c *C) {
+	commit, err := s.Commit.Parent(42)
+	c.Assert(err, Equals, ErrParentNotFound)
+	c.Assert(commit, IsNil)
+}
+
 func (s *SuiteCommit) TestPatch(c *C) {
 	from := s.commit(c, plumbing.NewHash("918c48b83bd081e863dbe1b80f8998f058cd8294"))
 	to := s.commit(c, plumbing.NewHash("6ecf0ef2c2dffb796033e5a02219af86ec6584e5"))


### PR DESCRIPTION
First parents are somewhat special in git.
There's even a --first-parent flag to 'git log'.

Add a helper method to look them up.
This avoids boilerplate and spares the client from
having to arrange for a handle to the Storer,
which is stored in the unexported field Commit.s.