### PR TITLE
prevent PackWriter from using Notify if nothing was written

### DIFF
--- a/storage/filesystem/internal/dotgit/writers.go
+++ b/storage/filesystem/internal/dotgit/writers.go
@@ -92,7 +92,7 @@ func (w *PackWriter) Write(p []byte) (int, error) {
 // was written, the tempfiles are deleted without writing a packfile.
 func (w *PackWriter) Close() error {
 	defer func() {
-		if w.Notify != nil {
+		if w.Notify != nil && w.index != nil && w.index.Size() > 0 {
 			w.Notify(w.checksum, w.index)
 		}
 

--- a/storage/filesystem/internal/dotgit/writers_test.go
+++ b/storage/filesystem/internal/dotgit/writers_test.go
@@ -12,6 +12,7 @@ import (
 
 	. "gopkg.in/check.v1"
 	"gopkg.in/src-d/go-billy.v3/osfs"
+	"gopkg.in/src-d/go-git.v4/plumbing"
 	"gopkg.in/src-d/go-git.v4/plumbing/format/packfile"
 )
 
@@ -131,4 +132,24 @@ func (s *SuiteDotGit) TestSyncedReader(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(n, Equals, 3)
 	c.Assert(string(head), Equals, "280")
+}
+
+func (s *SuiteDotGit) TestPackWriterUnusedNotify(c *C) {
+	dir, err := ioutil.TempDir("", "example")
+	if err != nil {
+		c.Assert(err, IsNil)
+	}
+
+	defer os.RemoveAll(dir)
+
+	fs := osfs.New(dir)
+
+	w, err := newPackWrite(fs)
+	c.Assert(err, IsNil)
+
+	w.Notify = func(h plumbing.Hash, idx *packfile.Index) {
+		c.Fatal("unexpected call to PackWriter.Notify")
+	}
+
+	c.Assert(w.Close(), IsNil)
 }


### PR DESCRIPTION
If PackWriter is not used, `Close` will call `Notify` even if the index is `nil`, which may cause a nil pointer dereference later down the line in the execution in `ObjectStorage` due to the insertion of `nil` indexes on the index.