### PR TITLE
fix race condition on ObjectLRU

### DIFF
--- a/plumbing/cache/object_lru.go
+++ b/plumbing/cache/object_lru.go
@@ -2,6 +2,7 @@ package cache
 
 import (
 	"container/list"
+	"sync"
 
 	"gopkg.in/src-d/go-git.v4/plumbing"
 )
@@ -14,6 +15,7 @@ type ObjectLRU struct {
 	actualSize FileSize
 	ll         *list.List
 	cache      map[interface{}]*list.Element
+	mut        sync.Mutex
 }
 
 // NewObjectLRU creates a new ObjectLRU with the given maximum size. The maximum
@@ -26,6 +28,9 @@ func NewObjectLRU(maxSize FileSize) *ObjectLRU {
 // will be marked as used. Otherwise, it will be inserted. A single object might
 // be evicted to make room for the new object.
 func (c *ObjectLRU) Put(obj plumbing.EncodedObject) {
+	c.mut.Lock()
+	defer c.mut.Unlock()
+
 	if c.cache == nil {
 		c.actualSize = 0
 		c.cache = make(map[interface{}]*list.Element, 1000)
@@ -67,6 +72,9 @@ func (c *ObjectLRU) Put(obj plumbing.EncodedObject) {
 // Get returns an object by its hash. It marks the object as used. If the object
 // is not in the cache, (nil, false) will be returned.
 func (c *ObjectLRU) Get(k plumbing.Hash) (plumbing.EncodedObject, bool) {
+	c.mut.Lock()
+	defer c.mut.Unlock()
+
 	ee, ok := c.cache[k]
 	if !ok {
 		return nil, false
@@ -78,6 +86,9 @@ func (c *ObjectLRU) Get(k plumbing.Hash) (plumbing.EncodedObject, bool) {
 
 // Clear the content of this object cache.
 func (c *ObjectLRU) Clear() {
+	c.mut.Lock()
+	defer c.mut.Unlock()
+
 	c.ll = nil
 	c.cache = nil
 	c.actualSize = 0


### PR DESCRIPTION
With concurrent usage, it could lead to a `concurrent map access` panic on runtime.

Sadly, the test only adds value with `-race` enabled. If you have any idea how to get that panic on the test, it would improve its robustness.