### PR TITLE
examples: add example for pulling changes

### DIFF
--- a/_examples/README.md
+++ b/_examples/README.md
@@ -12,6 +12,7 @@ Here you can find a list of annotated _go-git_ examples:
 - [push](push/main.go) - Push repository to default remote (origin)
 - [checkout](checkout/main.go) - check out a specific commit from a repository
 - [tag](tag/main.go) - list/print repository tags
+- [pull](pull/main.go) - pull changes from a remote repository
 ### Advanced
 - [custom_http](custom_http/main.go) - Replacing the HTTP client using a custom one
 - [storage](storage/README.md) - Implementing a custom storage system

--- a/_examples/common_test.go
+++ b/_examples/common_test.go
@@ -24,6 +24,7 @@ var args = map[string][]string{
 	"push":        []string{setEmptyRemote(cloneRepository(defaultURL, tempFolder()))},
 	"showcase":    []string{defaultURL, tempFolder()},
 	"tag":         []string{cloneRepository(defaultURL, tempFolder())},
+	"pull":        []string{createRepositoryWithRemote(tempFolder(), defaultURL)},
 }
 
 var ignored = map[string]bool{}
@@ -88,11 +89,26 @@ func cloneRepository(url, folder string) string {
 }
 
 func createBareRepository(dir string) string {
-	cmd := exec.Command("git", "init", "--bare", dir)
+	return createRepository(dir, true)
+}
+
+func createRepository(dir string, isBare bool) string {
+	var cmd *exec.Cmd
+	if isBare {
+		cmd = exec.Command("git", "init", "--bare", dir)
+	} else {
+		cmd = exec.Command("git", "init", dir)
+	}
 	err := cmd.Run()
 	CheckIfError(err)
 
 	return dir
+}
+
+func createRepositoryWithRemote(local, remote string) string {
+	createRepository(local, false)
+	addRemote(local, remote)
+	return local
 }
 
 func setEmptyRemote(dir string) string {
@@ -103,6 +119,13 @@ func setEmptyRemote(dir string) string {
 
 func setRemote(local, remote string) {
 	cmd := exec.Command("git", "remote", "set-url", "origin", remote)
+	cmd.Dir = local
+	err := cmd.Run()
+	CheckIfError(err)
+}
+
+func addRemote(local, remote string) {
+	cmd := exec.Command("git", "remote", "add", "origin", remote)
 	cmd.Dir = local
 	err := cmd.Run()
 	CheckIfError(err)

--- a/_examples/pull/main.go
+++ b/_examples/pull/main.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"gopkg.in/src-d/go-git.v4"
+	. "gopkg.in/src-d/go-git.v4/_examples"
+)
+
+// Pull changes from a remote repository
+func main() {
+	CheckArgs("<path>")
+	path := os.Args[1]
+
+	// We instance a new repository targeting the given path (the .git folder)
+	r, err := git.PlainOpen(path)
+	CheckIfError(err)
+
+	// Get the working directory for the repository
+	w, err := r.Worktree()
+	CheckIfError(err)
+
+	// Pull the latest changes from the origin remote and merge into the current branch
+	Info("git pull origin")
+	err = w.Pull(&git.PullOptions{RemoteName: "origin"})
+	CheckIfError(err)
+
+	// Print the latest commit that was just pulled
+	ref, err := r.Head()
+	CheckIfError(err)
+	commit, err := r.CommitObject(ref.Hash())
+	CheckIfError(err)
+
+	fmt.Println(commit)
+}


### PR DESCRIPTION
A question came up in #545 about how to conduct the equivalent of `git pull` with the library. I suspect that the appropriate method was overlooked at first because it is under the Worktree type instead of the Repository type (where the Clone/Fetch/Push methods live).

This PR adds some example code to demonstrate getting the Worktree for a repository and issuing a Pull from the origin remote.