### PR TITLE
plumbing: use LookPath instead of Stat to fix Windows executables

### DIFF
--- a/plumbing/transport/file/client.go
+++ b/plumbing/transport/file/client.go
@@ -66,7 +66,7 @@ func prefixExecPath(cmd string) (string, error) {
 	cmd = filepath.Join(execPath, cmd)
 
 	// Make sure it actually exists.
-	_, err = os.Stat(cmd)
+	_, err = exec.LookPath(cmd)
 	if err != nil {
 		return "", err
 	}

--- a/plumbing/transport/file/client_test.go
+++ b/plumbing/transport/file/client_test.go
@@ -33,7 +33,7 @@ func (s *ClientSuite) TestCommand(c *C) {
 
 	// Make sure we get an error for one that doesn't exist.
 	_, err = runner.Command("git-fake-command", ep, emptyAuth)
-	c.Assert(os.IsNotExist(err), Equals, true)
+	c.Assert(err, NotNil)
 }
 
 const bareConfig = `[core]


### PR DESCRIPTION
When git-core isn't in the user's PATH, we need to use `LookPath` to
verify the existence of the executable, rather than `os.Stat`, so that
on Windows it will search for files with executable suffixes.