### PR TITLE
_examples: context

### DIFF
--- a/_examples/README.md
+++ b/_examples/README.md
@@ -6,6 +6,7 @@ Here you can find a list of annotated _go-git_ examples:
 - [showcase](showcase/main.go) - A small showcase of the capabilities of _go-git_
 - [open](open/main.go) - Opening a existing repository cloned by _git_
 - [clone](clone/main.go) - Cloning a repository
+- [clone with context](context/main.go) - Cloning a repository with graceful cancellation.
 - [log](log/main.go) - Emulate `git log` command output iterating all the commit history from HEAD reference
 - [remotes](remotes/main.go) - Working with remotes: adding, removing, etc
 - [progress](progress/main.go) - Printing the progress information from the sideband

--- a/_examples/common_test.go
+++ b/_examples/common_test.go
@@ -17,6 +17,7 @@ var defaultURL = "https://github.com/git-fixtures/basic.git"
 var args = map[string][]string{
 	"checkout":    []string{defaultURL, tempFolder(), "35e85108805c84807bc66a02d91535e1e24b38b9"},
 	"clone":       []string{defaultURL, tempFolder()},
+	"context":     []string{defaultURL, tempFolder()},
 	"commit":      []string{cloneRepository(defaultURL, tempFolder())},
 	"custom_http": []string{defaultURL},
 	"open":        []string{cloneRepository(defaultURL, tempFolder())},

--- a/_examples/context/main.go
+++ b/_examples/context/main.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"context"
+	"os"
+	"os/signal"
+
+	"gopkg.in/src-d/go-git.v4"
+	. "gopkg.in/src-d/go-git.v4/_examples"
+)
+
+// Gracefull cancellation example of a basic git operation such as Clone.
+func main() {
+	CheckArgs("<url>", "<directory>")
+	url := os.Args[1]
+	directory := os.Args[2]
+
+	// Clone the given repository to the given directory
+	Info("git clone %s %s", url, directory)
+
+	stop := make(chan os.Signal, 1)
+	signal.Notify(stop, os.Interrupt)
+
+	// The context is the mechanism used by go-git, to support deadlines and
+	// cancellation signals.
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel() // cancel when we are finished consuming integers
+
+	go func() {
+		<-stop
+		Warning("\nSignal detected, canceling operation...")
+		cancel()
+	}()
+
+	Warning("To gracefully stop the clone operation, push Crtl-C.")
+
+	// Using PlainCloneContext we can provide to a context, if the context
+	// is cancelled, the clone operation stops gracefully.
+	_, err := git.PlainCloneContext(ctx, directory, false, &git.CloneOptions{
+		URL:      url,
+		Progress: os.Stdout,
+	})
+
+	// If the context was cancelled, an error is returned.
+	CheckIfError(err)
+}


### PR DESCRIPTION
This is an example that illustrates how to do a graceful shutdown of a clone operation.