### PR TITLE
dotgit: cache already visited references for future visits

### DIFF
--- a/storage/filesystem/internal/dotgit/dotgit_test.go
+++ b/storage/filesystem/internal/dotgit/dotgit_test.go
@@ -134,6 +134,24 @@ func (s *SuiteDotGit) TestRefsFromReferenceFile(c *C) {
 
 }
 
+func BenchmarkRefMultipleTimes(b *testing.B) {
+	fs := fixtures.Basic().ByTag(".git").One().DotGit()
+	refname := plumbing.ReferenceName("refs/remotes/origin/branch")
+
+	dir := New(fs)
+	_, err := dir.Ref(refname)
+	if err != nil {
+		b.Fatalf("unexpected error: %s", err)
+	}
+
+	for i := 0; i < b.N; i++ {
+		_, err := dir.Ref(refname)
+		if err != nil {
+			b.Fatalf("unexpected error: %s", err)
+		}
+	}
+}
+
 func (s *SuiteDotGit) TestRemoveRefFromReferenceFile(c *C) {
 	fs := fixtures.Basic().ByTag(".git").One().DotGit()
 	dir := New(fs)


### PR DESCRIPTION
This change introduces a cache of already visited references for future visits.
Right now, using `Ref` method of DotGit fetches all the references and then
returns the correct one, this is a very expensive operation if executed a lot
of times. Adding the cache, makes this orders of mangnitude faster on successive
calls at the expense of a little bit more of memory consumption.

Results of the added benchmark before:

```
➜ go test ./storage/filesystem/internal/dotgit/... -bench=.
OK: 30 passed
BenchmarkRefMultipleTimes-4   	    5000	    264626 ns/op
PASS
ok  	gopkg.in/src-d/go-git.v4/storage/filesystem/internal/dotgit	3.418s
```

Results of the benchmark now:

```
➜ go test ./storage/filesystem/internal/dotgit/... -bench=.
OK: 30 passed
BenchmarkRefMultipleTimes-4   	30000000	        38.5 ns/op
PASS
ok  	gopkg.in/src-d/go-git.v4/storage/filesystem/internal/dotgit	2.342s
```