### PR TITLE
dotgit: rewrite the way references are looked up

### DIFF
--- a/storage/filesystem/internal/dotgit/dotgit_test.go
+++ b/storage/filesystem/internal/dotgit/dotgit_test.go
@@ -134,6 +134,24 @@ func (s *SuiteDotGit) TestRefsFromReferenceFile(c *C) {
 
 }
 
+func BenchmarkRefMultipleTimes(b *testing.B) {
+	fs := fixtures.Basic().ByTag(".git").One().DotGit()
+	refname := plumbing.ReferenceName("refs/remotes/origin/branch")
+
+	dir := New(fs)
+	_, err := dir.Ref(refname)
+	if err != nil {
+		b.Fatalf("unexpected error: %s", err)
+	}
+
+	for i := 0; i < b.N; i++ {
+		_, err := dir.Ref(refname)
+		if err != nil {
+			b.Fatalf("unexpected error: %s", err)
+		}
+	}
+}
+
 func (s *SuiteDotGit) TestRemoveRefFromReferenceFile(c *C) {
 	fs := fixtures.Basic().ByTag(".git").One().DotGit()
 	dir := New(fs)


### PR DESCRIPTION
This change introduces a cache of already visited references for future visits.
Right now, using `Ref` method of DotGit fetches all the references and then
returns the correct one, this is a very expensive operation if executed a lot
of times. Adding the cache, makes this orders of mangnitude faster on successive
calls at the expense of a little bit more of memory consumption.

Results of the added benchmark before:

```
➜ go test ./storage/filesystem/internal/dotgit/... -bench=.
OK: 30 passed
BenchmarkRefMultipleTimes-4   	    5000	    264626 ns/op
PASS
ok  	gopkg.in/src-d/go-git.v4/storage/filesystem/internal/dotgit	3.418s
```

Results of the benchmark now:

```
➜ go test ./storage/filesystem/internal/dotgit/... -bench=.
OK: 30 passed
BenchmarkRefMultipleTimes-4   	  200000	      7264 ns/op
PASS
ok  	gopkg.in/src-d/go-git.v4/storage/filesystem/internal/dotgit	2.520s
```

Caveats:

* `Refs` is not cached. Can't make it pass `RemoteSuite.TestPushNewReference` and `RemoteSuite.TestPushRejectNonFastForward` even checking the modification time of `.git`. The cached results are not the same as the ones obtained with the usual process, even if the modtime of the .git is the same as it was.
* In `Ref` the first step is try to look directly for the file named after the ref. Same reason as above, only for other tests.

I've been trying another few implementations of this to try to make it work with `References` and not require that I/O operation at the beginning of `Ref`, but it's been proving really hard to cache at this level if we cannot rely on the `ModTime`.

This change makes a push that took ~30 mins with 0 changes take just a few seconds.