### PR TITLE
[wip] packfile: pass buffered reader to the zlib reader

### DIFF
--- a/plumbing/format/packfile/scanner.go
+++ b/plumbing/format/packfile/scanner.go
@@ -278,7 +278,7 @@ func (s *Scanner) NextObject(w io.Writer) (written int64, crc32 uint32, err erro
 // from it zlib stream in an object entry in the packfile.
 func (s *Scanner) copyObject(w io.Writer) (n int64, err error) {
 	if s.zr == nil {
-		zr, err := zlib.NewReader(s.r)
+		zr, err := zlib.NewReader(bufio.NewReader(s.r))
 		if err != nil {
 			return 0, fmt.Errorf("zlib initialization error: %s", err)
 		}


### PR DESCRIPTION
This speeds up the clone (and fetch) process a lot.

Some numbers:

Cloning git/git
- Before: 12m7.438061135s
- Now: 16.003801865s

Cloning git/git with all its refs:
- Before: 20m57.435068468s
- Now: 35.670778443s

Cloning rails/rails
- Before: 7m45.746104024s
- Now: 21.337505646s

Cloning go-git:
- Before: 4.978849309s
- Now: 1.352265308s

Cloning angular/angular:
- Before: 1m54.073271178s
- Now: 17.069522722s

Cloning with all refs torvalds/linux:
- Before: never got to clone it because it was super slow
- Now: 4m43.153874874s

Gonna investigate why tests are failing