### PR TITLE
Repository.Clone added Tags option, and set by default AllTags 

### DIFF
--- a/options.go
+++ b/options.go
@@ -50,6 +50,9 @@ type CloneOptions struct {
 	// stored, if nil nothing is stored and the capability (if supported)
 	// no-progress, is sent to the server to avoid send this information.
 	Progress sideband.Progress
+	// Tags describe how the tags will be fetched from the remote repository,
+	// by default is AllTags.
+	Tags TagMode
 }
 
 // Validate validates the fields and sets the default values.
@@ -64,6 +67,10 @@ func (o *CloneOptions) Validate() error {
 
 	if o.ReferenceName == "" {
 		o.ReferenceName = plumbing.HEAD
+	}
+
+	if o.Tags == InvalidTagMode {
+		o.Tags = AllTags
 	}
 
 	return nil
@@ -103,18 +110,19 @@ func (o *PullOptions) Validate() error {
 	return nil
 }
 
-type TagFetchMode int
+type TagMode int
 
-var (
+const (
+	InvalidTagMode TagMode = iota
 	// TagFollowing any tag that points into the histories being fetched is also
 	// fetched. TagFollowing requires a server with `include-tag` capability
 	// in order to fetch the annotated tags objects.
-	TagFollowing TagFetchMode = 0
+	TagFollowing
 	// AllTags fetch all tags from the remote (i.e., fetch remote tags
 	// refs/tags/* into local tags with the same name)
-	AllTags TagFetchMode = 1
+	AllTags
 	//NoTags fetch no tags from the remote at all
-	NoTags TagFetchMode = 2
+	NoTags
 )
 
 // FetchOptions describes how a fetch should be performed
@@ -133,13 +141,17 @@ type FetchOptions struct {
 	Progress sideband.Progress
 	// Tags describe how the tags will be fetched from the remote repository,
 	// by default is TagFollowing.
-	Tags TagFetchMode
+	Tags TagMode
 }
 
 // Validate validates the fields and sets the default values.
 func (o *FetchOptions) Validate() error {
 	if o.RemoteName == "" {
 		o.RemoteName = DefaultRemoteName
+	}
+
+	if o.Tags == InvalidTagMode {
+		o.Tags = TagFollowing
 	}
 
 	for _, r := range o.RefSpecs {

--- a/remote_test.go
+++ b/remote_test.go
@@ -143,7 +143,7 @@ func (s *RemoteSuite) TestFetchWithNoTags(c *C) {
 	s.testFetch(c, r, &FetchOptions{
 		Tags: NoTags,
 		RefSpecs: []config.RefSpec{
-			config.RefSpec("+refs/heads/master:refs/remotes/origin/master"),
+			config.RefSpec("+refs/heads/*:refs/remotes/origin/*"),
 		},
 	}, []*plumbing.Reference{
 		plumbing.NewReferenceFromStrings("refs/remotes/origin/master", "f7b877701fbf855b44c0a9e86f3fdce2c298b07f"),

--- a/repository.go
+++ b/repository.go
@@ -440,6 +440,7 @@ func (r *Repository) clone(ctx context.Context, o *CloneOptions) error {
 		Depth:    o.Depth,
 		Auth:     o.Auth,
 		Progress: o.Progress,
+		Tags:     o.Tags,
 	}, o.ReferenceName)
 	if err != nil {
 		return err

--- a/repository_test.go
+++ b/repository_test.go
@@ -177,6 +177,27 @@ func (s *RepositorySuite) TestCloneContext(c *C) {
 	c.Assert(err, NotNil)
 }
 
+func (s *RepositorySuite) TestCloneWithTags(c *C) {
+	url := s.GetLocalRepositoryURL(
+		fixtures.ByURL("https://github.com/git-fixtures/tags.git").One(),
+	)
+
+	r, err := Clone(memory.NewStorage(), nil, &CloneOptions{URL: url, Tags: NoTags})
+	c.Assert(err, IsNil)
+
+	remotes, err := r.Remotes()
+	c.Assert(err, IsNil)
+	c.Assert(remotes, HasLen, 1)
+
+	i, err := r.References()
+	c.Assert(err, IsNil)
+
+	var count int
+	i.ForEach(func(r *plumbing.Reference) error { count++; return nil })
+
+	c.Assert(count, Equals, 3)
+}
+
 func (s *RepositorySuite) TestCreateRemoteAndRemote(c *C) {
 	r, _ := Init(memory.NewStorage(), nil)
 	remote, err := r.CreateRemote(&config.RemoteConfig{


### PR DESCRIPTION
This PR fixes #574 and implements the [`--no-tags`](https://github.com/git/git/commit/0dab2468ee5bbfaa854a22eb17c70647fc8b6b83) option at clone