### PR TITLE
Worktree.Add: Support Add deleted files, fixes #571

### DIFF
--- a/worktree_commit_test.go
+++ b/worktree_commit_test.go
@@ -9,9 +9,9 @@ import (
 	"gopkg.in/src-d/go-git.v4/storage/memory"
 
 	. "gopkg.in/check.v1"
-	"gopkg.in/src-d/go-billy.v3"
 	"gopkg.in/src-d/go-billy.v3/memfs"
 	"gopkg.in/src-d/go-billy.v3/util"
+	"gopkg.in/src-d/go-billy.v3"
 )
 
 func (s *WorktreeSuite) TestCommitInvalidOptions(c *C) {
@@ -134,14 +134,6 @@ func (s *WorktreeSuite) TestRemoveAndCommitAll(c *C) {
 	c.Assert(err, IsNil)
 
 	assertStorageStatus(c, s.Repository, 13, 11, 11, expected)
-}
-
-func emulateExternalRemoval(c *C, fs billy.Basic, w *Worktree, path string) {
-
-	s, errStatus := w.Status()
-	c.Assert(errStatus, IsNil)
-	s[path].Worktree = Unmodified
-	s[path].Staging = Unmodified
 }
 
 func assertStorageStatus(

--- a/worktree_commit_test.go
+++ b/worktree_commit_test.go
@@ -11,7 +11,6 @@ import (
 	. "gopkg.in/check.v1"
 	"gopkg.in/src-d/go-billy.v3/memfs"
 	"gopkg.in/src-d/go-billy.v3/util"
-	"gopkg.in/src-d/go-billy.v3"
 )
 
 func (s *WorktreeSuite) TestCommitInvalidOptions(c *C) {

--- a/worktree_commit_test.go
+++ b/worktree_commit_test.go
@@ -9,6 +9,7 @@ import (
 	"gopkg.in/src-d/go-git.v4/storage/memory"
 
 	. "gopkg.in/check.v1"
+	"gopkg.in/src-d/go-billy.v3"
 	"gopkg.in/src-d/go-billy.v3/memfs"
 	"gopkg.in/src-d/go-billy.v3/util"
 )
@@ -97,6 +98,50 @@ func (s *WorktreeSuite) TestCommitAll(c *C) {
 	c.Assert(err, IsNil)
 
 	assertStorageStatus(c, s.Repository, 13, 11, 10, expected)
+}
+
+func (s *WorktreeSuite) TestRemoveAndCommitAll(c *C) {
+	expected := plumbing.NewHash("907cd576c6ced2ecd3dab34a72bf9cf65944b9a9")
+
+	fs := memfs.New()
+	w := &Worktree{
+		r:          s.Repository,
+		Filesystem: fs,
+	}
+
+	err := w.Checkout(&CheckoutOptions{})
+	c.Assert(err, IsNil)
+
+	util.WriteFile(fs, "foo", []byte("foo"), 0644)
+	_, err = w.Add("foo")
+	c.Assert(err, IsNil)
+
+	_, errFirst := w.Commit("Add in Repo\n", &CommitOptions{
+		Author: defaultSignature(),
+	})
+	c.Assert(errFirst, IsNil)
+
+	errRemove := fs.Remove("foo")
+	c.Assert(errRemove, IsNil)
+
+	hash, errSecond := w.Commit("Remove foo\n", &CommitOptions{
+		All:    true,
+		Author: defaultSignature(),
+	})
+	c.Assert(errSecond, IsNil)
+
+	c.Assert(hash, Equals, expected)
+	c.Assert(err, IsNil)
+
+	assertStorageStatus(c, s.Repository, 13, 11, 11, expected)
+}
+
+func emulateExternalRemoval(c *C, fs billy.Basic, w *Worktree, path string) {
+
+	s, errStatus := w.Status()
+	c.Assert(errStatus, IsNil)
+	s[path].Worktree = Unmodified
+	s[path].Staging = Unmodified
 }
 
 func assertStorageStatus(

--- a/worktree_status.go
+++ b/worktree_status.go
@@ -267,8 +267,7 @@ func (w *Worktree) Add(path string) (plumbing.Hash, error) {
 }
 
 func (w *Worktree) removeIfDeleted(path string, hash plumbing.Hash, err error) (plumbing.Hash, error) {
-	pathError, ok := err.(*os.PathError)
-	if ok && pathError.Op == "lstat" || os.IsNotExist(err) {
+	if os.IsNotExist(err) {
 		h, errDelete := w.deleteFromIndex(path)
 		if errDelete != nil {
 			return h, errDelete

--- a/worktree_status.go
+++ b/worktree_status.go
@@ -268,7 +268,7 @@ func (w *Worktree) Add(path string) (plumbing.Hash, error) {
 
 func (w *Worktree) removeIfDeleted(path string, hash plumbing.Hash, err error) (plumbing.Hash, error) {
 	pathError, ok := err.(*os.PathError)
-	if ok && pathError.Op == "lstat" || w.isErrNotExist(err) {
+	if ok && pathError.Op == "lstat" || os.IsNotExist(err) {
 		h, errDelete := w.deleteFromIndex(path)
 		if errDelete != nil {
 			return h, errDelete
@@ -277,10 +277,6 @@ func (w *Worktree) removeIfDeleted(path string, hash plumbing.Hash, err error) (
 	}
 
 	return hash, err
-}
-
-func (w *Worktree) isErrNotExist(err error) bool {
-	return err.Error() == os.ErrNotExist.Error()
 }
 
 func (w *Worktree) copyFileToStorage(path string) (hash plumbing.Hash, err error) {

--- a/worktree_test.go
+++ b/worktree_test.go
@@ -349,7 +349,11 @@ func (s *WorktreeSuite) TestFilenameNormalization(c *C) {
 
 	modFilename := norm.Form(norm.NFKD).String(filename)
 	util.WriteFile(w.Filesystem, modFilename, []byte("foo"), 0755)
+
 	_, err = w.Add(filename)
+	c.Assert(err, IsNil)
+	_, err = w.Add(modFilename)
+	c.Assert(err, IsNil)
 
 	status, err = w.Status()
 	c.Assert(err, IsNil)


### PR DESCRIPTION
In order to fix the bug mentioned in the issue, I modified the Add method of Worktree to handle the case where a file is removed but is still in the repository.

My fix just ensure that the repo and the filesystem are always in sync.

I also found what I think to be a false positive in the TestFilenameNormalization test. 
The wrong file were added.