### PR TITLE
Add port to SCP Endpoints

### DIFF
--- a/plumbing/transport/common.go
+++ b/plumbing/transport/common.go
@@ -187,6 +187,7 @@ func (e urlEndpoint) Path() string {
 type scpEndpoint struct {
 	user string
 	host string
+	port string
 	path string
 }
 
@@ -194,8 +195,14 @@ func (e *scpEndpoint) Protocol() string { return "ssh" }
 func (e *scpEndpoint) User() string     { return e.user }
 func (e *scpEndpoint) Password() string { return "" }
 func (e *scpEndpoint) Host() string     { return e.host }
-func (e *scpEndpoint) Port() int        { return 22 }
 func (e *scpEndpoint) Path() string     { return e.path }
+func (e *scpEndpoint) Port() int {
+	i, err := strconv.Atoi(e.port)
+	if err != nil {
+		return 22
+	}
+	return i
+}
 
 func (e *scpEndpoint) String() string {
 	var user string
@@ -220,7 +227,7 @@ func (e *fileEndpoint) String() string   { return e.path }
 
 var (
 	isSchemeRegExp   = regexp.MustCompile(`^[^:]+://`)
-	scpLikeUrlRegExp = regexp.MustCompile(`^(?:(?P<user>[^@]+)@)?(?P<host>[^:\s]+):(?P<path>[^\\].*)$`)
+	scpLikeUrlRegExp = regexp.MustCompile(`^(?:(?P<user>[^@]+)@)?(?P<host>[^:\s]+):(?:(?P<port>[0-9]+):)?(?P<path>[^\\].*)$`)
 )
 
 func parseSCPLike(endpoint string) (Endpoint, bool) {
@@ -232,7 +239,8 @@ func parseSCPLike(endpoint string) (Endpoint, bool) {
 	return &scpEndpoint{
 		user: m[1],
 		host: m[2],
-		path: m[3],
+		port: m[3],
+		path: m[4],
 	}, true
 }
 

--- a/plumbing/transport/common.go
+++ b/plumbing/transport/common.go
@@ -227,7 +227,7 @@ func (e *fileEndpoint) String() string   { return e.path }
 
 var (
 	isSchemeRegExp   = regexp.MustCompile(`^[^:]+://`)
-	scpLikeUrlRegExp = regexp.MustCompile(`^(?:(?P<user>[^@]+)@)?(?P<host>[^:\s]+):(?:(?P<port>[0-9]+):)?(?P<path>[^\\].*)$`)
+	scpLikeUrlRegExp = regexp.MustCompile(`^(?:(?P<user>[^@]+)@)?(?P<host>[^:\s]+):(?:(?P<port>[0-9]{1,5})/)?(?P<path>[^\\].*)$`)
 )
 
 func parseSCPLike(endpoint string) (Endpoint, bool) {

--- a/plumbing/transport/common_test.go
+++ b/plumbing/transport/common_test.go
@@ -75,7 +75,7 @@ func (s *SuiteCommon) TestNewEndpointSCPLike(c *C) {
 }
 
 func (s *SuiteCommon) TestNewEndpointSCPLikeWithPort(c *C) {
-	e, err := NewEndpoint("git@github.com:9999:user/repository.git")
+	e, err := NewEndpoint("git@github.com:9999/user/repository.git")
 	c.Assert(err, IsNil)
 	c.Assert(e.Protocol(), Equals, "ssh")
 	c.Assert(e.User(), Equals, "git")

--- a/plumbing/transport/common_test.go
+++ b/plumbing/transport/common_test.go
@@ -74,6 +74,18 @@ func (s *SuiteCommon) TestNewEndpointSCPLike(c *C) {
 	c.Assert(e.String(), Equals, "git@github.com:user/repository.git")
 }
 
+func (s *SuiteCommon) TestNewEndpointSCPLikeWithPort(c *C) {
+	e, err := NewEndpoint("git@github.com:9999:user/repository.git")
+	c.Assert(err, IsNil)
+	c.Assert(e.Protocol(), Equals, "ssh")
+	c.Assert(e.User(), Equals, "git")
+	c.Assert(e.Password(), Equals, "")
+	c.Assert(e.Host(), Equals, "github.com")
+	c.Assert(e.Port(), Equals, 9999)
+	c.Assert(e.Path(), Equals, "user/repository.git")
+	c.Assert(e.String(), Equals, "git@github.com:user/repository.git")
+}
+
 func (s *SuiteCommon) TestNewEndpointFileAbs(c *C) {
 	e, err := NewEndpoint("/foo.git")
 	c.Assert(err, IsNil)


### PR DESCRIPTION
The port for SCP-like URLs was hardcoded to 22.
This commit modifies the regex to find a port (optional), and adds a new test case that covers this scenario.

All tests pass, and I've tried cloning a repo with a custom port through the command line example and it works.

Some notes:

* 22 is kept as the default port. The ssh transport also has a default port  defined . It may be best to use 0 and let the ssh transport handle it.
* I use `strconv.Atoi` in the getter method to mimic the behavior of the other types. It might be more efficient to just parse it once after the regex.
