### PR TITLE
remote: add support for ls-remote

### DIFF
--- a/options.go
+++ b/options.go
@@ -348,3 +348,9 @@ func (o *CommitOptions) Validate(r *Repository) error {
 
 	return nil
 }
+
+// ListOptions describes how a remote list should be performed.
+type ListOptions struct {
+	// Auth credentials, if required, to use with the remote repository.
+	Auth transport.AuthMethod
+}

--- a/remote.go
+++ b/remote.go
@@ -728,6 +728,39 @@ func (r *Remote) buildFetchedTags(refs memory.ReferenceStorage) (updated bool, e
 	return
 }
 
+// LSRemote performs ls-remote on the remote.
+func (r *Remote) LSRemote(auth transport.AuthMethod) ([]*plumbing.Reference, error) {
+	s, err := newUploadPackSession(r.c.URLs[0], auth)
+	if err != nil {
+		return nil, err
+	}
+
+	defer ioutil.CheckClose(s, &err)
+
+	ar, err := s.AdvertisedReferences()
+	if err != nil {
+		return nil, err
+	}
+
+	allRefs, err := ar.AllReferences()
+	if err != nil {
+		return nil, err
+	}
+
+	refs, err := allRefs.IterReferences()
+	if err != nil {
+		return nil, err
+	}
+
+	var resultRefs []*plumbing.Reference
+	refs.ForEach(func(ref *plumbing.Reference) error {
+		resultRefs = append(resultRefs, ref)
+		return nil
+	})
+
+	return resultRefs, nil
+}
+
 func objectsToPush(commands []*packp.Command) ([]plumbing.Hash, error) {
 	var objects []plumbing.Hash
 	for _, cmd := range commands {

--- a/remote.go
+++ b/remote.go
@@ -728,9 +728,9 @@ func (r *Remote) buildFetchedTags(refs memory.ReferenceStorage) (updated bool, e
 	return
 }
 
-// LSRemote performs ls-remote on the remote.
-func (r *Remote) LSRemote(auth transport.AuthMethod) ([]*plumbing.Reference, error) {
-	s, err := newUploadPackSession(r.c.URLs[0], auth)
+// List the references on the remote repository.
+func (r *Remote) List(o *ListOptions) ([]*plumbing.Reference, error) {
+	s, err := newUploadPackSession(r.c.URLs[0], o.Auth)
 	if err != nil {
 		return nil, err
 	}

--- a/remote_test.go
+++ b/remote_test.go
@@ -11,7 +11,6 @@ import (
 	"gopkg.in/src-d/go-git.v4/config"
 	"gopkg.in/src-d/go-git.v4/plumbing"
 	"gopkg.in/src-d/go-git.v4/plumbing/storer"
-	"gopkg.in/src-d/go-git.v4/plumbing/transport"
 	"gopkg.in/src-d/go-git.v4/storage"
 	"gopkg.in/src-d/go-git.v4/storage/filesystem"
 	"gopkg.in/src-d/go-git.v4/storage/memory"
@@ -644,7 +643,7 @@ func (s *RemoteSuite) TestGetHaves(c *C) {
 	c.Assert(l, HasLen, 2)
 }
 
-func (s *RemoteSuite) TestLSRemote(c *C) {
+func (s *RemoteSuite) TestList(c *C) {
 	url := c.MkDir()
 	server, err := PlainInit(url, true)
 	c.Assert(err, IsNil)
@@ -664,9 +663,8 @@ func (s *RemoteSuite) TestLSRemote(c *C) {
 	})
 	c.Assert(err, IsNil)
 
-	// Perform ls-remote.
-	var authMethod transport.AuthMethod
-	refs, err := remote.LSRemote(authMethod)
+	listOptions := ListOptions{}
+	refs, err := remote.List(&listOptions)
 	c.Assert(err, IsNil)
 
 	// Create a map of remote name and their hash.


### PR DESCRIPTION
Adds support for ls-remote in `Remote`.

Found this in [#601-comment](https://github.com/src-d/go-git/issues/601#issuecomment-330873442), so maybe fixes #601 .

Need some guidance in the test with relevant existing examples. Not sure if this test is enough.