### PR TITLE
Fix spelling Unstagged -> Unstaged

### DIFF
--- a/worktree.go
+++ b/worktree.go
@@ -25,7 +25,7 @@ import (
 var (
 	ErrWorktreeNotClean  = errors.New("worktree is not clean")
 	ErrSubmoduleNotFound = errors.New("submodule not found")
-	ErrUnstaggedChanges  = errors.New("worktree contains unstagged changes")
+	ErrUnstagedChanges   = errors.New("worktree contains unstaged changes")
 )
 
 // Worktree represents a git worktree.
@@ -152,7 +152,7 @@ func (w *Worktree) Checkout(opts *CheckoutOptions) error {
 		}
 
 		if unstaged {
-			return ErrUnstaggedChanges
+			return ErrUnstagedChanges
 		}
 	}
 
@@ -269,7 +269,7 @@ func (w *Worktree) Reset(opts *ResetOptions) error {
 		}
 
 		if unstaged {
-			return ErrUnstaggedChanges
+			return ErrUnstagedChanges
 		}
 	}
 

--- a/worktree_test.go
+++ b/worktree_test.go
@@ -813,7 +813,7 @@ func (s *WorktreeSuite) TestResetMerge(c *C) {
 	c.Assert(err, IsNil)
 
 	err = w.Reset(&ResetOptions{Mode: MergeReset, Commit: commitB})
-	c.Assert(err, Equals, ErrUnstaggedChanges)
+	c.Assert(err, Equals, ErrUnstagedChanges)
 
 	branch, err = w.r.Reference(plumbing.Master, false)
 	c.Assert(err, IsNil)


### PR DESCRIPTION
This pull request fixes a spelling error.

The error is in the name of an exported variable and should therefore be considered backwards incompatible.