### PR TITLE
Add support for signed commits

### DIFF
--- a/plumbing/object/commit.go
+++ b/plumbing/object/commit.go
@@ -12,6 +12,11 @@ import (
 	"gopkg.in/src-d/go-git.v4/utils/ioutil"
 )
 
+const (
+	beginpgp string = "-----BEGIN PGP SIGNATURE-----"
+	endpgp   string = "-----END PGP SIGNATURE-----"
+)
+
 // Hash represents the hash of an object
 type Hash plumbing.Hash
 
@@ -28,6 +33,8 @@ type Commit struct {
 	// Committer is the one performing the commit, might be different from
 	// Author.
 	Committer Signature
+	// GPGSignature is the GPG signature of the commit.
+	GPGSignature string
 	// Message is the commit message, contains arbitrary text.
 	Message string
 	// TreeHash is the hash of the root tree of the commit.
@@ -145,10 +152,31 @@ func (c *Commit) Decode(o plumbing.EncodedObject) (err error) {
 	r := bufio.NewReader(reader)
 
 	var message bool
+	var gpgsig bool
 	for {
 		line, err := r.ReadBytes('\n')
 		if err != nil && err != io.EOF {
 			return err
+		}
+
+		if gpgsig {
+			// Check if it's the end of a PGP signature.
+			if bytes.Contains(line, []byte(endpgp)) {
+				c.GPGSignature += string(endpgp) + "\n"
+				gpgsig = false
+			} else {
+				// Trim the left padding.
+				line = bytes.TrimLeft(line, " ")
+				c.GPGSignature += string(line)
+			}
+			continue
+		}
+
+		// Check if it's the beginning of a PGP signature.
+		if bytes.Contains(line, []byte(beginpgp)) {
+			c.GPGSignature += string(beginpgp) + "\n"
+			gpgsig = true
+			continue
 		}
 
 		if !message {
@@ -213,6 +241,21 @@ func (b *Commit) Encode(o plumbing.EncodedObject) error {
 
 	if err = b.Committer.Encode(w); err != nil {
 		return err
+	}
+
+	if b.GPGSignature != "" {
+		if _, err = fmt.Fprint(w, "gpgsig"); err != nil {
+			return err
+		}
+
+		// Split all the signature lines and write with a left padding and
+		// newline at the end.
+		lines := strings.Split(b.GPGSignature, "\n")
+		for _, line := range lines {
+			if _, err = fmt.Fprintf(w, " %s\n", line); err != nil {
+				return err
+			}
+		}
 	}
 
 	if _, err = fmt.Fprintf(w, "\n\n%s", b.Message); err != nil {

--- a/plumbing/object/commit_test.go
+++ b/plumbing/object/commit_test.go
@@ -233,12 +233,12 @@ func (s *SuiteCommit) TestLongCommitMessageSerialization(c *C) {
 	c.Assert(decoded.Message, Equals, longMessage)
 }
 
-func (s *SuiteCommit) TestGPGSignatureSerialization(c *C) {
+func (s *SuiteCommit) TestPGPSignatureSerialization(c *C) {
 	encoded := &plumbing.MemoryObject{}
 	decoded := &Commit{}
 	commit := *s.Commit
 
-	gpgsignature := `-----BEGIN PGP SIGNATURE-----
+	pgpsignature := `-----BEGIN PGP SIGNATURE-----
 
 iQEcBAABAgAGBQJTZbQlAAoJEF0+sviABDDrZbQH/09PfE51KPVPlanr6q1v4/Ut
 LQxfojUWiLQdg2ESJItkcuweYg+kc3HCyFejeDIBw9dpXt00rY26p05qrpnG+85b
@@ -249,12 +249,12 @@ RUysgqjcpT8+iQM1PblGfHR4XAhuOqN5Fx06PSaFZhqvWFezJ28/CLyX5q+oIVk=
 =EFTF
 -----END PGP SIGNATURE-----
 `
-	commit.GPGSignature = gpgsignature
+	commit.PGPSignature = pgpsignature
 
 	err := commit.Encode(encoded)
 	c.Assert(err, IsNil)
 
 	err = decoded.Decode(encoded)
 	c.Assert(err, IsNil)
-	c.Assert(decoded.GPGSignature, Equals, gpgsignature)
+	c.Assert(decoded.PGPSignature, Equals, pgpsignature)
 }

--- a/plumbing/object/commit_test.go
+++ b/plumbing/object/commit_test.go
@@ -232,3 +232,29 @@ func (s *SuiteCommit) TestLongCommitMessageSerialization(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(decoded.Message, Equals, longMessage)
 }
+
+func (s *SuiteCommit) TestGPGSignatureSerialization(c *C) {
+	encoded := &plumbing.MemoryObject{}
+	decoded := &Commit{}
+	commit := *s.Commit
+
+	gpgsignature := `-----BEGIN PGP SIGNATURE-----
+
+iQEcBAABAgAGBQJTZbQlAAoJEF0+sviABDDrZbQH/09PfE51KPVPlanr6q1v4/Ut
+LQxfojUWiLQdg2ESJItkcuweYg+kc3HCyFejeDIBw9dpXt00rY26p05qrpnG+85b
+hM1/PswpPLuBSr+oCIDj5GMC2r2iEKsfv2fJbNW8iWAXVLoWZRF8B0MfqX/YTMbm
+ecorc4iXzQu7tupRihslbNkfvfciMnSDeSvzCpWAHl7h8Wj6hhqePmLm9lAYqnKp
+8S5B/1SSQuEAjRZgI4IexpZoeKGVDptPHxLLS38fozsyi0QyDyzEgJxcJQVMXxVi
+RUysgqjcpT8+iQM1PblGfHR4XAhuOqN5Fx06PSaFZhqvWFezJ28/CLyX5q+oIVk=
+=EFTF
+-----END PGP SIGNATURE-----
+`
+	commit.GPGSignature = gpgsignature
+
+	err := commit.Encode(encoded)
+	c.Assert(err, IsNil)
+
+	err = decoded.Decode(encoded)
+	c.Assert(err, IsNil)
+	c.Assert(decoded.GPGSignature, Equals, gpgsignature)
+}


### PR DESCRIPTION
This change adds `PGPSignature` field to `Commit` object. This is used
to store the signature of the commit, if any.

Related to #605 
fixes #524 