### PR TITLE
utils: merkletrie, filesystem fix symlinks to dir 

### DIFF
--- a/utils/merkletrie/filesystem/node.go
+++ b/utils/merkletrie/filesystem/node.go
@@ -77,6 +77,10 @@ func (n *node) NumChildren() (int, error) {
 }
 
 func (n *node) calculateChildren() error {
+	if !n.IsDir() {
+		return nil
+	}
+
 	if len(n.children) != 0 {
 		return nil
 	}

--- a/utils/merkletrie/filesystem/node_test.go
+++ b/utils/merkletrie/filesystem/node_test.go
@@ -82,6 +82,42 @@ func (s *NoderSuite) TestDiffChangeContent(c *C) {
 	c.Assert(ch, HasLen, 1)
 }
 
+func (s *NoderSuite) TestDiffSymlinkDirOnA(c *C) {
+	fsA := memfs.New()
+	WriteFile(fsA, "qux/qux", []byte("foo"), 0644)
+
+	fsB := memfs.New()
+	fsB.Symlink("qux", "foo")
+	WriteFile(fsB, "qux/qux", []byte("foo"), 0644)
+
+	ch, err := merkletrie.DiffTree(
+		NewRootNode(fsA, nil),
+		NewRootNode(fsB, nil),
+		IsEquals,
+	)
+
+	c.Assert(err, IsNil)
+	c.Assert(ch, HasLen, 1)
+}
+
+func (s *NoderSuite) TestDiffSymlinkDirOnB(c *C) {
+	fsA := memfs.New()
+	fsA.Symlink("qux", "foo")
+	WriteFile(fsA, "qux/qux", []byte("foo"), 0644)
+
+	fsB := memfs.New()
+	WriteFile(fsB, "qux/qux", []byte("foo"), 0644)
+
+	ch, err := merkletrie.DiffTree(
+		NewRootNode(fsA, nil),
+		NewRootNode(fsB, nil),
+		IsEquals,
+	)
+
+	c.Assert(err, IsNil)
+	c.Assert(ch, HasLen, 1)
+}
+
 func (s *NoderSuite) TestDiffChangeMissing(c *C) {
 	fsA := memfs.New()
 	WriteFile(fsA, "foo", []byte("foo"), 0644)


### PR DESCRIPTION
I tried to figure how to write a proper test, but failed in a reasonable time frame, so sending the PR without a test. Nevertheless, here is a tiny repository which reproduces an issue: https://github.com/dimonomid/git-go-symlink-test/blob/master/test_symlink_dir.go

It uses another repository as a test case: https://github.com/dimonomid/git-go-fixture-dir-symlink , which has just two commits; the second one adds this tree:
```
.
├── dir2
│   └── file2
└── dir3
    └── dir2_symlink -> ../dir2
```
And to reproduce the issue, we can just clone the repo (so that we have these `dir2/file2` and symlink to it), and then checkout the previous revision. This is the list of changes it tries to apply:

```
<Delete dir2/file2>
<Delete dir3/dir2_symlink>
<Delete dir3/dir2_symlink/file2>
```

And obviously the last one fails, because `dir2/file2` was already removed before. This PR prevents non-dir items from having children.