### PR TITLE
transport: made public all the fields and standardized AuthMethod

### DIFF
--- a/plumbing/transport/http/common.go
+++ b/plumbing/transport/http/common.go
@@ -151,17 +151,12 @@ func basicAuthFromEndpoint(ep *transport.Endpoint) *BasicAuth {
 		return nil
 	}
 
-	return NewBasicAuth(u, ep.Password)
+	return &BasicAuth{u, ep.Password}
 }
 
 // BasicAuth represent a HTTP basic auth
 type BasicAuth struct {
-	username, password string
-}
-
-// NewBasicAuth returns a basicAuth base on the given user and password
-func NewBasicAuth(username, password string) *BasicAuth {
-	return &BasicAuth{username, password}
+	Username, Password string
 }
 
 func (a *BasicAuth) setAuth(r *http.Request) {
@@ -169,7 +164,7 @@ func (a *BasicAuth) setAuth(r *http.Request) {
 		return
 	}
 
-	r.SetBasicAuth(a.username, a.password)
+	r.SetBasicAuth(a.Username, a.Password)
 }
 
 // Name is name of the auth
@@ -179,11 +174,11 @@ func (a *BasicAuth) Name() string {
 
 func (a *BasicAuth) String() string {
 	masked := "*******"
-	if a.password == "" {
+	if a.Password == "" {
 		masked = "<empty>"
 	}
 
-	return fmt.Sprintf("%s - %s:%s", a.Name(), a.username, masked)
+	return fmt.Sprintf("%s - %s:%s", a.Name(), a.Username, masked)
 }
 
 // Err is a dedicated error to return errors based on status code

--- a/plumbing/transport/http/common_test.go
+++ b/plumbing/transport/http/common_test.go
@@ -49,7 +49,7 @@ func (s *UploadPackSuite) TestNewClient(c *C) {
 }
 
 func (s *ClientSuite) TestNewBasicAuth(c *C) {
-	a := NewBasicAuth("foo", "qux")
+	a := &BasicAuth{"foo", "qux"}
 
 	c.Assert(a.Name(), Equals, "http-basic-auth")
 	c.Assert(a.String(), Equals, "http-basic-auth - foo:*******")

--- a/plumbing/transport/ssh/auth_method_test.go
+++ b/plumbing/transport/ssh/auth_method_test.go
@@ -32,16 +32,16 @@ func (s *SuiteCommon) TestKeyboardInteractiveString(c *C) {
 
 func (s *SuiteCommon) TestPasswordName(c *C) {
 	a := &Password{
-		User: "test",
-		Pass: "",
+		User:     "test",
+		Password: "",
 	}
 	c.Assert(a.Name(), Equals, PasswordName)
 }
 
 func (s *SuiteCommon) TestPasswordString(c *C) {
 	a := &Password{
-		User: "test",
-		Pass: "",
+		User:     "test",
+		Password: "",
 	}
 	c.Assert(a.String(), Equals, fmt.Sprintf("user: test, name: %s", PasswordName))
 }

--- a/plumbing/transport/ssh/common.go
+++ b/plumbing/transport/ssh/common.go
@@ -98,8 +98,7 @@ func (c *command) connect() error {
 	}
 
 	var err error
-	config := c.auth.clientConfig()
-	config.HostKeyCallback, err = c.auth.hostKeyCallback()
+	config, err := c.auth.ClientConfig()
 	if err != nil {
 		return err
 	}
@@ -158,8 +157,4 @@ func overrideConfig(overrides *ssh.ClientConfig, c *ssh.ClientConfig) {
 	}
 
 	*c = vc.Interface().(ssh.ClientConfig)
-}
-
-func isZeroValue(v reflect.Value) bool {
-	return reflect.DeepEqual(v.Interface(), reflect.Zero(v.Type()).Interface())
 }


### PR DESCRIPTION
I made a small review on the `AuthMethod` at transport, some methods/fields were private making to the user more complex to build custom solutions. 

Also I standardized AuthMethod constructors and fields, since we had for example `Pass` and `Password` in http/ssh