### PR TITLE
storage: filesystem, add support for git alternates

### DIFF
--- a/storage/filesystem/internal/dotgit/dotgit.go
+++ b/storage/filesystem/internal/dotgit/dotgit.go
@@ -3,6 +3,7 @@ package dotgit
 
 import (
 	"bufio"
+	"bytes"
 	"errors"
 	"fmt"
 	"io"
@@ -756,9 +757,27 @@ func (d *DotGit) PackRefs() (err error) {
 	return nil
 }
 
-// Module return a billy.Filesystem poiting to the module folder
+// Module return a billy.Filesystem pointing to the module folder
 func (d *DotGit) Module(name string) (billy.Filesystem, error) {
 	return d.fs.Chroot(d.fs.Join(modulePath, name))
+}
+
+// Alternates returns the content of objects/info/alternates if available.
+// This can be used to checks if it's a shared repository.
+func (d *DotGit) Alternates() (string, error) {
+	altpath := d.fs.Join("objects", "info", "alternates")
+	f, err := d.fs.Open(altpath)
+	if os.IsNotExist(err) {
+		return "", err
+	}
+
+	buf := new(bytes.Buffer)
+	_, err = buf.ReadFrom(f)
+	if err != nil {
+		return "", err
+	}
+
+	return buf.String(), nil
 }
 
 func isHex(s string) bool {

--- a/storage/filesystem/internal/dotgit/dotgit.go
+++ b/storage/filesystem/internal/dotgit/dotgit.go
@@ -3,15 +3,16 @@ package dotgit
 
 import (
 	"bufio"
-	"bytes"
 	"errors"
 	"fmt"
 	"io"
 	stdioutil "io/ioutil"
 	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
+	"gopkg.in/src-d/go-billy.v4/osfs"
 	"gopkg.in/src-d/go-git.v4/plumbing"
 	"gopkg.in/src-d/go-git.v4/utils/ioutil"
 
@@ -762,22 +763,41 @@ func (d *DotGit) Module(name string) (billy.Filesystem, error) {
 	return d.fs.Chroot(d.fs.Join(modulePath, name))
 }
 
-// Alternates returns the content of objects/info/alternates if available.
-// This can be used to checks if it's a shared repository.
-func (d *DotGit) Alternates() (string, error) {
+// Alternates returns DotGit(s) based off paths in objects/info/alternates if
+// available. This can be used to checks if it's a shared repository.
+func (d *DotGit) Alternates() ([]*DotGit, error) {
 	altpath := d.fs.Join("objects", "info", "alternates")
 	f, err := d.fs.Open(altpath)
-	if os.IsNotExist(err) {
-		return "", err
-	}
-
-	buf := new(bytes.Buffer)
-	_, err = buf.ReadFrom(f)
 	if err != nil {
-		return "", err
+		return nil, err
+	}
+	defer f.Close()
+
+	var alternates []*DotGit
+
+	// Read alternate paths line-by-line and create DotGit objects.
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		path := scanner.Text()
+		if !filepath.IsAbs(path) {
+			// If the path is not absolute, it must be relative to object
+			// database (.git/objects/info).
+			// https://www.kernel.org/pub/software/scm/git/docs/gitrepository-layout.html
+			// Hence, derive a path relative to DotGit's root.
+			// "../../../reponame/.git/" -> "../../reponame/.git"
+			// Remove the first ../
+			relpath := filepath.Join(strings.Split(path, "/")[1:]...)
+			path = filepath.Join(d.fs.Root(), relpath)
+		}
+		fs := osfs.New(filepath.Dir(path))
+		alternates = append(alternates, New(fs))
 	}
 
-	return buf.String(), nil
+	if err = scanner.Err(); err != nil {
+		return nil, err
+	}
+
+	return alternates, nil
 }
 
 func isHex(s string) bool {

--- a/storage/filesystem/internal/dotgit/dotgit.go
+++ b/storage/filesystem/internal/dotgit/dotgit.go
@@ -780,14 +780,18 @@ func (d *DotGit) Alternates() ([]*DotGit, error) {
 	for scanner.Scan() {
 		path := scanner.Text()
 		if !filepath.IsAbs(path) {
+			// For relative paths, we can perform an internal conversion to
+			// slash so that they work cross-platform.
+			slashPath := filepath.ToSlash(path)
 			// If the path is not absolute, it must be relative to object
 			// database (.git/objects/info).
 			// https://www.kernel.org/pub/software/scm/git/docs/gitrepository-layout.html
 			// Hence, derive a path relative to DotGit's root.
 			// "../../../reponame/.git/" -> "../../reponame/.git"
 			// Remove the first ../
-			relpath := filepath.Join(strings.Split(path, "/")[1:]...)
-			path = filepath.Join(d.fs.Root(), relpath)
+			relpath := filepath.Join(strings.Split(slashPath, "/")[1:]...)
+			normalPath := filepath.FromSlash(relpath)
+			path = filepath.Join(d.fs.Root(), normalPath)
 		}
 		fs := osfs.New(filepath.Dir(path))
 		alternates = append(alternates, New(fs))

--- a/storage/filesystem/internal/dotgit/dotgit_test.go
+++ b/storage/filesystem/internal/dotgit/dotgit_test.go
@@ -615,3 +615,30 @@ func (s *SuiteDotGit) TestPackRefs(c *C) {
 	c.Assert(ref, NotNil)
 	c.Assert(ref.Hash().String(), Equals, "b8d3ffab552895c19b9fcf7aa264d277cde33881")
 }
+
+func (s *SuiteDotGit) TestAlternates(c *C) {
+	tmp, err := ioutil.TempDir("", "dot-git")
+	c.Assert(err, IsNil)
+	defer os.RemoveAll(tmp)
+
+	// Create a new billy fs.
+	fs := osfs.New(tmp)
+
+	// Create a new dotgit object and initialize.
+	dir := New(fs)
+	err = dir.Initialize()
+	c.Assert(err, IsNil)
+
+	// Create alternates file.
+	altpath := filepath.Join("objects", "info", "alternates")
+	f, err := fs.Create(altpath)
+	c.Assert(err, IsNil)
+
+	content := []byte("/Users/username/rep1//.git/objects")
+	f.Write(content)
+	f.Close()
+
+	alt, err := dir.Alternates()
+	c.Assert(err, IsNil)
+	c.Assert(alt, Equals, "/Users/username/rep1//.git/objects")
+}

--- a/storage/filesystem/internal/dotgit/dotgit_test.go
+++ b/storage/filesystem/internal/dotgit/dotgit_test.go
@@ -634,11 +634,20 @@ func (s *SuiteDotGit) TestAlternates(c *C) {
 	f, err := fs.Create(altpath)
 	c.Assert(err, IsNil)
 
-	content := []byte("/Users/username/rep1//.git/objects")
+	// Multiple alternates.
+	content := []byte("/Users/username/rep1//.git/objects\n../../../rep2//.git/objects")
 	f.Write(content)
 	f.Close()
 
-	alt, err := dir.Alternates()
+	dotgits, err := dir.Alternates()
 	c.Assert(err, IsNil)
-	c.Assert(alt, Equals, "/Users/username/rep1//.git/objects")
+	c.Assert(dotgits[0].fs.Root(), Equals, "/Users/username/rep1/.git")
+
+	// For relative path:
+	// /some/absolute/path/to/dot-git -> /some/absolute/path
+	pathx := strings.Split(tmp, "/")
+	pathx = pathx[:len(pathx)-2]
+	resolvedPath := filepath.Join(pathx...)
+	// Append the alternate path to the resolvedPath
+	c.Assert(dotgits[1].fs.Root(), Equals, filepath.Join("/", resolvedPath, "rep2", ".git"))
 }

--- a/worktree_test.go
+++ b/worktree_test.go
@@ -1287,3 +1287,33 @@ func (s *WorktreeSuite) TestClean(c *C) {
 
 	c.Assert(len(status), Equals, 0)
 }
+
+func (s *WorktreeSuite) TestAlternatesRepo(c *C) {
+	fs := fixtures.ByTag("alternates").One().Worktree()
+
+	// Open 1st repo.
+	rep1fs, err := fs.Chroot("rep1")
+	c.Assert(err, IsNil)
+	rep1, err := PlainOpen(rep1fs.Root())
+	c.Assert(err, IsNil)
+
+	// Open 2nd repo.
+	rep2fs, err := fs.Chroot("rep2")
+	c.Assert(err, IsNil)
+	rep2, err := PlainOpen(rep2fs.Root())
+	c.Assert(err, IsNil)
+
+	// Get the HEAD commit from the main repo.
+	h, err := rep1.Head()
+	c.Assert(err, IsNil)
+	commit1, err := rep1.CommitObject(h.Hash())
+	c.Assert(err, IsNil)
+
+	// Get the HEAD commit from the shared repo.
+	h, err = rep2.Head()
+	c.Assert(err, IsNil)
+	commit2, err := rep2.CommitObject(h.Hash())
+	c.Assert(err, IsNil)
+
+	c.Assert(commit1.String(), Equals, commit2.String())
+}


### PR DESCRIPTION
This change adds a new method `Alternates()` in `DotGit` to check and
query alternate source.
```
func (d *DotGit) Alternates() (string, error)
```
This is used by `ObjectStorage.EncodedObject` to check for alternates
and get the queried object from the alternate source.

I've manually tested this with the scenario and code in #325 but I'm not sure what would be the right way to setup an automated test for this. **Need help with testing**.

Fixes #325 