### PR TITLE
plumbing/transport: Fix truncated comment in Endpoint

### DIFF
--- a/plumbing/transport/common.go
+++ b/plumbing/transport/common.go
@@ -94,7 +94,7 @@ type ReceivePackSession interface {
 
 // Endpoint represents a Git URL in any supported protocol.
 type Endpoint struct {
-	// Protocol is the protocol of the endpoint (e.g. git, https, file). I
+	// Protocol is the protocol of the endpoint (e.g. git, https, file).
 	Protocol string
 	// User is the user.
 	User string


### PR DESCRIPTION
Minor comment clean up following refactoring introduced in #650 