### PR TITLE
all: simplification

### DIFF
--- a/blame.go
+++ b/blame.go
@@ -147,10 +147,7 @@ func (b *blame) fillRevs() error {
 	var err error
 
 	b.revs, err = references(b.fRev, b.path)
-	if err != nil {
-		return err
-	}
-	return nil
+	return err
 }
 
 // build graph of a file from its revision history
@@ -244,7 +241,7 @@ func (b *blame) GoString() string {
 
 	lines := strings.Split(contents, "\n")
 	// max line number length
-	mlnl := len(fmt.Sprintf("%s", strconv.Itoa(len(lines))))
+	mlnl := len(strconv.Itoa(len(lines)))
 	// max author length
 	mal := b.maxAuthorLength()
 	format := fmt.Sprintf("%%s (%%-%ds %%%dd) %%s\n",

--- a/common_test.go
+++ b/common_test.go
@@ -30,7 +30,7 @@ func (s *BaseSuite) SetUpSuite(c *C) {
 	s.Suite.SetUpSuite(c)
 	s.buildBasicRepository(c)
 
-	s.cache = make(map[string]*Repository, 0)
+	s.cache = make(map[string]*Repository)
 }
 
 func (s *BaseSuite) TearDownSuite(c *C) {

--- a/config/config.go
+++ b/config/config.go
@@ -65,8 +65,8 @@ type Config struct {
 // NewConfig returns a new empty Config.
 func NewConfig() *Config {
 	return &Config{
-		Remotes:    make(map[string]*RemoteConfig, 0),
-		Submodules: make(map[string]*Submodule, 0),
+		Remotes:    make(map[string]*RemoteConfig),
+		Submodules: make(map[string]*Submodule),
 		Raw:        format.New(),
 	}
 }
@@ -290,13 +290,8 @@ func (c *RemoteConfig) unmarshal(s *format.Subsection) error {
 		fetch = append(fetch, rs)
 	}
 
-	var urls []string
-	for _, f := range c.raw.Options.GetAll(urlKey) {
-		urls = append(urls, f)
-	}
-
 	c.Name = c.raw.Name
-	c.URLs = urls
+	c.URLs = append([]string(nil), c.raw.Options.GetAll(urlKey)...)
 	c.Fetch = fetch
 
 	return nil

--- a/config/modules.go
+++ b/config/modules.go
@@ -24,7 +24,7 @@ type Modules struct {
 // NewModules returns a new empty Modules
 func NewModules() *Modules {
 	return &Modules{
-		Submodules: make(map[string]*Submodule, 0),
+		Submodules: make(map[string]*Submodule),
 		raw:        format.New(),
 	}
 }

--- a/config/refspec.go
+++ b/config/refspec.go
@@ -51,20 +51,12 @@ func (s RefSpec) Validate() error {
 
 // IsForceUpdate returns if update is allowed in non fast-forward merges.
 func (s RefSpec) IsForceUpdate() bool {
-	if s[0] == refSpecForce[0] {
-		return true
-	}
-
-	return false
+	return s[0] == refSpecForce[0]
 }
 
 // IsDelete returns true if the refspec indicates a delete (empty src).
 func (s RefSpec) IsDelete() bool {
-	if s[0] == refSpecSeparator[0] {
-		return true
-	}
-
-	return false
+	return s[0] == refSpecSeparator[0]
 }
 
 // Src return the src side.
@@ -87,7 +79,7 @@ func (s RefSpec) Match(n plumbing.ReferenceName) bool {
 
 // IsWildcard returns true if the RefSpec contains a wildcard.
 func (s RefSpec) IsWildcard() bool {
-	return strings.Index(string(s), refSpecWildcard) != -1
+	return strings.Contains(string(s), refSpecWildcard)
 }
 
 func (s RefSpec) matchExact(n plumbing.ReferenceName) bool {

--- a/plumbing/format/config/encoder.go
+++ b/plumbing/format/config/encoder.go
@@ -53,17 +53,13 @@ func (e *Encoder) encodeSubsection(sectionName string, s *Subsection) error {
 		return err
 	}
 
-	if err := e.encodeOptions(s.Options); err != nil {
-		return err
-	}
-
-	return nil
+	return e.encodeOptions(s.Options)
 }
 
 func (e *Encoder) encodeOptions(opts Options) error {
 	for _, o := range opts {
 		pattern := "\t%s = %s\n"
-		if strings.Index(o.Value, "\\") != -1 {
+		if strings.Contains(o.Value, "\\") {
 			pattern = "\t%s = %q\n"
 		}
 

--- a/plumbing/format/index/decoder.go
+++ b/plumbing/format/index/decoder.go
@@ -200,11 +200,8 @@ func (d *Decoder) padEntry(idx *Index, e *Entry, read int) error {
 
 	entrySize := read + len(e.Name)
 	padLen := 8 - entrySize%8
-	if _, err := io.CopyN(ioutil.Discard, d.r, int64(padLen)); err != nil {
-		return err
-	}
-
-	return nil
+	_, err := io.CopyN(ioutil.Discard, d.r, int64(padLen))
+	return err
 }
 
 func (d *Decoder) readExtensions(idx *Index) error {
@@ -288,7 +285,7 @@ func (d *Decoder) readChecksum(expected []byte, alreadyRead [4]byte) error {
 		return err
 	}
 
-	if bytes.Compare(h[:], expected) != 0 {
+	if !bytes.Equal(h[:], expected) {
 		return ErrInvalidChecksum
 	}
 
@@ -407,7 +404,7 @@ func (d *resolveUndoDecoder) Decode(ru *ResolveUndo) error {
 
 func (d *resolveUndoDecoder) readEntry() (*ResolveUndoEntry, error) {
 	e := &ResolveUndoEntry{
-		Stages: make(map[Stage]plumbing.Hash, 0),
+		Stages: make(map[Stage]plumbing.Hash),
 	}
 
 	path, err := binary.ReadUntil(d.r, '\x00')

--- a/plumbing/format/objfile/reader.go
+++ b/plumbing/format/objfile/reader.go
@@ -110,9 +110,5 @@ func (r *Reader) Hash() plumbing.Hash {
 // Close releases any resources consumed by the Reader. Calling Close does not
 // close the wrapped io.Reader originally passed to NewReader.
 func (r *Reader) Close() error {
-	if err := r.zlib.Close(); err != nil {
-		return err
-	}
-
-	return nil
+	return r.zlib.Close()
 }

--- a/plumbing/format/packfile/decoder.go
+++ b/plumbing/format/packfile/decoder.go
@@ -105,7 +105,7 @@ func NewDecoderForType(s *Scanner, o storer.EncodedObjectStorer,
 		o: o,
 
 		idx:          NewIndex(0),
-		offsetToType: make(map[int64]plumbing.ObjectType, 0),
+		offsetToType: make(map[int64]plumbing.ObjectType),
 		decoderType:  t,
 	}, nil
 }

--- a/plumbing/format/packfile/delta_index.go
+++ b/plumbing/format/packfile/delta_index.go
@@ -215,12 +215,10 @@ var len8tab = [256]uint8{
 }
 
 func hashBlock(raw []byte, ptr int) int {
-	var hash uint32
-
 	// The first 4 steps collapse out into a 4 byte big-endian decode,
 	// with a larger right shift as we combined shift lefts together.
 	//
-	hash = ((uint32(raw[ptr]) & 0xff) << 24) |
+	hash := ((uint32(raw[ptr]) & 0xff) << 24) |
 		((uint32(raw[ptr+1]) & 0xff) << 16) |
 		((uint32(raw[ptr+2]) & 0xff) << 8) |
 		(uint32(raw[ptr+3]) & 0xff)

--- a/plumbing/format/packfile/object_pack.go
+++ b/plumbing/format/packfile/object_pack.go
@@ -84,11 +84,7 @@ func (o *ObjectToPack) Size() int64 {
 }
 
 func (o *ObjectToPack) IsDelta() bool {
-	if o.Base != nil {
-		return true
-	}
-
-	return false
+	return o.Base != nil
 }
 
 func (o *ObjectToPack) SetDelta(base *ObjectToPack, delta plumbing.EncodedObject) {

--- a/plumbing/format/packfile/patch_delta.go
+++ b/plumbing/format/packfile/patch_delta.go
@@ -38,11 +38,8 @@ func ApplyDelta(target, base plumbing.EncodedObject, delta []byte) error {
 
 	target.SetSize(int64(len(dst)))
 
-	if _, err := w.Write(dst); err != nil {
-		return err
-	}
-
-	return nil
+	_, err = w.Write(dst)
+	return err
 }
 
 var (

--- a/plumbing/format/pktline/encoder.go
+++ b/plumbing/format/pktline/encoder.go
@@ -63,21 +63,15 @@ func (e *Encoder) encodeLine(p []byte) error {
 	}
 
 	if bytes.Equal(p, Flush) {
-		if err := e.Flush(); err != nil {
-			return err
-		}
-		return nil
+		return e.Flush()
 	}
 
 	n := len(p) + 4
 	if _, err := e.w.Write(asciiHex16(n)); err != nil {
 		return err
 	}
-	if _, err := e.w.Write(p); err != nil {
-		return err
-	}
-
-	return nil
+	_, err := e.w.Write(p)
+	return err
 }
 
 // Returns the hexadecimal ascii representation of the 16 less

--- a/plumbing/protocol/packp/advrefs_encode.go
+++ b/plumbing/protocol/packp/advrefs_encode.go
@@ -133,7 +133,7 @@ func encodeRefs(e *advRefsEncoder) encoderStateFn {
 			continue
 		}
 
-		hash, _ := e.data.References[r]
+		hash := e.data.References[r]
 		if e.err = e.pe.Encodef("%s %s\n", hash.String(), r); e.err != nil {
 			return nil
 		}

--- a/plumbing/protocol/packp/shallowupd.go
+++ b/plumbing/protocol/packp/shallowupd.go
@@ -32,7 +32,7 @@ func (r *ShallowUpdate) Decode(reader io.Reader) error {
 			err = r.decodeShallowLine(line)
 		case bytes.HasPrefix(line, unshallow):
 			err = r.decodeUnshallowLine(line)
-		case bytes.Compare(line, pktline.Flush) == 0:
+		case bytes.Equal(line, pktline.Flush):
 			return nil
 		}
 

--- a/plumbing/protocol/packp/srvresp.go
+++ b/plumbing/protocol/packp/srvresp.go
@@ -77,7 +77,7 @@ func (r *ServerResponse) stopReading(reader *bufio.Reader) (bool, error) {
 func (r *ServerResponse) isValidCommand(b []byte) bool {
 	commands := [][]byte{ack, nak}
 	for _, c := range commands {
-		if bytes.Compare(b, c) == 0 {
+		if bytes.Equal(b, c) {
 			return true
 		}
 	}
@@ -90,11 +90,11 @@ func (r *ServerResponse) decodeLine(line []byte) error {
 		return fmt.Errorf("unexpected flush")
 	}
 
-	if bytes.Compare(line[0:3], ack) == 0 {
+	if bytes.Equal(line[0:3], ack) {
 		return r.decodeACKLine(line)
 	}
 
-	if bytes.Compare(line[0:3], nak) == 0 {
+	if bytes.Equal(line[0:3], nak) {
 		return nil
 	}
 

--- a/plumbing/protocol/packp/ulreq_encode.go
+++ b/plumbing/protocol/packp/ulreq_encode.go
@@ -70,7 +70,7 @@ func (e *ulReqEncoder) encodeFirstWant() stateFn {
 func (e *ulReqEncoder) encodeAditionalWants() stateFn {
 	last := e.data.Wants[0]
 	for _, w := range e.data.Wants[1:] {
-		if bytes.Compare(last[:], w[:]) == 0 {
+		if bytes.Equal(last[:], w[:]) {
 			continue
 		}
 
@@ -90,7 +90,7 @@ func (e *ulReqEncoder) encodeShallows() stateFn {
 
 	var last plumbing.Hash
 	for _, s := range e.data.Shallows {
-		if bytes.Compare(last[:], s[:]) == 0 {
+		if bytes.Equal(last[:], s[:]) {
 			continue
 		}
 

--- a/plumbing/protocol/packp/uppackreq.go
+++ b/plumbing/protocol/packp/uppackreq.go
@@ -77,7 +77,7 @@ func (u *UploadHaves) Encode(w io.Writer, flush bool) error {
 
 	var last plumbing.Hash
 	for _, have := range u.Haves {
-		if bytes.Compare(last[:], have[:]) == 0 {
+		if bytes.Equal(last[:], have[:]) {
 			continue
 		}
 

--- a/plumbing/protocol/packp/uppackresp_test.go
+++ b/plumbing/protocol/packp/uppackresp_test.go
@@ -92,7 +92,7 @@ func (s *UploadPackResponseSuite) TestEncodeNAK(c *C) {
 	c.Assert(res.Encode(b), IsNil)
 
 	expected := "0008NAK\n[PACK]"
-	c.Assert(string(b.Bytes()), Equals, expected)
+	c.Assert(b.String(), Equals, expected)
 }
 
 func (s *UploadPackResponseSuite) TestEncodeDepth(c *C) {
@@ -107,7 +107,7 @@ func (s *UploadPackResponseSuite) TestEncodeDepth(c *C) {
 	c.Assert(res.Encode(b), IsNil)
 
 	expected := "00000008NAK\nPACK"
-	c.Assert(string(b.Bytes()), Equals, expected)
+	c.Assert(b.String(), Equals, expected)
 }
 
 func (s *UploadPackResponseSuite) TestEncodeMultiACK(c *C) {

--- a/plumbing/storer/reference_test.go
+++ b/plumbing/storer/reference_test.go
@@ -97,11 +97,7 @@ func (s *ReferenceSuite) TestReferenceFilteredIterNext(c *C) {
 	}
 
 	i := NewReferenceFilteredIter(func(r *plumbing.Reference) bool {
-		if r.Name() == "bar" {
-			return true
-		}
-
-		return false
+		return r.Name() == "bar"
 	}, NewReferenceSliceIter(slice))
 	foo, err := i.Next()
 	c.Assert(err, IsNil)
@@ -120,11 +116,7 @@ func (s *ReferenceSuite) TestReferenceFilteredIterForEach(c *C) {
 	}
 
 	i := NewReferenceFilteredIter(func(r *plumbing.Reference) bool {
-		if r.Name() == "bar" {
-			return true
-		}
-
-		return false
+		return r.Name() == "bar"
 	}, NewReferenceSliceIter(slice))
 	var count int
 	i.ForEach(func(r *plumbing.Reference) error {
@@ -143,11 +135,7 @@ func (s *ReferenceSuite) TestReferenceFilteredIterError(c *C) {
 	}
 
 	i := NewReferenceFilteredIter(func(r *plumbing.Reference) bool {
-		if r.Name() == "bar" {
-			return true
-		}
-
-		return false
+		return r.Name() == "bar"
 	}, NewReferenceSliceIter(slice))
 	var count int
 	exampleErr := errors.New("SOME ERROR")
@@ -172,11 +160,7 @@ func (s *ReferenceSuite) TestReferenceFilteredIterForEachStop(c *C) {
 	}
 
 	i := NewReferenceFilteredIter(func(r *plumbing.Reference) bool {
-		if r.Name() == "bar" {
-			return true
-		}
-
-		return false
+		return r.Name() == "bar"
 	}, NewReferenceSliceIter(slice))
 
 	var count int

--- a/references.go
+++ b/references.go
@@ -26,7 +26,7 @@ import (
 // to fix this).
 func references(c *object.Commit, path string) ([]*object.Commit, error) {
 	var result []*object.Commit
-	seen := make(map[plumbing.Hash]struct{}, 0)
+	seen := make(map[plumbing.Hash]struct{})
 	if err := walkGraph(&result, &seen, c, path); err != nil {
 		return nil, err
 	}

--- a/remote.go
+++ b/remote.go
@@ -580,7 +580,7 @@ func getHaves(
 	}
 
 	for _, ref := range localRefs {
-		if haves[ref.Hash()] == true {
+		if haves[ref.Hash()] {
 			continue
 		}
 
@@ -618,7 +618,7 @@ func calculateRefs(
 		return nil, err
 	}
 
-	refs := make(memory.ReferenceStorage, 0)
+	refs := make(memory.ReferenceStorage)
 	return refs, iter.ForEach(func(ref *plumbing.Reference) error {
 		if !config.MatchAny(spec, ref.Name()) {
 			return nil

--- a/repository.go
+++ b/repository.go
@@ -323,7 +323,7 @@ func newRepository(s storage.Storer, worktree billy.Filesystem) *Repository {
 	return &Repository{
 		Storer: s,
 		wt:     worktree,
-		r:      make(map[string]*Remote, 0),
+		r:      make(map[string]*Remote),
 	}
 }
 

--- a/storage/filesystem/internal/dotgit/dotgit.go
+++ b/storage/filesystem/internal/dotgit/dotgit.go
@@ -265,11 +265,7 @@ func (d *DotGit) checkReferenceAndTruncate(f billy.File, old *plumbing.Reference
 	if err != nil {
 		return err
 	}
-	err = f.Truncate(0)
-	if err != nil {
-		return err
-	}
-	return nil
+	return f.Truncate(0)
 }
 
 func (d *DotGit) SetRef(r, old *plumbing.Reference) error {

--- a/storage/filesystem/object.go
+++ b/storage/filesystem/object.go
@@ -41,7 +41,7 @@ func (s *ObjectStorage) requireIndex() error {
 		return nil
 	}
 
-	s.index = make(map[plumbing.Hash]*packfile.Index, 0)
+	s.index = make(map[plumbing.Hash]*packfile.Index)
 	packs, err := s.dir.ObjectPacks()
 	if err != nil {
 		return err
@@ -319,7 +319,7 @@ func (s *ObjectStorage) IterEncodedObjects(t plumbing.ObjectType) (storer.Encode
 		return nil, err
 	}
 
-	seen := make(map[plumbing.Hash]bool, 0)
+	seen := make(map[plumbing.Hash]bool)
 	var iters []storer.EncodedObjectIter
 	if len(objects) != 0 {
 		iters = append(iters, &objectsIter{s: s, t: t, h: objects})

--- a/storage/memory/storage.go
+++ b/storage/memory/storage.go
@@ -30,17 +30,17 @@ type Storage struct {
 // NewStorage returns a new Storage base on memory
 func NewStorage() *Storage {
 	return &Storage{
-		ReferenceStorage: make(ReferenceStorage, 0),
+		ReferenceStorage: make(ReferenceStorage),
 		ConfigStorage:    ConfigStorage{},
 		ShallowStorage:   ShallowStorage{},
 		ObjectStorage: ObjectStorage{
-			Objects: make(map[plumbing.Hash]plumbing.EncodedObject, 0),
-			Commits: make(map[plumbing.Hash]plumbing.EncodedObject, 0),
-			Trees:   make(map[plumbing.Hash]plumbing.EncodedObject, 0),
-			Blobs:   make(map[plumbing.Hash]plumbing.EncodedObject, 0),
-			Tags:    make(map[plumbing.Hash]plumbing.EncodedObject, 0),
+			Objects: make(map[plumbing.Hash]plumbing.EncodedObject),
+			Commits: make(map[plumbing.Hash]plumbing.EncodedObject),
+			Trees:   make(map[plumbing.Hash]plumbing.EncodedObject),
+			Blobs:   make(map[plumbing.Hash]plumbing.EncodedObject),
+			Tags:    make(map[plumbing.Hash]plumbing.EncodedObject),
 		},
-		ModuleStorage: make(ModuleStorage, 0),
+		ModuleStorage: make(ModuleStorage),
 	}
 }
 
@@ -152,7 +152,7 @@ func flattenObjectMap(m map[plumbing.Hash]plumbing.EncodedObject) []plumbing.Enc
 func (o *ObjectStorage) Begin() storer.Transaction {
 	return &TxObjectStorage{
 		Storage: o,
-		Objects: make(map[plumbing.Hash]plumbing.EncodedObject, 0),
+		Objects: make(map[plumbing.Hash]plumbing.EncodedObject),
 	}
 }
 
@@ -189,7 +189,7 @@ func (tx *TxObjectStorage) Commit() error {
 }
 
 func (tx *TxObjectStorage) Rollback() error {
-	tx.Objects = make(map[plumbing.Hash]plumbing.EncodedObject, 0)
+	tx.Objects = make(map[plumbing.Hash]plumbing.EncodedObject)
 	return nil
 }
 

--- a/worktree_status.go
+++ b/worktree_status.go
@@ -39,7 +39,7 @@ func (w *Worktree) Status() (Status, error) {
 }
 
 func (w *Worktree) status(commit plumbing.Hash) (Status, error) {
-	s := make(Status, 0)
+	s := make(Status)
 
 	left, err := w.diffCommitWithStaging(commit, false)
 	if err != nil {


### PR DESCRIPTION
 - no length for map initialization
 - don't check for boolean/error return
 - don't format string
 - use string method of bytes buffer instead of converting bytes to string
 - use `strings.Contains` instead of `strings.Index`
 - use `bytes.Equal` instead of `bytes.Compare`