### PR TITLE
storage/repository: add new functions for garbage collection

### DIFF
--- a/object_walker.go
+++ b/object_walker.go
@@ -1,0 +1,105 @@
+package git
+
+import (
+	"fmt"
+
+	"gopkg.in/src-d/go-git.v4/plumbing"
+	"gopkg.in/src-d/go-git.v4/plumbing/filemode"
+	"gopkg.in/src-d/go-git.v4/plumbing/object"
+	"gopkg.in/src-d/go-git.v4/storage"
+)
+
+type objectWalker struct {
+	Storer storage.Storer
+	// seen is the set of objects seen in the repo.
+	// seen map can become huge if walking over large
+	// repos. Thus using struct{} as the value type.
+	seen map[plumbing.Hash]struct{}
+}
+
+func newObjectWalker(s storage.Storer) *objectWalker {
+	return &objectWalker{s, map[plumbing.Hash]struct{}{}}
+}
+
+// walkAllRefs walks all (hash) refererences from the repo.
+func (p *objectWalker) walkAllRefs() error {
+	// Walk over all the references in the repo.
+	it, err := p.Storer.IterReferences()
+	if err != nil {
+		return err
+	}
+	defer it.Close()
+	err = it.ForEach(func(ref *plumbing.Reference) error {
+		// Exit this iteration early for non-hash references.
+		if ref.Type() != plumbing.HashReference {
+			return nil
+		}
+		return p.walkObjectTree(ref.Hash())
+	})
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (p *objectWalker) isSeen(hash plumbing.Hash) bool {
+	_, seen := p.seen[hash]
+	return seen
+}
+
+func (p *objectWalker) add(hash plumbing.Hash) {
+	p.seen[hash] = struct{}{}
+}
+
+// walkObjectTree walks over all objects and remembers references
+// to them in the objectWalker. This is used instead of the revlist
+// walks because memory usage is tight with huge repos.
+func (p *objectWalker) walkObjectTree(hash plumbing.Hash) error {
+	// Check if we have already seen, and mark this object
+	if p.isSeen(hash) {
+		return nil
+	}
+	p.add(hash)
+	// Fetch the object.
+	obj, err := object.GetObject(p.Storer, hash)
+	if err != nil {
+		return fmt.Errorf("Getting object %s failed: %v", hash, err)
+	}
+	// Walk all children depending on object type.
+	switch obj := obj.(type) {
+	case *object.Commit:
+		err = p.walkObjectTree(obj.TreeHash)
+		if err != nil {
+			return err
+		}
+		for _, h := range obj.ParentHashes {
+			err = p.walkObjectTree(h)
+			if err != nil {
+				return err
+			}
+		}
+	case *object.Tree:
+		for i := range obj.Entries {
+			// Shortcut for blob objects:
+			// 'or' the lower bits of a mode and check that it
+			// it matches a filemode.Executable. The type information
+			// is in the higher bits, but this is the cleanest way
+			// to handle plain files with different modes.
+			// Other non-tree objects are somewhat rare, so they
+			// are not special-cased.
+			if obj.Entries[i].Mode|0755 == filemode.Executable {
+				p.add(obj.Entries[i].Hash)
+				continue
+			}
+			// Normal walk for sub-trees (and symlinks etc).
+			err = p.walkObjectTree(obj.Entries[i].Hash)
+			if err != nil {
+				return err
+			}
+		}
+	default:
+		// Error out on unhandled object types.
+		return fmt.Errorf("Unknown object %X %s %T\n", obj.ID(), obj.Type(), obj)
+	}
+	return nil
+}

--- a/plumbing/storer/object.go
+++ b/plumbing/storer/object.go
@@ -43,10 +43,12 @@ type EncodedObjectStorer interface {
 	// ForEachObjectHash iterates over all the (loose) object hashes
 	// in the repository without necessarily having to read those objects.
 	// Objects only inside pack files may be omitted.
+	// If ErrStop is sent the iteration is stop but no error is returned.
 	ForEachObjectHash(func(plumbing.Hash) error) error
 	// LooseObjectTime looks up the (m)time associated with the
-	// loose object (that is not in a pack file). Implementations
-	// may
+	// loose object (that is not in a pack file). Some
+	// implementations (e.g. without loose objects)
+	// always return an error.
 	LooseObjectTime(plumbing.Hash) (time.Time, error)
 	// DeleteLooseObject deletes a loose object if it exists.
 	DeleteLooseObject(plumbing.Hash) error

--- a/plumbing/storer/object.go
+++ b/plumbing/storer/object.go
@@ -3,6 +3,7 @@ package storer
 import (
 	"errors"
 	"io"
+	"time"
 
 	"gopkg.in/src-d/go-git.v4/plumbing"
 )
@@ -36,6 +37,19 @@ type EncodedObjectStorer interface {
 	//
 	// Valid plumbing.ObjectType values are CommitObject, BlobObject, TagObject,
 	IterEncodedObjects(plumbing.ObjectType) (EncodedObjectIter, error)
+	// HasEncodedObject returns ErrObjNotFound if the object doesn't
+	// exist.  If the object does exist, it returns nil.
+	HasEncodedObject(plumbing.Hash) error
+	// ForEachObjectHash iterates over all the (loose) object hashes
+	// in the repository without necessarily having to read those objects.
+	// Objects only inside pack files may be omitted.
+	ForEachObjectHash(func(plumbing.Hash) error) error
+	// LooseObjectTime looks up the (m)time associated with the
+	// loose object (that is not in a pack file). Implementations
+	// may
+	LooseObjectTime(plumbing.Hash) (time.Time, error)
+	// DeleteLooseObject deletes a loose object if it exists.
+	DeleteLooseObject(plumbing.Hash) error
 }
 
 // DeltaObjectStorer is an EncodedObjectStorer that can return delta

--- a/plumbing/storer/object.go
+++ b/plumbing/storer/object.go
@@ -52,6 +52,11 @@ type EncodedObjectStorer interface {
 	LooseObjectTime(plumbing.Hash) (time.Time, error)
 	// DeleteLooseObject deletes a loose object if it exists.
 	DeleteLooseObject(plumbing.Hash) error
+	// ObjectPacks returns hashes of object packs if the underlying
+	// implementation has pack files.
+	ObjectPacks() ([]plumbing.Hash, error)
+	// DeleteObjectPackAndIndex deletes an object pack and the corresponding index file if they exist.
+	DeleteObjectPackAndIndex(plumbing.Hash) error
 }
 
 // DeltaObjectStorer is an EncodedObjectStorer that can return delta

--- a/plumbing/storer/object.go
+++ b/plumbing/storer/object.go
@@ -40,24 +40,6 @@ type EncodedObjectStorer interface {
 	// HasEncodedObject returns ErrObjNotFound if the object doesn't
 	// exist.  If the object does exist, it returns nil.
 	HasEncodedObject(plumbing.Hash) error
-	// ForEachObjectHash iterates over all the (loose) object hashes
-	// in the repository without necessarily having to read those objects.
-	// Objects only inside pack files may be omitted.
-	// If ErrStop is sent the iteration is stop but no error is returned.
-	ForEachObjectHash(func(plumbing.Hash) error) error
-	// LooseObjectTime looks up the (m)time associated with the
-	// loose object (that is not in a pack file). Some
-	// implementations (e.g. without loose objects)
-	// always return an error.
-	LooseObjectTime(plumbing.Hash) (time.Time, error)
-	// DeleteLooseObject deletes a loose object if it exists.
-	DeleteLooseObject(plumbing.Hash) error
-	// ObjectPacks returns hashes of object packs if the underlying
-	// implementation has pack files.
-	ObjectPacks() ([]plumbing.Hash, error)
-	// DeleteOldObjectPackAndIndex deletes an object pack and the corresponding index file if they exist.
-	// Deletion is only performed if the pack is older than the supplied time (or the time is zero).
-	DeleteOldObjectPackAndIndex(plumbing.Hash, time.Time) error
 }
 
 // DeltaObjectStorer is an EncodedObjectStorer that can return delta
@@ -73,6 +55,34 @@ type DeltaObjectStorer interface {
 type Transactioner interface {
 	// Begin starts a transaction.
 	Begin() Transaction
+}
+
+// LooseObjectStorer is an optional interface for managing "loose"
+// objects, i.e. those not in packfiles.
+type LooseObjectStorer interface {
+	// ForEachObjectHash iterates over all the (loose) object hashes
+	// in the repository without necessarily having to read those objects.
+	// Objects only inside pack files may be omitted.
+	// If ErrStop is sent the iteration is stop but no error is returned.
+	ForEachObjectHash(func(plumbing.Hash) error) error
+	// LooseObjectTime looks up the (m)time associated with the
+	// loose object (that is not in a pack file). Some
+	// implementations (e.g. without loose objects)
+	// always return an error.
+	LooseObjectTime(plumbing.Hash) (time.Time, error)
+	// DeleteLooseObject deletes a loose object if it exists.
+	DeleteLooseObject(plumbing.Hash) error
+}
+
+// PackedObjectStorer is an optional interface for managing objects in
+// packfiles.
+type PackedObjectStorer interface {
+	// ObjectPacks returns hashes of object packs if the underlying
+	// implementation has pack files.
+	ObjectPacks() ([]plumbing.Hash, error)
+	// DeleteOldObjectPackAndIndex deletes an object pack and the corresponding index file if they exist.
+	// Deletion is only performed if the pack is older than the supplied time (or the time is zero).
+	DeleteOldObjectPackAndIndex(plumbing.Hash, time.Time) error
 }
 
 // PackfileWriter is a optional method for ObjectStorer, it enable direct write

--- a/plumbing/storer/object.go
+++ b/plumbing/storer/object.go
@@ -55,8 +55,9 @@ type EncodedObjectStorer interface {
 	// ObjectPacks returns hashes of object packs if the underlying
 	// implementation has pack files.
 	ObjectPacks() ([]plumbing.Hash, error)
-	// DeleteObjectPackAndIndex deletes an object pack and the corresponding index file if they exist.
-	DeleteObjectPackAndIndex(plumbing.Hash) error
+	// DeleteOldObjectPackAndIndex deletes an object pack and the corresponding index file if they exist.
+	// Deletion is only performed if the pack is older than the supplied time (or the time is zero).
+	DeleteOldObjectPackAndIndex(plumbing.Hash, time.Time) error
 }
 
 // DeltaObjectStorer is an EncodedObjectStorer that can return delta

--- a/plumbing/storer/object_test.go
+++ b/plumbing/storer/object_test.go
@@ -165,3 +165,7 @@ func (o *MockObjectStorage) DeleteLooseObject(plumbing.Hash) error {
 func (o *MockObjectStorage) ObjectPacks() ([]plumbing.Hash, error) {
 	return nil, nil
 }
+
+func (o *MockObjectStorage) DeleteOldObjectPackAndIndex(plumbing.Hash, time.Time) error {
+	return plumbing.ErrObjectNotFound
+}

--- a/plumbing/storer/object_test.go
+++ b/plumbing/storer/object_test.go
@@ -133,6 +133,15 @@ func (o *MockObjectStorage) SetEncodedObject(obj plumbing.EncodedObject) (plumbi
 	return plumbing.ZeroHash, nil
 }
 
+func (o *MockObjectStorage) HasEncodedObject(h plumbing.Hash) error {
+	for _, o := range o.db {
+		if o.Hash() == h {
+			return nil
+		}
+	}
+	return plumbing.ErrObjectNotFound
+}
+
 func (o *MockObjectStorage) EncodedObject(t plumbing.ObjectType, h plumbing.Hash) (plumbing.EncodedObject, error) {
 	for _, o := range o.db {
 		if o.Hash() == h {

--- a/plumbing/storer/object_test.go
+++ b/plumbing/storer/object_test.go
@@ -3,7 +3,6 @@ package storer
 import (
 	"fmt"
 	"testing"
-	"time"
 
 	. "gopkg.in/check.v1"
 	"gopkg.in/src-d/go-git.v4/plumbing"
@@ -157,24 +156,4 @@ func (o *MockObjectStorage) IterEncodedObjects(t plumbing.ObjectType) (EncodedOb
 
 func (o *MockObjectStorage) Begin() Transaction {
 	return nil
-}
-
-func (o *MockObjectStorage) ForEachObjectHash(fun func(plumbing.Hash) error) error {
-	return nil
-}
-
-func (o *MockObjectStorage) LooseObjectTime(plumbing.Hash) (time.Time, error) {
-	return time.Time{}, plumbing.ErrObjectNotFound
-}
-
-func (o *MockObjectStorage) DeleteLooseObject(plumbing.Hash) error {
-	return plumbing.ErrObjectNotFound
-}
-
-func (o *MockObjectStorage) ObjectPacks() ([]plumbing.Hash, error) {
-	return nil, nil
-}
-
-func (o *MockObjectStorage) DeleteOldObjectPackAndIndex(plumbing.Hash, time.Time) error {
-	return plumbing.ErrObjectNotFound
 }

--- a/plumbing/storer/object_test.go
+++ b/plumbing/storer/object_test.go
@@ -3,6 +3,7 @@ package storer
 import (
 	"fmt"
 	"testing"
+	"time"
 
 	. "gopkg.in/check.v1"
 	"gopkg.in/src-d/go-git.v4/plumbing"
@@ -147,4 +148,16 @@ func (o *MockObjectStorage) IterEncodedObjects(t plumbing.ObjectType) (EncodedOb
 
 func (o *MockObjectStorage) Begin() Transaction {
 	return nil
+}
+
+func (o *MockObjectStorage) ForEachObjectHash(fun func(plumbing.Hash) error) error {
+	return nil
+}
+
+func (o *MockObjectStorage) LooseObjectTime(plumbing.Hash) (time.Time, error) {
+	return time.Time{}, plumbing.ErrObjectNotFound
+}
+
+func (o *MockObjectStorage) DeleteLooseObject(plumbing.Hash) error {
+	return plumbing.ErrObjectNotFound
 }

--- a/plumbing/storer/object_test.go
+++ b/plumbing/storer/object_test.go
@@ -161,3 +161,7 @@ func (o *MockObjectStorage) LooseObjectTime(plumbing.Hash) (time.Time, error) {
 func (o *MockObjectStorage) DeleteLooseObject(plumbing.Hash) error {
 	return plumbing.ErrObjectNotFound
 }
+
+func (o *MockObjectStorage) ObjectPacks() ([]plumbing.Hash, error) {
+	return nil, nil
+}

--- a/plumbing/storer/reference.go
+++ b/plumbing/storer/reference.go
@@ -24,6 +24,8 @@ type ReferenceStorer interface {
 	Reference(plumbing.ReferenceName) (*plumbing.Reference, error)
 	IterReferences() (ReferenceIter, error)
 	RemoveReference(plumbing.ReferenceName) error
+	CountLooseRefs() (int, error)
+	PackRefs() error
 }
 
 // ReferenceIter is a generic closable interface for iterating over references.

--- a/prune.go
+++ b/prune.go
@@ -1,0 +1,145 @@
+package git
+
+import (
+	"fmt"
+	"time"
+
+	"gopkg.in/src-d/go-git.v4/plumbing"
+	"gopkg.in/src-d/go-git.v4/plumbing/filemode"
+	"gopkg.in/src-d/go-git.v4/plumbing/object"
+	"gopkg.in/src-d/go-git.v4/storage"
+)
+
+type PruneHandler func(unreferencedObjectHash plumbing.Hash) error
+type PruneOptions struct {
+	// OnlyObjectsOlderThan if set to non-zero value
+	// selects only objects older than the time provided.
+	OnlyObjectsOlderThan time.Time
+	// Handler is called on matching objects
+	Handler PruneHandler
+}
+
+// DeleteObject deletes an object from a repository.
+// The type conveniently matches PruneHandler.
+func (r *Repository) DeleteObject(hash plumbing.Hash) error {
+	return r.Storer.DeleteLooseObject(hash)
+}
+
+func (r *Repository) Prune(opt PruneOptions) error {
+	pw := &pruneWalker{
+		Storer: r.Storer,
+		seen:   map[plumbing.Hash]struct{}{},
+	}
+	// Walk over all the references in the repo.
+	it, err := r.Storer.IterReferences()
+	if err != nil {
+		return nil
+	}
+	defer it.Close()
+	err = it.ForEach(func(ref *plumbing.Reference) error {
+		// Exit this iteration early for non-hash references.
+		if ref.Type() != plumbing.HashReference {
+			return nil
+		}
+		return pw.walkObjectTree(ref.Hash())
+	})
+	if err != nil {
+		return err
+	}
+	// Now walk all (loose) objects in storage.
+	err = r.Storer.ForEachObjectHash(func(hash plumbing.Hash) error {
+		// Get out if we have seen this object.
+		if pw.isSeen(hash) {
+			return nil
+		}
+		// Otherwise it is a candidate for pruning.
+		// Check out for too new objects next.
+		if opt.OnlyObjectsOlderThan != (time.Time{}) {
+			// Errors here are non-fatal. The object may be e.g. packed.
+			// Or concurrently deleted. Skip such objects.
+			t, err := r.Storer.LooseObjectTime(hash)
+			if err != nil {
+				return nil
+			}
+			// Skip too new objects.
+			if !t.Before(opt.OnlyObjectsOlderThan) {
+				return nil
+			}
+		}
+		return opt.Handler(hash)
+	})
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+type pruneWalker struct {
+	Storer storage.Storer
+	// seen is the set of objects seen in the repo.
+	// seen map can become huge if walking over large
+	// repos. Thus using struct{} as the value type.
+	seen map[plumbing.Hash]struct{}
+}
+
+func (p *pruneWalker) isSeen(hash plumbing.Hash) bool {
+	_, seen := p.seen[hash]
+	return seen
+}
+
+func (p *pruneWalker) add(hash plumbing.Hash) {
+	p.seen[hash] = struct{}{}
+}
+
+// walkObjectTree walks over all objects and remembers references
+// to them in the pruneWalker. This is used instead of the revlist
+// walks because memory usage is tight with huge repos.
+func (p *pruneWalker) walkObjectTree(hash plumbing.Hash) error {
+	// Check if we have already seen, and mark this object
+	if p.isSeen(hash) {
+		return nil
+	}
+	p.add(hash)
+	// Fetch the object.
+	obj, err := object.GetObject(p.Storer, hash)
+	if err != nil {
+		return fmt.Errorf("Getting object %s failed: %v", hash, err)
+	}
+	// Walk all children depending on object type.
+	switch obj := obj.(type) {
+	case *object.Commit:
+		err = p.walkObjectTree(obj.TreeHash)
+		if err != nil {
+			return err
+		}
+		for _, h := range obj.ParentHashes {
+			err = p.walkObjectTree(h)
+			if err != nil {
+				return err
+			}
+		}
+	case *object.Tree:
+		for i := range obj.Entries {
+			// Shortcut for blob objects:
+			// 'or' the lower bits of a mode and check that it
+			// it matches a filemode.Executable. The type information
+			// is in the higher bits, but this is the cleanest way
+			// to handle plain files with different modes.
+			// Other non-tree objects are somewhat rare, so they
+			// are not special-cased.
+			if obj.Entries[i].Mode|0755 == filemode.Executable {
+				p.add(obj.Entries[i].Hash)
+				continue
+			}
+			// Normal walk for sub-trees (and symlinks etc).
+			err = p.walkObjectTree(obj.Entries[i].Hash)
+			if err != nil {
+				return err
+			}
+		}
+	default:
+		// Error out on unhandled object types.
+		return fmt.Errorf("Unknown object %X %s %T\n", obj.ID(), obj.Type(), obj)
+	}
+	return nil
+}

--- a/prune.go
+++ b/prune.go
@@ -1,9 +1,11 @@
 package git
 
 import (
+	"errors"
 	"time"
 
 	"gopkg.in/src-d/go-git.v4/plumbing"
+	"gopkg.in/src-d/go-git.v4/plumbing/storer"
 )
 
 type PruneHandler func(unreferencedObjectHash plumbing.Hash) error
@@ -15,20 +17,32 @@ type PruneOptions struct {
 	Handler PruneHandler
 }
 
+var ErrLooseObjectsNotSupported = errors.New("Loose objects not supported")
+
 // DeleteObject deletes an object from a repository.
 // The type conveniently matches PruneHandler.
 func (r *Repository) DeleteObject(hash plumbing.Hash) error {
-	return r.Storer.DeleteLooseObject(hash)
+	los, ok := r.Storer.(storer.LooseObjectStorer)
+	if !ok {
+		return ErrLooseObjectsNotSupported
+	}
+
+	return los.DeleteLooseObject(hash)
 }
 
 func (r *Repository) Prune(opt PruneOptions) error {
+	los, ok := r.Storer.(storer.LooseObjectStorer)
+	if !ok {
+		return ErrLooseObjectsNotSupported
+	}
+
 	pw := newObjectWalker(r.Storer)
 	err := pw.walkAllRefs()
 	if err != nil {
 		return err
 	}
 	// Now walk all (loose) objects in storage.
-	return r.Storer.ForEachObjectHash(func(hash plumbing.Hash) error {
+	return los.ForEachObjectHash(func(hash plumbing.Hash) error {
 		// Get out if we have seen this object.
 		if pw.isSeen(hash) {
 			return nil
@@ -38,7 +52,7 @@ func (r *Repository) Prune(opt PruneOptions) error {
 		if opt.OnlyObjectsOlderThan != (time.Time{}) {
 			// Errors here are non-fatal. The object may be e.g. packed.
 			// Or concurrently deleted. Skip such objects.
-			t, err := r.Storer.LooseObjectTime(hash)
+			t, err := los.LooseObjectTime(hash)
 			if err != nil {
 				return nil
 			}

--- a/prune.go
+++ b/prune.go
@@ -1,13 +1,9 @@
 package git
 
 import (
-	"fmt"
 	"time"
 
 	"gopkg.in/src-d/go-git.v4/plumbing"
-	"gopkg.in/src-d/go-git.v4/plumbing/filemode"
-	"gopkg.in/src-d/go-git.v4/plumbing/object"
-	"gopkg.in/src-d/go-git.v4/storage"
 )
 
 type PruneHandler func(unreferencedObjectHash plumbing.Hash) error
@@ -26,23 +22,8 @@ func (r *Repository) DeleteObject(hash plumbing.Hash) error {
 }
 
 func (r *Repository) Prune(opt PruneOptions) error {
-	pw := &pruneWalker{
-		Storer: r.Storer,
-		seen:   map[plumbing.Hash]struct{}{},
-	}
-	// Walk over all the references in the repo.
-	it, err := r.Storer.IterReferences()
-	if err != nil {
-		return nil
-	}
-	defer it.Close()
-	err = it.ForEach(func(ref *plumbing.Reference) error {
-		// Exit this iteration early for non-hash references.
-		if ref.Type() != plumbing.HashReference {
-			return nil
-		}
-		return pw.walkObjectTree(ref.Hash())
-	})
+	pw := newObjectWalker(r.Storer)
+	err := pw.walkAllRefs()
 	if err != nil {
 		return err
 	}
@@ -70,76 +51,6 @@ func (r *Repository) Prune(opt PruneOptions) error {
 	})
 	if err != nil {
 		return err
-	}
-	return nil
-}
-
-type pruneWalker struct {
-	Storer storage.Storer
-	// seen is the set of objects seen in the repo.
-	// seen map can become huge if walking over large
-	// repos. Thus using struct{} as the value type.
-	seen map[plumbing.Hash]struct{}
-}
-
-func (p *pruneWalker) isSeen(hash plumbing.Hash) bool {
-	_, seen := p.seen[hash]
-	return seen
-}
-
-func (p *pruneWalker) add(hash plumbing.Hash) {
-	p.seen[hash] = struct{}{}
-}
-
-// walkObjectTree walks over all objects and remembers references
-// to them in the pruneWalker. This is used instead of the revlist
-// walks because memory usage is tight with huge repos.
-func (p *pruneWalker) walkObjectTree(hash plumbing.Hash) error {
-	// Check if we have already seen, and mark this object
-	if p.isSeen(hash) {
-		return nil
-	}
-	p.add(hash)
-	// Fetch the object.
-	obj, err := object.GetObject(p.Storer, hash)
-	if err != nil {
-		return fmt.Errorf("Getting object %s failed: %v", hash, err)
-	}
-	// Walk all children depending on object type.
-	switch obj := obj.(type) {
-	case *object.Commit:
-		err = p.walkObjectTree(obj.TreeHash)
-		if err != nil {
-			return err
-		}
-		for _, h := range obj.ParentHashes {
-			err = p.walkObjectTree(h)
-			if err != nil {
-				return err
-			}
-		}
-	case *object.Tree:
-		for i := range obj.Entries {
-			// Shortcut for blob objects:
-			// 'or' the lower bits of a mode and check that it
-			// it matches a filemode.Executable. The type information
-			// is in the higher bits, but this is the cleanest way
-			// to handle plain files with different modes.
-			// Other non-tree objects are somewhat rare, so they
-			// are not special-cased.
-			if obj.Entries[i].Mode|0755 == filemode.Executable {
-				p.add(obj.Entries[i].Hash)
-				continue
-			}
-			// Normal walk for sub-trees (and symlinks etc).
-			err = p.walkObjectTree(obj.Entries[i].Hash)
-			if err != nil {
-				return err
-			}
-		}
-	default:
-		// Error out on unhandled object types.
-		return fmt.Errorf("Unknown object %X %s %T\n", obj.ID(), obj.Type(), obj)
 	}
 	return nil
 }

--- a/prune.go
+++ b/prune.go
@@ -28,7 +28,7 @@ func (r *Repository) Prune(opt PruneOptions) error {
 		return err
 	}
 	// Now walk all (loose) objects in storage.
-	err = r.Storer.ForEachObjectHash(func(hash plumbing.Hash) error {
+	return r.Storer.ForEachObjectHash(func(hash plumbing.Hash) error {
 		// Get out if we have seen this object.
 		if pw.isSeen(hash) {
 			return nil
@@ -49,8 +49,4 @@ func (r *Repository) Prune(opt PruneOptions) error {
 		}
 		return opt.Handler(hash)
 	})
-	if err != nil {
-		return err
-	}
-	return nil
 }

--- a/prune_test.go
+++ b/prune_test.go
@@ -18,7 +18,7 @@ type PruneSuite struct {
 
 var _ = Suite(&PruneSuite{})
 
-func (s *PruneSuite) TestPrune(c *C, deleteTime time.Time) {
+func (s *PruneSuite) testPrune(c *C, deleteTime time.Time) {
 	srcFs := fixtures.ByTag("unpacked").One().DotGit()
 	var sto storage.Storer
 	var err error
@@ -46,7 +46,8 @@ func (s *PruneSuite) TestPrune(c *C, deleteTime time.Time) {
 	c.Assert(err, IsNil)
 
 	err = r.Prune(PruneOptions{
-		Handler: r.DeleteObject,
+		OnlyObjectsOlderThan: deleteTime,
+		Handler:              r.DeleteObject,
 	})
 	c.Assert(err, IsNil)
 

--- a/prune_test.go
+++ b/prune_test.go
@@ -1,0 +1,72 @@
+package git
+
+import (
+	"time"
+
+	"gopkg.in/src-d/go-git.v4/plumbing"
+	"gopkg.in/src-d/go-git.v4/plumbing/storer"
+	"gopkg.in/src-d/go-git.v4/storage"
+	"gopkg.in/src-d/go-git.v4/storage/filesystem"
+
+	. "gopkg.in/check.v1"
+	"gopkg.in/src-d/go-git-fixtures.v3"
+)
+
+type PruneSuite struct {
+	BaseSuite
+}
+
+var _ = Suite(&PruneSuite{})
+
+func (s *PruneSuite) TestPrune(c *C, deleteTime time.Time) {
+	srcFs := fixtures.ByTag("unpacked").One().DotGit()
+	var sto storage.Storer
+	var err error
+	sto, err = filesystem.NewStorage(srcFs)
+	c.Assert(err, IsNil)
+
+	los := sto.(storer.LooseObjectStorer)
+	c.Assert(los, NotNil)
+
+	count := 0
+	err = los.ForEachObjectHash(func(_ plumbing.Hash) error {
+		count++
+		return nil
+	})
+	c.Assert(err, IsNil)
+
+	r, err := Open(sto, srcFs)
+	c.Assert(err, IsNil)
+	c.Assert(r, NotNil)
+
+	// Remove a branch so we can prune some objects.
+	err = sto.RemoveReference(plumbing.ReferenceName("refs/heads/v4"))
+	c.Assert(err, IsNil)
+	err = sto.RemoveReference(plumbing.ReferenceName("refs/remotes/origin/v4"))
+	c.Assert(err, IsNil)
+
+	err = r.Prune(PruneOptions{
+		Handler: r.DeleteObject,
+	})
+	c.Assert(err, IsNil)
+
+	newCount := 0
+	err = los.ForEachObjectHash(func(_ plumbing.Hash) error {
+		newCount++
+		return nil
+	})
+	if deleteTime.IsZero() {
+		c.Assert(newCount < count, Equals, true)
+	} else {
+		// Assume a delete time older than any of the objects was passed in.
+		c.Assert(newCount, Equals, count)
+	}
+}
+
+func (s *PruneSuite) TestPrune(c *C) {
+	s.testPrune(c, time.Time{})
+}
+
+func (s *PruneSuite) TestPruneWithNoDelete(c *C) {
+	s.testPrune(c, time.Unix(0, 1))
+}

--- a/repository.go
+++ b/repository.go
@@ -1018,8 +1018,6 @@ type RepackConfig struct {
 	// UseRefDeltas configures whether packfile encoder will use reference deltas.
 	// By default OFSDeltaObject is used.
 	UseRefDeltas bool
-	// PackWindow for packing objects.
-	PackWindow uint
 	// OnlyDeletePacksOlderThan if set to non-zero value
 	// selects only objects older than the time provided.
 	OnlyDeletePacksOlderThan time.Time
@@ -1078,8 +1076,12 @@ func (r *Repository) createNewObjectPack(cfg *RepackConfig) (h plumbing.Hash, er
 	if err != nil {
 		return h, err
 	}
+	scfg, err := r.Storer.Config()
+	if err != nil {
+		return h, err
+	}
 	enc := packfile.NewEncoder(wc, r.Storer, cfg.UseRefDeltas)
-	h, err = enc.Encode(objs, cfg.PackWindow)
+	h, err = enc.Encode(objs, scfg.Pack.Window)
 	if err != nil {
 		return h, err
 	}

--- a/repository.go
+++ b/repository.go
@@ -12,6 +12,7 @@ import (
 	"gopkg.in/src-d/go-git.v4/config"
 	"gopkg.in/src-d/go-git.v4/internal/revision"
 	"gopkg.in/src-d/go-git.v4/plumbing"
+	"gopkg.in/src-d/go-git.v4/plumbing/format/packfile"
 	"gopkg.in/src-d/go-git.v4/plumbing/object"
 	"gopkg.in/src-d/go-git.v4/plumbing/storer"
 	"gopkg.in/src-d/go-git.v4/storage"
@@ -1010,4 +1011,65 @@ func (r *Repository) ResolveRevision(rev plumbing.Revision) (*plumbing.Hash, err
 	}
 
 	return &commit.Hash, nil
+}
+
+func (r *Repository) RepackObjects() (err error) {
+	// Get the existing object packs.
+	hs, err := r.Storer.ObjectPacks()
+	if err != nil {
+		return err
+	}
+
+	// Create a new pack.
+	nh, err := r.createNewObjectPack()
+	if err != nil {
+		return err
+	}
+
+	// Delete old packs.
+	for _, h := range hs {
+		// Skip if new hash is the same as an old one.
+		if h == nh {
+			continue
+		}
+		err = r.Storer.DeleteObjectPackAndIndex(h)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// createNewObjectPack is a helper for RepackObjects taking care
+// of creating a new pack. It is used so the the PackfileWriter
+// deferred close has the right scope.
+func (r *Repository) createNewObjectPack() (h plumbing.Hash, err error) {
+	pfw, ok := r.Storer.(storer.PackfileWriter)
+	if !ok {
+		return h, fmt.Errorf("Repository storer is not a storer.PackfileWriter")
+	}
+	wc, err := pfw.PackfileWriter(nil)
+	if err != nil {
+		return h, err
+	}
+	defer ioutil.CheckClose(wc, &err)
+	var objs []plumbing.Hash
+	iter, err := r.Storer.IterEncodedObjects(plumbing.AnyObject)
+	if err != nil {
+		return h, err
+	}
+	err = iter.ForEach(func(obj plumbing.EncodedObject) error {
+		objs = append(objs, obj.Hash())
+		return nil
+	})
+	if err != nil {
+		return h, err
+	}
+	enc := packfile.NewEncoder(wc, r.Storer, false)
+	h, err = enc.Encode(objs, 10, nil)
+	if err != nil {
+		return h, err
+	}
+	return h, err
 }

--- a/repository.go
+++ b/repository.go
@@ -1088,5 +1088,22 @@ func (r *Repository) createNewObjectPack(cfg *RepackConfig) (h plumbing.Hash, er
 	if err != nil {
 		return h, err
 	}
+
+	// Delete the packed, loose objects.
+	if los, ok := r.Storer.(storer.LooseObjectStorer); ok {
+		err = los.ForEachObjectHash(func(hash plumbing.Hash) error {
+			if ow.isSeen(hash) {
+				err := los.DeleteLooseObject(hash)
+				if err != nil {
+					return err
+				}
+			}
+			return nil
+		})
+		if err != nil {
+			return h, err
+		}
+	}
+
 	return h, err
 }

--- a/repository.go
+++ b/repository.go
@@ -8,12 +8,10 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"time"
 
 	"gopkg.in/src-d/go-git.v4/config"
 	"gopkg.in/src-d/go-git.v4/internal/revision"
 	"gopkg.in/src-d/go-git.v4/plumbing"
-	"gopkg.in/src-d/go-git.v4/plumbing/filemode"
 	"gopkg.in/src-d/go-git.v4/plumbing/object"
 	"gopkg.in/src-d/go-git.v4/plumbing/storer"
 	"gopkg.in/src-d/go-git.v4/storage"
@@ -1012,126 +1010,4 @@ func (r *Repository) ResolveRevision(rev plumbing.Revision) (*plumbing.Hash, err
 	}
 
 	return &commit.Hash, nil
-}
-
-type PruneHandler func(unreferencedObjectHash plumbing.Hash) error
-type PruneOptions struct {
-	// OnlyObjectsOlderThan if set to non-zero value
-	// selects only objects older than the time provided.
-	OnlyObjectsOlderThan time.Time
-	// Handler is called on matching objects
-	Handler PruneHandler
-}
-
-// DeleteObject deletes an object from a repository.
-// The type conveniently matches PruneHandler.
-func (r *Repository) DeleteObject(hash plumbing.Hash) error {
-	return r.Storer.DeleteLooseObject(hash)
-}
-
-func (r *Repository) Prune(opt PruneOptions) error {
-	pw := &pruneWalker{
-		r:    r,
-		seen: map[plumbing.Hash]struct{}{},
-	}
-	// Walk over all the references in the repo.
-	it, err := r.Storer.IterReferences()
-	if err != nil {
-		return nil
-	}
-	defer it.Close()
-	err = it.ForEach(func(ref *plumbing.Reference) error {
-		// Exit this iteration early for non-hash references.
-		if ref.Type() != plumbing.HashReference {
-			return nil
-		}
-		return pw.walkObjectTree(ref.Hash())
-	})
-	if err != nil {
-		return err
-	}
-	// Now walk all (loose) objects in storage.
-	err = r.Storer.ForEachObjectHash(func(hash plumbing.Hash) error {
-		// Get out if we have seen this object.
-		if pw.isSeen(hash) {
-			return nil
-		}
-		// Otherwise it is a candidate for pruning.
-		// Check out for too new objects next.
-		if opt.OnlyObjectsOlderThan != (time.Time{}) {
-			// Errors here are non-fatal. The object may be e.g. packed.
-			// Or concurrently deleted. Skip such objects.
-			t, err := r.Storer.LooseObjectTime(hash)
-			if err != nil {
-				return nil
-			}
-			// Skip too new objects.
-			if !t.Before(opt.OnlyObjectsOlderThan) {
-				return nil
-			}
-		}
-		return opt.Handler(hash)
-	})
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
-type pruneWalker struct {
-	r    *Repository
-	seen map[plumbing.Hash]struct{}
-}
-
-func (p *pruneWalker) isSeen(hash plumbing.Hash) bool {
-	_, seen := p.seen[hash]
-	return seen
-}
-
-func (p *pruneWalker) add(hash plumbing.Hash) {
-	p.seen[hash] = struct{}{}
-}
-
-func (p *pruneWalker) walkObjectTree(hash plumbing.Hash) error {
-	// Check if we have already seen, and mark this object
-	if p.isSeen(hash) {
-		return nil
-	}
-	p.add(hash)
-	// Fetch the object.
-	obj, err := object.GetObject(p.r.Storer, hash)
-	if err != nil {
-		return fmt.Errorf("Getting object %s failed: %v", hash, err)
-	}
-	// Walk all children depending on object type.
-	switch obj := obj.(type) {
-	case *object.Commit:
-		err = p.walkObjectTree(obj.TreeHash)
-		if err != nil {
-			return err
-		}
-		for _, h := range obj.ParentHashes {
-			err = p.walkObjectTree(h)
-			if err != nil {
-				return err
-			}
-		}
-	case *object.Tree:
-		for i := range obj.Entries {
-			// Shortcut for blob objects:
-			if obj.Entries[i].Mode|0755 == filemode.Executable {
-				p.add(obj.Entries[i].Hash)
-				continue
-			}
-			// Normal walk for sub-trees (and symlinks etc).
-			err = p.walkObjectTree(obj.Entries[i].Hash)
-			if err != nil {
-				return err
-			}
-		}
-	default:
-		// Error out on unhandled object types.
-		return fmt.Errorf("Unknown object %X %s %T\n", obj.ID(), obj.Type(), obj)
-	}
-	return nil
 }

--- a/repository.go
+++ b/repository.go
@@ -8,10 +8,12 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"gopkg.in/src-d/go-git.v4/config"
 	"gopkg.in/src-d/go-git.v4/internal/revision"
 	"gopkg.in/src-d/go-git.v4/plumbing"
+	"gopkg.in/src-d/go-git.v4/plumbing/filemode"
 	"gopkg.in/src-d/go-git.v4/plumbing/object"
 	"gopkg.in/src-d/go-git.v4/plumbing/storer"
 	"gopkg.in/src-d/go-git.v4/storage"
@@ -1010,4 +1012,126 @@ func (r *Repository) ResolveRevision(rev plumbing.Revision) (*plumbing.Hash, err
 	}
 
 	return &commit.Hash, nil
+}
+
+type PruneHandler func(unreferencedObjectHash plumbing.Hash) error
+type PruneOptions struct {
+	// OnlyObjectsOlderThan if set to non-zero value
+	// selects only objects older than the time provided.
+	OnlyObjectsOlderThan time.Time
+	// Handler is called on matching objects
+	Handler PruneHandler
+}
+
+// DeleteObject deletes an object from a repository.
+// The type conveniently matches PruneHandler.
+func (r *Repository) DeleteObject(hash plumbing.Hash) error {
+	return r.Storer.DeleteLooseObject(hash)
+}
+
+func (r *Repository) Prune(opt PruneOptions) error {
+	pw := &pruneWalker{
+		r:    r,
+		seen: map[plumbing.Hash]struct{}{},
+	}
+	// Walk over all the references in the repo.
+	it, err := r.Storer.IterReferences()
+	if err != nil {
+		return nil
+	}
+	defer it.Close()
+	err = it.ForEach(func(ref *plumbing.Reference) error {
+		// Exit this iteration early for non-hash references.
+		if ref.Type() != plumbing.HashReference {
+			return nil
+		}
+		return pw.walkObjectTree(ref.Hash())
+	})
+	if err != nil {
+		return err
+	}
+	// Now walk all (loose) objects in storage.
+	err = r.Storer.ForEachObjectHash(func(hash plumbing.Hash) error {
+		// Get out if we have seen this object.
+		if pw.isSeen(hash) {
+			return nil
+		}
+		// Otherwise it is a candidate for pruning.
+		// Check out for too new objects next.
+		if opt.OnlyObjectsOlderThan != (time.Time{}) {
+			// Errors here are non-fatal. The object may be e.g. packed.
+			// Or concurrently deleted. Skip such objects.
+			t, err := r.Storer.LooseObjectTime(hash)
+			if err != nil {
+				return nil
+			}
+			// Skip too new objects.
+			if !t.Before(opt.OnlyObjectsOlderThan) {
+				return nil
+			}
+		}
+		return opt.Handler(hash)
+	})
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+type pruneWalker struct {
+	r    *Repository
+	seen map[plumbing.Hash]struct{}
+}
+
+func (p *pruneWalker) isSeen(hash plumbing.Hash) bool {
+	_, seen := p.seen[hash]
+	return seen
+}
+
+func (p *pruneWalker) add(hash plumbing.Hash) {
+	p.seen[hash] = struct{}{}
+}
+
+func (p *pruneWalker) walkObjectTree(hash plumbing.Hash) error {
+	// Check if we have already seen, and mark this object
+	if p.isSeen(hash) {
+		return nil
+	}
+	p.add(hash)
+	// Fetch the object.
+	obj, err := object.GetObject(p.r.Storer, hash)
+	if err != nil {
+		return fmt.Errorf("Getting object %s failed: %v", hash, err)
+	}
+	// Walk all children depending on object type.
+	switch obj := obj.(type) {
+	case *object.Commit:
+		err = p.walkObjectTree(obj.TreeHash)
+		if err != nil {
+			return err
+		}
+		for _, h := range obj.ParentHashes {
+			err = p.walkObjectTree(h)
+			if err != nil {
+				return err
+			}
+		}
+	case *object.Tree:
+		for i := range obj.Entries {
+			// Shortcut for blob objects:
+			if obj.Entries[i].Mode|0755 == filemode.Executable {
+				p.add(obj.Entries[i].Hash)
+				continue
+			}
+			// Normal walk for sub-trees (and symlinks etc).
+			err = p.walkObjectTree(obj.Entries[i].Hash)
+			if err != nil {
+				return err
+			}
+		}
+	default:
+		// Error out on unhandled object types.
+		return fmt.Errorf("Unknown object %X %s %T\n", obj.ID(), obj.Type(), obj)
+	}
+	return nil
 }

--- a/storage/filesystem/internal/dotgit/dotgit.go
+++ b/storage/filesystem/internal/dotgit/dotgit.go
@@ -597,6 +597,10 @@ func (d *DotGit) CountLooseRefs() (int, error) {
 // ref update could also lock packed-refs, so only one lock is
 // required during ref-packing.  But that would worsen performance in
 // the common case.
+//
+// TODO: add an "all" boolean like the `git pack-refs --all` flag.
+// When `all` is false, it would only pack refs that have already been
+// packed, plus all tags.
 func (d *DotGit) PackRefs() (err error) {
 	// Lock packed-refs, and create it if it doesn't exist yet.
 	f, err := d.fs.Open(packedRefsPath)

--- a/storage/filesystem/internal/dotgit/dotgit.go
+++ b/storage/filesystem/internal/dotgit/dotgit.go
@@ -205,39 +205,67 @@ func (d *DotGit) NewObject() (*ObjectWriter, error) {
 // Objects returns a slice with the hashes of objects found under the
 // .git/objects/ directory.
 func (d *DotGit) Objects() ([]plumbing.Hash, error) {
+	var objects []plumbing.Hash
+	err := d.ForEachObjectHash(func(hash plumbing.Hash) error {
+		objects = append(objects, hash)
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return objects, nil
+}
+
+// Objects returns a slice with the hashes of objects found under the
+// .git/objects/ directory.
+func (d *DotGit) ForEachObjectHash(fun func(plumbing.Hash) error) error {
 	files, err := d.fs.ReadDir(objectsPath)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return nil, nil
+			return nil
 		}
 
-		return nil, err
+		return err
 	}
 
-	var objects []plumbing.Hash
 	for _, f := range files {
 		if f.IsDir() && len(f.Name()) == 2 && isHex(f.Name()) {
 			base := f.Name()
 			d, err := d.fs.ReadDir(d.fs.Join(objectsPath, base))
 			if err != nil {
-				return nil, err
+				return err
 			}
 
 			for _, o := range d {
-				objects = append(objects, plumbing.NewHash(base+o.Name()))
+				err = fun(plumbing.NewHash(base + o.Name()))
+				if err != nil {
+					return err
+				}
 			}
 		}
 	}
 
-	return objects, nil
+	return nil
 }
 
-// Object return a fs.File pointing the object file, if exists
-func (d *DotGit) Object(h plumbing.Hash) (billy.File, error) {
+func (d *DotGit) objectPath(h plumbing.Hash) string {
 	hash := h.String()
-	file := d.fs.Join(objectsPath, hash[0:2], hash[2:40])
+	return d.fs.Join(objectsPath, hash[0:2], hash[2:40])
+}
 
-	return d.fs.Open(file)
+// Object returns a fs.File pointing the object file, if exists
+func (d *DotGit) Object(h plumbing.Hash) (billy.File, error) {
+	return d.fs.Open(d.objectPath(h))
+}
+
+// ObjectStat returns a os.FileInfo pointing the object file, if exists
+func (d *DotGit) ObjectStat(h plumbing.Hash) (os.FileInfo, error) {
+	return d.fs.Stat(d.objectPath(h))
+}
+
+// ObjectDelete removes the object file, if exists
+func (d *DotGit) ObjectDelete(h plumbing.Hash) error {
+	return d.fs.Remove(d.objectPath(h))
 }
 
 func (d *DotGit) readReferenceFrom(rd io.Reader, name string) (ref *plumbing.Reference, err error) {

--- a/storage/filesystem/internal/dotgit/dotgit_rewrite_packed_refs_nix.go
+++ b/storage/filesystem/internal/dotgit/dotgit_rewrite_packed_refs_nix.go
@@ -1,0 +1,11 @@
+// +build !windows
+
+package dotgit
+
+import "gopkg.in/src-d/go-billy.v4"
+
+func (d *DotGit) rewritePackedRefsWhileLocked(
+	tmp billy.File, pr billy.File) error {
+	// On non-Windows platforms, we can have atomic rename.
+	return d.fs.Rename(tmp.Name(), pr.Name())
+}

--- a/storage/filesystem/internal/dotgit/dotgit_rewrite_packed_refs_windows.go
+++ b/storage/filesystem/internal/dotgit/dotgit_rewrite_packed_refs_windows.go
@@ -1,0 +1,39 @@
+// +build windows
+
+package dotgit
+
+import (
+	"io"
+
+	"gopkg.in/src-d/go-billy.v4"
+)
+
+func (d *DotGit) rewritePackedRefsWhileLocked(
+	tmp billy.File, pr billy.File) error {
+	// If we aren't using the bare Windows filesystem as the storage
+	// layer, we might be able to get away with a rename over a locked
+	// file.
+	err := d.fs.Rename(tmp.Name(), pr.Name())
+	if err == nil {
+		return nil
+	}
+
+	// Otherwise, Windows doesn't let us rename over a locked file, so
+	// we have to do a straight copy.  Unfortunately this could result
+	// in a partially-written file if the process fails before the
+	// copy completes.
+	_, err = pr.Seek(0, io.SeekStart)
+	if err != nil {
+		return err
+	}
+	err = pr.Truncate(0)
+	if err != nil {
+		return err
+	}
+	_, err = tmp.Seek(0, io.SeekStart)
+	if err != nil {
+		return err
+	}
+	_, err = io.Copy(pr, tmp)
+	return err
+}

--- a/storage/filesystem/object.go
+++ b/storage/filesystem/object.go
@@ -503,3 +503,11 @@ func (s *ObjectStorage) LooseObjectTime(hash plumbing.Hash) (time.Time, error) {
 func (s *ObjectStorage) DeleteLooseObject(hash plumbing.Hash) error {
 	return s.dir.ObjectDelete(hash)
 }
+
+func (s *ObjectStorage) ObjectPacks() ([]plumbing.Hash, error) {
+	return s.dir.ObjectPacks()
+}
+
+func (s *ObjectStorage) DeleteObjectPackAndIndex(h plumbing.Hash) error {
+	return s.dir.DeleteObjectPackAndIndex(h)
+}

--- a/storage/filesystem/object.go
+++ b/storage/filesystem/object.go
@@ -126,6 +126,32 @@ func (s *ObjectStorage) SetEncodedObject(o plumbing.EncodedObject) (plumbing.Has
 	return o.Hash(), err
 }
 
+// HasEncodedObject returns nil if the object exists, without actually
+// reading the object data from storage.
+func (s *ObjectStorage) HasEncodedObject(h plumbing.Hash) (err error) {
+	// Check unpacked objects
+	f, err := s.dir.Object(h)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			return err
+		}
+		// Fall through to check packed objects.
+	} else {
+		defer ioutil.CheckClose(f, &err)
+		return nil
+	}
+
+	// Check packed objects.
+	if err := s.requireIndex(); err != nil {
+		return err
+	}
+	_, _, offset := s.findObjectInPackfile(h)
+	if offset == -1 {
+		return plumbing.ErrObjectNotFound
+	}
+	return nil
+}
+
 // EncodedObject returns the object with the given hash, by searching for it in
 // the packfile and the git object directories.
 func (s *ObjectStorage) EncodedObject(t plumbing.ObjectType, h plumbing.Hash) (plumbing.EncodedObject, error) {

--- a/storage/filesystem/object.go
+++ b/storage/filesystem/object.go
@@ -3,6 +3,7 @@ package filesystem
 import (
 	"io"
 	"os"
+	"time"
 
 	"gopkg.in/src-d/go-git.v4/plumbing"
 	"gopkg.in/src-d/go-git.v4/plumbing/cache"
@@ -478,4 +479,27 @@ func hashListAsMap(l []plumbing.Hash) map[plumbing.Hash]bool {
 	}
 
 	return m
+}
+
+func (s *ObjectStorage) ForEachObjectHash(fun func(plumbing.Hash) error) error {
+	err := s.dir.ForEachObjectHash(fun)
+	if err != nil {
+		if err == storer.ErrStop {
+			return nil
+		}
+		return err
+	}
+	return nil
+}
+
+func (s *ObjectStorage) LooseObjectTime(hash plumbing.Hash) (time.Time, error) {
+	fi, err := s.dir.ObjectStat(hash)
+	if err != nil {
+		return time.Time{}, err
+	}
+	return fi.ModTime(), nil
+}
+
+func (s *ObjectStorage) DeleteLooseObject(hash plumbing.Hash) error {
+	return s.dir.ObjectDelete(hash)
 }

--- a/storage/filesystem/object.go
+++ b/storage/filesystem/object.go
@@ -508,6 +508,6 @@ func (s *ObjectStorage) ObjectPacks() ([]plumbing.Hash, error) {
 	return s.dir.ObjectPacks()
 }
 
-func (s *ObjectStorage) DeleteObjectPackAndIndex(h plumbing.Hash) error {
-	return s.dir.DeleteObjectPackAndIndex(h)
+func (s *ObjectStorage) DeleteOldObjectPackAndIndex(h plumbing.Hash, t time.Time) error {
+	return s.dir.DeleteOldObjectPackAndIndex(h, t)
 }

--- a/storage/filesystem/object.go
+++ b/storage/filesystem/object.go
@@ -509,13 +509,10 @@ func hashListAsMap(l []plumbing.Hash) map[plumbing.Hash]bool {
 
 func (s *ObjectStorage) ForEachObjectHash(fun func(plumbing.Hash) error) error {
 	err := s.dir.ForEachObjectHash(fun)
-	if err != nil {
-		if err == storer.ErrStop {
-			return nil
-		}
-		return err
+	if err == storer.ErrStop {
+		return nil
 	}
-	return nil
+	return err
 }
 
 func (s *ObjectStorage) LooseObjectTime(hash plumbing.Hash) (time.Time, error) {

--- a/storage/filesystem/reference.go
+++ b/storage/filesystem/reference.go
@@ -34,3 +34,11 @@ func (r *ReferenceStorage) IterReferences() (storer.ReferenceIter, error) {
 func (r *ReferenceStorage) RemoveReference(n plumbing.ReferenceName) error {
 	return r.dir.RemoveRef(n)
 }
+
+func (r *ReferenceStorage) CountLooseRefs() (int, error) {
+	return r.dir.CountLooseRefs()
+}
+
+func (r *ReferenceStorage) PackRefs() error {
+	return r.dir.PackRefs()
+}

--- a/storage/memory/storage.go
+++ b/storage/memory/storage.go
@@ -173,8 +173,8 @@ func (o *ObjectStorage) ForEachObjectHash(fun func(plumbing.Hash) error) error {
 func (o *ObjectStorage) ObjectPacks() ([]plumbing.Hash, error) {
 	return nil, nil
 }
-func (o *ObjectStorage) DeleteObjectPackAndIndex(plumbing.Hash) error {
-	return errNotSupported
+func (o *ObjectStorage) DeleteOldObjectPackAndIndex(plumbing.Hash, time.Time) error {
+	return nil
 }
 
 var errNotSupported = fmt.Errorf("Not supported")

--- a/storage/memory/storage.go
+++ b/storage/memory/storage.go
@@ -115,6 +115,14 @@ func (o *ObjectStorage) SetEncodedObject(obj plumbing.EncodedObject) (plumbing.H
 	return h, nil
 }
 
+func (o *ObjectStorage) HasEncodedObject(h plumbing.Hash) (err error) {
+	_, ok := o.Objects[h]
+	if !ok {
+		return plumbing.ErrObjectNotFound
+	}
+	return nil
+}
+
 func (o *ObjectStorage) EncodedObject(t plumbing.ObjectType, h plumbing.Hash) (plumbing.EncodedObject, error) {
 	obj, ok := o.Objects[h]
 	if !ok || (plumbing.AnyObject != t && obj.Type() != t) {

--- a/storage/memory/storage.go
+++ b/storage/memory/storage.go
@@ -3,6 +3,7 @@ package memory
 
 import (
 	"fmt"
+	"time"
 
 	"gopkg.in/src-d/go-git.v4/config"
 	"gopkg.in/src-d/go-git.v4/plumbing"
@@ -154,6 +155,28 @@ func (o *ObjectStorage) Begin() storer.Transaction {
 		Storage: o,
 		Objects: make(map[plumbing.Hash]plumbing.EncodedObject),
 	}
+}
+
+func (o *ObjectStorage) ForEachObjectHash(fun func(plumbing.Hash) error) error {
+	for h, _ := range o.Objects {
+		err := fun(h)
+		if err != nil {
+			if err == storer.ErrStop {
+				return nil
+			}
+			return err
+		}
+	}
+	return nil
+}
+
+var errNotSupported = fmt.Errorf("Not supported")
+
+func (s *ObjectStorage) LooseObjectTime(hash plumbing.Hash) (time.Time, error) {
+	return time.Time{}, errNotSupported
+}
+func (s *ObjectStorage) DeleteLooseObject(plumbing.Hash) error {
+	return errNotSupported
 }
 
 type TxObjectStorage struct {

--- a/storage/memory/storage.go
+++ b/storage/memory/storage.go
@@ -116,8 +116,7 @@ func (o *ObjectStorage) SetEncodedObject(obj plumbing.EncodedObject) (plumbing.H
 }
 
 func (o *ObjectStorage) HasEncodedObject(h plumbing.Hash) (err error) {
-	_, ok := o.Objects[h]
-	if !ok {
+	if _, ok := o.Objects[h]; !ok {
 		return plumbing.ErrObjectNotFound
 	}
 	return nil

--- a/storage/memory/storage.go
+++ b/storage/memory/storage.go
@@ -170,6 +170,13 @@ func (o *ObjectStorage) ForEachObjectHash(fun func(plumbing.Hash) error) error {
 	return nil
 }
 
+func (o *ObjectStorage) ObjectPacks() ([]plumbing.Hash, error) {
+	return nil, nil
+}
+func (o *ObjectStorage) DeleteObjectPackAndIndex(plumbing.Hash) error {
+	return errNotSupported
+}
+
 var errNotSupported = fmt.Errorf("Not supported")
 
 func (s *ObjectStorage) LooseObjectTime(hash plumbing.Hash) (time.Time, error) {

--- a/storage/memory/storage.go
+++ b/storage/memory/storage.go
@@ -236,6 +236,14 @@ func (r ReferenceStorage) IterReferences() (storer.ReferenceIter, error) {
 	return storer.NewReferenceSliceIter(refs), nil
 }
 
+func (r ReferenceStorage) CountLooseRefs() (int, error) {
+	return len(r), nil
+}
+
+func (r ReferenceStorage) PackRefs() error {
+	return nil
+}
+
 func (r ReferenceStorage) RemoveReference(n plumbing.ReferenceName) error {
 	delete(r, n)
 	return nil


### PR DESCRIPTION
This PR lays the groundwork for garbage collection.  It adds separate functions for each of the major pieces of garbage collection:

* `ReferenceStorer.PackRefs()` packs all existing refs into a single packed-refs file, and deletes all the other loose refs.  Right now the `dotgit` implementation is equivalent to `git pack-refs --all`.
* `Repository.Prune()` deletes loose, unreferenced objects that are older than a certain specified time.
* `Repository.RepackObjects()` re-packs all referenced objects (including those in packfiles) into a single packfile, and then deletes all other packfiles older than a certain specified time.

Note that for object walking, we've included an alternative implementation from the existing `revlist` implementation, that is more memory-efficient for large repos.

I know the PR is light on tests, but I wanted to get it up quickly to see what the feedback would be.  We've written app-specific tests outside of this repo and are working on more general tests with large repos. Please let me know what types of unit tests you'd like to see added when you review.  Thanks!