### PR TITLE
worktree.go: fix checking out branches on empty repositories

### DIFF
--- a/worktree.go
+++ b/worktree.go
@@ -140,9 +140,9 @@ func (w *Worktree) Checkout(opts *CheckoutOptions) error {
 	}
 
 	if opts.Create {
-		if err := w.createBranch(opts); err != nil {
-			return err
-		}
+		h := plumbing.NewSymbolicReference(plumbing.HEAD, opts.Branch)
+		w.r.Storer.SetReference(h)
+		return nil
 	}
 
 	if !opts.Force {

--- a/worktree.go
+++ b/worktree.go
@@ -140,9 +140,9 @@ func (w *Worktree) Checkout(opts *CheckoutOptions) error {
 	}
 
 	if opts.Create {
-		h := plumbing.NewSymbolicReference(plumbing.HEAD, opts.Branch)
-		w.r.Storer.SetReference(h)
-		return nil
+		if err := w.createBranch(opts); err != nil {
+			return err
+		}
 	}
 
 	if !opts.Force {

--- a/worktree.go
+++ b/worktree.go
@@ -140,9 +140,9 @@ func (w *Worktree) Checkout(opts *CheckoutOptions) error {
 	}
 
 	if opts.Create {
-		if err := w.createBranch(opts); err != nil {
-			return err
-		}
+		h := plumbing.NewSymbolicReference(plumbing.HEAD, opts.Branch)
+		w.r.Storer.SetReference(h)
+		return nil
 	}
 
 	if !opts.Force {
@@ -164,6 +164,21 @@ func (w *Worktree) Checkout(opts *CheckoutOptions) error {
 	ro := &ResetOptions{Commit: c, Mode: MergeReset}
 	if opts.Force {
 		ro.Mode = HardReset
+	}
+
+	if opts.Create {
+		err := w.createBranch(opts)
+		if err != nil {
+			return err
+		}
+
+		err = w.setHEADToBranch(opts.Branch, c)
+		if err == plumbing.ErrObjectNotFound {
+			fmt.Println("ERRRRRR")
+			return nil
+		} else {
+			return err
+		}
 	}
 
 	if !opts.Hash.IsZero() && !opts.Create {


### PR DESCRIPTION
The previous behaviour of `createBranch` when checking out a branch on a git repository with no branches (directly after `git init`) and subsequently making a commit: was to ignore the branch that was checked out and commit to master. Because the case of `plumbing.ErrReferenceNotFound == true` was not handled. This PR now handles that case and creates the branch as expected. 

**Need help with testing**