### PR TITLE
git: worktree, add Clean() method for git clean

### DIFF
--- a/options.go
+++ b/options.go
@@ -360,3 +360,8 @@ type ListOptions struct {
 	// Auth credentials, if required, to use with the remote repository.
 	Auth transport.AuthMethod
 }
+
+// CleanOptions describes how a clean should be performed.
+type CleanOptions struct {
+	Dir bool
+}

--- a/worktree_test.go
+++ b/worktree_test.go
@@ -1252,3 +1252,38 @@ func (s *WorktreeSuite) TestMoveToExistent(c *C) {
 	c.Assert(hash.IsZero(), Equals, true)
 	c.Assert(err, Equals, ErrDestinationExists)
 }
+
+func (s *WorktreeSuite) TestClean(c *C) {
+	fs := fixtures.ByTag("dirty").One().Worktree()
+
+	// Open the repo.
+	fs, err := fs.Chroot("repo")
+	c.Assert(err, IsNil)
+	r, err := PlainOpen(fs.Root())
+	c.Assert(err, IsNil)
+
+	wt, err := r.Worktree()
+	c.Assert(err, IsNil)
+
+	// Status before cleaning.
+	status, err := wt.Status()
+	c.Assert(len(status), Equals, 2)
+
+	err = wt.Clean(&CleanOptions{})
+	c.Assert(err, IsNil)
+
+	// Status after cleaning.
+	status, err = wt.Status()
+	c.Assert(err, IsNil)
+
+	c.Assert(len(status), Equals, 1)
+
+	// Clean with Dir: true.
+	err = wt.Clean(&CleanOptions{Dir: true})
+	c.Assert(err, IsNil)
+
+	status, err = wt.Status()
+	c.Assert(err, IsNil)
+
+	c.Assert(len(status), Equals, 0)
+}


### PR DESCRIPTION
This change implement git clean with a `Dir` option. By default, clean
removes only the untracked files in the working directory. If `Dir`
option is set to true, untracked files under other directories are also
cleaned.

Depends on fixtures from https://github.com/src-d/go-git-fixtures/pull/9 .