### PR TITLE
check .ssh/config for host and port overrides; fixes #629

### DIFF
--- a/plumbing/transport/ssh/common.go
+++ b/plumbing/transport/ssh/common.go
@@ -4,11 +4,13 @@ package ssh
 import (
 	"fmt"
 	"reflect"
+	"strconv"
 
 	"gopkg.in/src-d/go-git.v4/plumbing/transport"
 	"gopkg.in/src-d/go-git.v4/plumbing/transport/internal/common"
 
 	"golang.org/x/crypto/ssh"
+	"github.com/kevinburke/ssh_config"
 )
 
 // DefaultClient is the default SSH client.
@@ -122,7 +124,20 @@ func (c *command) connect() error {
 
 func (c *command) getHostWithPort() string {
 	host := c.endpoint.Host
+
+	configHost := ssh_config.Get(host, "Hostname")
+	if (configHost != "") {
+		host = configHost
+	}
+
 	port := c.endpoint.Port
+	configPort := ssh_config.Get(host, "Port")
+	if (configPort != "") {
+		i, err := strconv.Atoi(configPort)
+		if err != nil {
+			port = i
+		}
+	}
 	if port <= 0 {
 		port = DefaultPort
 	}

--- a/plumbing/transport/ssh/common_test.go
+++ b/plumbing/transport/ssh/common_test.go
@@ -3,9 +3,12 @@ package ssh
 import (
 	"testing"
 
+	"github.com/kevinburke/ssh_config"
+
 	"golang.org/x/crypto/ssh"
 
 	. "gopkg.in/check.v1"
+	"gopkg.in/src-d/go-git.v4/plumbing/transport"
 )
 
 func Test(t *testing.T) { TestingT(t) }
@@ -38,4 +41,68 @@ func (s *SuiteCommon) TestOverrideConfigKeep(c *C) {
 
 	overrideConfig(config, target)
 	c.Assert(target.User, Equals, "foo")
+}
+
+func (s *SuiteCommon) TestDefaultSSHConfig(c *C) {
+	defer func() {
+		DefaultSSHConfig = ssh_config.DefaultUserSettings
+	}()
+
+	DefaultSSHConfig = &mockSSHConfig{map[string]map[string]string{
+		"github.com": map[string]string{
+			"Hostname": "foo.local",
+			"Port":     "42",
+		},
+	}}
+
+	ep, err := transport.NewEndpoint("git@github.com:foo/bar.git")
+	c.Assert(err, IsNil)
+
+	cmd := &command{endpoint: ep}
+	c.Assert(cmd.getHostWithPort(), Equals, "foo.local:42")
+}
+
+func (s *SuiteCommon) TestDefaultSSHConfigNil(c *C) {
+	defer func() {
+		DefaultSSHConfig = ssh_config.DefaultUserSettings
+	}()
+
+	DefaultSSHConfig = nil
+
+	ep, err := transport.NewEndpoint("git@github.com:foo/bar.git")
+	c.Assert(err, IsNil)
+
+	cmd := &command{endpoint: ep}
+	c.Assert(cmd.getHostWithPort(), Equals, "github.com:22")
+}
+
+func (s *SuiteCommon) TestDefaultSSHConfigWildcard(c *C) {
+	defer func() {
+		DefaultSSHConfig = ssh_config.DefaultUserSettings
+	}()
+
+	DefaultSSHConfig = &mockSSHConfig{Values: map[string]map[string]string{
+		"*": map[string]string{
+			"Port": "42",
+		},
+	}}
+
+	ep, err := transport.NewEndpoint("git@github.com:foo/bar.git")
+	c.Assert(err, IsNil)
+
+	cmd := &command{endpoint: ep}
+	c.Assert(cmd.getHostWithPort(), Equals, "github.com:22")
+}
+
+type mockSSHConfig struct {
+	Values map[string]map[string]string
+}
+
+func (c *mockSSHConfig) Get(alias, key string) string {
+	a, ok := c.Values[alias]
+	if !ok {
+		return c.Values["*"][key]
+	}
+
+	return a[key]
 }


### PR DESCRIPTION
I ran into this issue and figured I'd send a PR of what I ended up doing.

Per https://github.com/golang/go/issues/18781 there is no built-in parser for `.ssh/config` so I introduce a dependency on https://github.com/kevinburke/ssh_config

Let me know if you had something else in mind or don't agree with the additional dep.