### PR TITLE
Add a setRef version that supports siva fs

### DIFF
--- a/storage/filesystem/internal/dotgit/dotgit.go
+++ b/storage/filesystem/internal/dotgit/dotgit.go
@@ -323,36 +323,9 @@ func (d *DotGit) SetRef(r, old *plumbing.Reference) error {
 		content = fmt.Sprintln(r.Hash().String())
 	}
 
-	// If we are not checking an old ref, just truncate the file.
-	mode := os.O_RDWR | os.O_CREATE
-	if old == nil {
-		mode |= os.O_TRUNC
-	}
+	fileName := r.Name().String()
 
-	f, err := d.fs.OpenFile(r.Name().String(), mode, 0666)
-	if err != nil {
-		return err
-	}
-
-	defer ioutil.CheckClose(f, &err)
-
-	// Lock is unlocked by the deferred Close above. This is because Unlock
-	// does not imply a fsync and thus there would be a race between
-	// Unlock+Close and other concurrent writers. Adding Sync to go-billy
-	// could work, but this is better (and avoids superfluous syncs).
-	err = f.Lock()
-	if err != nil {
-		return err
-	}
-
-	// this is a no-op to call even when old is nil.
-	err = d.checkReferenceAndTruncate(f, old)
-	if err != nil {
-		return err
-	}
-
-	_, err = f.Write([]byte(content))
-	return err
+	return d.setRef(fileName, content, old)
 }
 
 // Refs scans the git directory collecting references, which it returns.

--- a/storage/filesystem/internal/dotgit/dotgit_setref.go
+++ b/storage/filesystem/internal/dotgit/dotgit_setref.go
@@ -1,0 +1,43 @@
+// +build !siva
+
+package dotgit
+
+import (
+	"os"
+
+	"gopkg.in/src-d/go-git.v4/plumbing"
+	"gopkg.in/src-d/go-git.v4/utils/ioutil"
+)
+
+func (d *DotGit) setRef(fileName, content string, old *plumbing.Reference) error {
+	// If we are not checking an old ref, just truncate the file.
+	mode := os.O_RDWR | os.O_CREATE
+	if old == nil {
+		mode |= os.O_TRUNC
+	}
+
+	f, err := d.fs.OpenFile(fileName, mode, 0666)
+	if err != nil {
+		return err
+	}
+
+	defer ioutil.CheckClose(f, &err)
+
+	// Lock is unlocked by the deferred Close above. This is because Unlock
+	// does not imply a fsync and thus there would be a race between
+	// Unlock+Close and other concurrent writers. Adding Sync to go-billy
+	// could work, but this is better (and avoids superfluous syncs).
+	err = f.Lock()
+	if err != nil {
+		return err
+	}
+
+	// this is a no-op to call even when old is nil.
+	err = d.checkReferenceAndTruncate(f, old)
+	if err != nil {
+		return err
+	}
+
+	_, err = f.Write([]byte(content))
+	return err
+}

--- a/storage/filesystem/internal/dotgit/dotgit_setref_siva.go
+++ b/storage/filesystem/internal/dotgit/dotgit_setref_siva.go
@@ -1,0 +1,17 @@
+// +build siva
+
+package dotgit
+
+import "gopkg.in/src-d/go-git.v4/plumbing"
+
+func (d *DotGit) setRef(fileName, content string, old *plumbing.Reference) error {
+	f, err := d.fs.Create(fileName)
+	if err != nil {
+		return err
+	}
+
+	defer f.Close()
+
+	_, err = f.Write([]byte(content))
+	return err
+}


### PR DESCRIPTION
siva FS only support openning files in read only or write only mode. The
method SetRef is split in files with an extra version that only writes
the reference. It can be activated with `-tags siva` on building.