### PR TITLE
Set default pack window size in config

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -70,7 +70,7 @@ func NewConfig() *Config {
 		Raw:        format.New(),
 	}
 
-	config.Pack.Window = defaultPackWindow
+	config.Pack.Window = DefaultPackWindow
 
 	return config
 }
@@ -101,7 +101,9 @@ const (
 	worktreeKey      = "worktree"
 	windowKey        = "window"
 
-	defaultPackWindow = uint(10)
+	// DefaultPackWindow holds the number of previous objects used to
+	// generate deltas. The value 10 is the same used by git command.
+	DefaultPackWindow = uint(10)
 )
 
 // Unmarshal parses a git-config file and stores it.
@@ -135,7 +137,7 @@ func (c *Config) unmarshalPack() error {
 	s := c.Raw.Section(packSection)
 	window := s.Options.Get(windowKey)
 	if window == "" {
-		c.Pack.Window = defaultPackWindow
+		c.Pack.Window = DefaultPackWindow
 	} else {
 		winUint, err := strconv.ParseUint(window, 10, 32)
 		if err != nil {
@@ -196,7 +198,7 @@ func (c *Config) marshalCore() {
 
 func (c *Config) marshalPack() {
 	s := c.Raw.Section(packSection)
-	if c.Pack.Window != defaultPackWindow {
+	if c.Pack.Window != DefaultPackWindow {
 		s.SetOption(windowKey, fmt.Sprintf("%d", c.Pack.Window))
 	}
 }

--- a/config/config.go
+++ b/config/config.go
@@ -64,11 +64,15 @@ type Config struct {
 
 // NewConfig returns a new empty Config.
 func NewConfig() *Config {
-	return &Config{
+	config := &Config{
 		Remotes:    make(map[string]*RemoteConfig),
 		Submodules: make(map[string]*Submodule),
 		Raw:        format.New(),
 	}
+
+	config.Pack.Window = defaultPackWindow
+
+	return config
 }
 
 // Validate validates the fields and sets the default values.

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -156,3 +156,12 @@ func (s *ConfigSuite) TestRemoteConfigValidateDefault(c *C) {
 	c.Assert(fetch, HasLen, 1)
 	c.Assert(fetch[0].String(), Equals, "+refs/heads/*:refs/remotes/foo/*")
 }
+
+func (s *ConfigSuite) TestRemoteConfigDefaultValues(c *C) {
+	config := NewConfig()
+
+	c.Assert(config.Remotes, HasLen, 0)
+	c.Assert(config.Submodules, HasLen, 0)
+	c.Assert(config.Raw, NotNil)
+	c.Assert(config.Pack.Window, Equals, defaultPackWindow)
+}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -163,5 +163,5 @@ func (s *ConfigSuite) TestRemoteConfigDefaultValues(c *C) {
 	c.Assert(config.Remotes, HasLen, 0)
 	c.Assert(config.Submodules, HasLen, 0)
 	c.Assert(config.Raw, NotNil)
-	c.Assert(config.Pack.Window, Equals, defaultPackWindow)
+	c.Assert(config.Pack.Window, Equals, DefaultPackWindow)
 }


### PR DESCRIPTION
Config is not initialized with the default window size. Without this the window size is 0 and packfile code is unable to generate deltas.