### PR TITLE
plumbing: cache, modify cache to delete more than one item to free space

### DIFF
--- a/plumbing/cache/object_lru.go
+++ b/plumbing/cache/object_lru.go
@@ -51,7 +51,7 @@ func (c *ObjectLRU) Put(obj plumbing.EncodedObject) {
 
 	objSize := FileSize(obj.Size())
 
-	if objSize >= c.MaxSize {
+	if objSize > c.MaxSize {
 		return
 	}
 

--- a/plumbing/cache/object_lru.go
+++ b/plumbing/cache/object_lru.go
@@ -55,7 +55,7 @@ func (c *ObjectLRU) Put(obj plumbing.EncodedObject) {
 		return
 	}
 
-	if c.actualSize+objSize > c.MaxSize {
+	for c.actualSize+objSize > c.MaxSize {
 		last := c.ll.Back()
 		lastObj := last.Value.(plumbing.EncodedObject)
 		lastSize := FileSize(lastObj.Size())
@@ -63,10 +63,6 @@ func (c *ObjectLRU) Put(obj plumbing.EncodedObject) {
 		c.ll.Remove(last)
 		delete(c.cache, lastObj.Hash())
 		c.actualSize -= lastSize
-
-		if c.actualSize+objSize > c.MaxSize {
-			return
-		}
 	}
 
 	ee := c.ll.PushFront(obj)

--- a/plumbing/format/packfile/decoder.go
+++ b/plumbing/format/packfile/decoder.go
@@ -407,6 +407,8 @@ func (d *Decoder) fillOFSDeltaObjectContent(obj plumbing.EncodedObject, offset i
 		if err != nil {
 			return 0, err
 		}
+
+		d.cachePut(base)
 	}
 
 	obj.SetType(base.Type())


### PR DESCRIPTION
The previous version could only delete the oldest used object. If the
object to cache was bigger than the space freed it could not be added.

Also the decoder adds bases to the cache when they are needed.

This change increases the speed creating indexes 2x.