### PR TITLE
Support for clone without checkout (git clone -n)

### DIFF
--- a/options.go
+++ b/options.go
@@ -41,6 +41,8 @@ type CloneOptions struct {
 	ReferenceName plumbing.ReferenceName
 	// Fetch only ReferenceName if true.
 	SingleBranch bool
+	// No checkout of HEAD after clone if true.
+	NoCheckout bool
 	// Limit fetching to the specified number of commits.
 	Depth int
 	// RecurseSubmodules after the clone is created, initialize all submodules

--- a/repository.go
+++ b/repository.go
@@ -449,7 +449,7 @@ func (r *Repository) clone(ctx context.Context, o *CloneOptions) error {
 		return err
 	}
 
-	if r.wt != nil {
+	if r.wt != nil && !o.NoCheckout {
 		w, err := r.Worktree()
 		if err != nil {
 			return err

--- a/repository_test.go
+++ b/repository_test.go
@@ -448,6 +448,28 @@ func (s *RepositorySuite) TestPlainCloneWithRecurseSubmodules(c *C) {
 	c.Assert(cfg.Submodules, HasLen, 2)
 }
 
+func (s *RepositorySuite) TestPlainCloneNoCheckout(c *C) {
+	dir, err := ioutil.TempDir("", "plain-clone-no-checkout")
+	c.Assert(err, IsNil)
+	defer os.RemoveAll(dir)
+
+	path := fixtures.ByTag("submodule").One().Worktree().Root()
+	r, err := PlainClone(dir, false, &CloneOptions{
+		URL:               path,
+		NoCheckout:        true,
+		RecurseSubmodules: DefaultSubmoduleRecursionDepth,
+	})
+	c.Assert(err, IsNil)
+
+	h, err := r.Head()
+	c.Assert(err, IsNil)
+	c.Assert(h.Hash().String(), Equals, "b685400c1f9316f350965a5993d350bc746b0bf4")
+
+	fi, err := osfs.New(dir).ReadDir("")
+	c.Assert(err, IsNil)
+	c.Assert(fi, HasLen, 1) // .git
+}
+
 func (s *RepositorySuite) TestFetch(c *C) {
 	r, _ := Init(memory.NewStorage(), nil)
 	_, err := r.CreateRemote(&config.RemoteConfig{


### PR DESCRIPTION
Based on  #705 issue discussion about supporting `git clone -n` option that doesn't checkout HEAD after cloning a remote repository.  This follows documented `git-clone` behavior of ignoring `--recurse-submodules` when no-checkout option is enabled:

> This option is ignored if the cloned repository does not have a worktree/checkout (i.e. if any of --no-checkout/-n, --bare, or --mirror is given)

src: https://git-scm.com/docs/git-clone#git-clone---recurse-submodulesltpathspec