### PR TITLE
plumbing: format/packfile, fix crash with cycle deltas

### DIFF
--- a/plumbing/format/packfile/delta_selector.go
+++ b/plumbing/format/packfile/delta_selector.go
@@ -196,7 +196,8 @@ func (dw *deltaSelector) restoreOriginal(otp *ObjectToPack) error {
 		return err
 	}
 
-	otp.Original = obj
+	otp.SetOriginal(obj)
+
 	return nil
 }
 

--- a/plumbing/format/packfile/encoder.go
+++ b/plumbing/format/packfile/encoder.go
@@ -87,6 +87,7 @@ func (e *Encoder) entry(o *ObjectToPack) error {
 		// (for example due to a concurrent repack) and a different base
 		// was chosen, forcing a cycle. Select something other than a
 		// delta, and write this object.
+		e.selector.restoreOriginal(o)
 		o.BackToOriginal()
 	}
 

--- a/plumbing/format/packfile/encoder_test.go
+++ b/plumbing/format/packfile/encoder_test.go
@@ -202,6 +202,15 @@ func (s *EncoderSuite) deltaOverDeltaCyclicTest(c *C) {
 	o3 := newObject(plumbing.BlobObject, []byte("011111"))
 	o4 := newObject(plumbing.BlobObject, []byte("01111100000"))
 
+	_, err := s.store.SetEncodedObject(o1)
+	c.Assert(err, IsNil)
+	_, err = s.store.SetEncodedObject(o2)
+	c.Assert(err, IsNil)
+	_, err = s.store.SetEncodedObject(o3)
+	c.Assert(err, IsNil)
+	_, err = s.store.SetEncodedObject(o4)
+	c.Assert(err, IsNil)
+
 	d2, err := GetDelta(o1, o2)
 	c.Assert(err, IsNil)
 
@@ -218,6 +227,18 @@ func (s *EncoderSuite) deltaOverDeltaCyclicTest(c *C) {
 
 	pd3.SetDelta(pd4, d3)
 	pd4.SetDelta(pd3, d4)
+
+	// SetOriginal is used by delta selector when generating ObjectToPack.
+	// It also fills type, hash and size values to be used when Original
+	// is nil.
+	po1.SetOriginal(po1.Original)
+	pd2.SetOriginal(pd2.Original)
+	pd2.Original = nil
+
+	pd3.SetOriginal(pd3.Original)
+	pd3.Original = nil
+
+	pd4.SetOriginal(pd4.Original)
 
 	encHash, err := s.enc.encode([]*ObjectToPack{
 		po1,

--- a/plumbing/format/packfile/encoder_test.go
+++ b/plumbing/format/packfile/encoder_test.go
@@ -233,10 +233,10 @@ func (s *EncoderSuite) deltaOverDeltaCyclicTest(c *C) {
 	// is nil.
 	po1.SetOriginal(po1.Original)
 	pd2.SetOriginal(pd2.Original)
-	pd2.Original = nil
+	pd2.SetOriginal(nil)
 
 	pd3.SetOriginal(pd3.Original)
-	pd3.Original = nil
+	pd3.SetOriginal(nil)
 
 	pd4.SetOriginal(pd4.Original)
 

--- a/plumbing/format/packfile/object_pack.go
+++ b/plumbing/format/packfile/object_pack.go
@@ -53,7 +53,7 @@ func newDeltaObjectToPack(base *ObjectToPack, original, delta plumbing.EncodedOb
 
 // BackToOriginal converts that ObjectToPack to a non-deltified object if it was one
 func (o *ObjectToPack) BackToOriginal() {
-	if o.IsDelta() {
+	if o.IsDelta() && o.Original != nil {
 		o.Object = o.Original
 		o.Base = nil
 		o.Depth = 0
@@ -77,13 +77,17 @@ func (o *ObjectToPack) WantWrite() bool {
 	return o.Offset == 1
 }
 
-// SetOriginal sets both Original and saves size, type and hash
+// SetOriginal sets both Original and saves size, type and hash. If object
+// is nil Original is set but previous resolved values are kept
 func (o *ObjectToPack) SetOriginal(obj plumbing.EncodedObject) {
 	o.Original = obj
-	o.originalSize = obj.Size()
-	o.originalType = obj.Type()
-	o.originalHash = obj.Hash()
-	o.resolvedOriginal = true
+
+	if obj != nil {
+		o.originalSize = obj.Size()
+		o.originalType = obj.Type()
+		o.originalHash = obj.Hash()
+		o.resolvedOriginal = true
+	}
 }
 
 func (o *ObjectToPack) Type() plumbing.ObjectType {


### PR DESCRIPTION
Resolving cycles relied on `ObjectToPack` objects having Original. This is no longer true with the changes from #720. This commit changes:

* Save original type, hash and size in `ObjectToPack`
* Use `SetObject` to set both Original and resolved type, hash and size
* Restore original object before using `BackToOriginal` (cycle resolution)
* Update encoder test to check this case

