### PR TITLE
plumbing: format/packfile, fix panic retrieving object hash.

### DIFF
--- a/plumbing/format/packfile/delta_selector.go
+++ b/plumbing/format/packfile/delta_selector.go
@@ -103,7 +103,7 @@ func (dw *deltaSelector) objectsToPack(
 
 		otp := newObjectToPack(o)
 		if _, ok := o.(plumbing.DeltaObject); ok {
-			otp.Original = nil
+			otp.CleanOriginal()
 		}
 
 		objectsToPack = append(objectsToPack, otp)
@@ -231,7 +231,8 @@ func (dw *deltaSelector) walk(
 			delete(indexMap, obj.Hash())
 
 			if obj.IsDelta() {
-				obj.Original = nil
+				obj.SetOriginal(obj.Original)
+				obj.CleanOriginal()
 			}
 		}
 

--- a/plumbing/format/packfile/delta_selector.go
+++ b/plumbing/format/packfile/delta_selector.go
@@ -231,7 +231,7 @@ func (dw *deltaSelector) walk(
 			delete(indexMap, obj.Hash())
 
 			if obj.IsDelta() {
-				obj.SetOriginal(obj.Original)
+				obj.SaveOriginalMetadata()
 				obj.CleanOriginal()
 			}
 		}

--- a/plumbing/format/packfile/encoder_test.go
+++ b/plumbing/format/packfile/encoder_test.go
@@ -233,10 +233,10 @@ func (s *EncoderSuite) deltaOverDeltaCyclicTest(c *C) {
 	// is nil.
 	po1.SetOriginal(po1.Original)
 	pd2.SetOriginal(pd2.Original)
-	pd2.SetOriginal(nil)
+	pd2.CleanOriginal()
 
 	pd3.SetOriginal(pd3.Original)
-	pd3.SetOriginal(nil)
+	pd3.CleanOriginal()
 
 	pd4.SetOriginal(pd4.Original)
 

--- a/plumbing/format/packfile/object_pack.go
+++ b/plumbing/format/packfile/object_pack.go
@@ -81,11 +81,15 @@ func (o *ObjectToPack) WantWrite() bool {
 // is nil Original is set but previous resolved values are kept
 func (o *ObjectToPack) SetOriginal(obj plumbing.EncodedObject) {
 	o.Original = obj
+	o.SaveOriginalMetadata()
+}
 
-	if obj != nil {
-		o.originalSize = obj.Size()
-		o.originalType = obj.Type()
-		o.originalHash = obj.Hash()
+// SaveOriginalMetadata saves size, type and hash of Original object
+func (o *ObjectToPack) SaveOriginalMetadata() {
+	if o.Original != nil {
+		o.originalSize = o.Original.Size()
+		o.originalType = o.Original.Type()
+		o.originalHash = o.Original.Hash()
 		o.resolvedOriginal = true
 	}
 }

--- a/plumbing/format/packfile/object_pack.go
+++ b/plumbing/format/packfile/object_pack.go
@@ -90,6 +90,11 @@ func (o *ObjectToPack) SetOriginal(obj plumbing.EncodedObject) {
 	}
 }
 
+// CleanOriginal sets Original to nil
+func (o *ObjectToPack) CleanOriginal() {
+	o.Original = nil
+}
+
 func (o *ObjectToPack) Type() plumbing.ObjectType {
 	if o.Original != nil {
 		return o.Original.Type()


### PR DESCRIPTION
In some cases the original data is not saved before it is cleaned and forces a panic when it's retrieved.

The change adds `ObjectToPack.CleanOriginal` to be used to clean original object instead of:

    object.Original = nil

Now when the Original data is freed because it's no longer in the pack window a `SetOriginal` call is done to make sure that Size, Hash and Size data is not lost.

Fixes https://github.com/src-d/borges/issues/229
