### PR TITLE
plumbing: diff, fix crash when a small ending equal-chunk

### DIFF
--- a/plumbing/format/diff/unified_encoder.go
+++ b/plumbing/format/diff/unified_encoder.go
@@ -262,11 +262,15 @@ func (c *hunksGenerator) processEqualsLines(ls []string, i int) {
 		c.current.AddOp(Equal, c.afterContext...)
 		c.afterContext = nil
 	} else {
-		c.current.AddOp(Equal, c.afterContext[:c.ctxLines]...)
+		ctxLines := c.ctxLines
+		if ctxLines > len(c.afterContext) {
+			ctxLines = len(c.afterContext)
+		}
+		c.current.AddOp(Equal, c.afterContext[:ctxLines]...)
 		c.hunks = append(c.hunks, c.current)
 
 		c.current = nil
-		c.beforeContext = c.afterContext[c.ctxLines:]
+		c.beforeContext = c.afterContext[ctxLines:]
 		c.afterContext = nil
 	}
 }

--- a/plumbing/format/diff/unified_encoder_test.go
+++ b/plumbing/format/diff/unified_encoder_test.go
@@ -476,6 +476,43 @@ index ab5eed5d4a2c33aeef67e0188ee79bed666bde6f..0adddcde4fd38042c354518351820eb0
  W
 `,
 }, {
+	patch:   oneChunkPatch,
+	desc:    "modified deleting lines file with context to 6",
+	context: 6,
+	diff: `diff --git a/onechunk.txt b/onechunk.txt
+index ab5eed5d4a2c33aeef67e0188ee79bed666bde6f..0adddcde4fd38042c354518351820eb06c417c82 100644
+--- a/onechunk.txt
++++ b/onechunk.txt
+@@ -1,27 +1,23 @@
+-A
+ B
+ C
+ D
+ E
+ F
+ G
+-H
+ I
+ J
+ K
+ L
+ M
+ N
+-Ñ
+ O
+ P
+ Q
+ R
+ S
+ T
+-U
+ V
+ W
+ X
+ Y
+ Z
+`,
+}, {
 	patch: oneChunkPatch,
 
 	desc:    "modified deleting lines file with context to 3",


### PR DESCRIPTION
Signed-off-by: Mechiel Lukkien <mechiel@ueber.net>

note: i'm not familiar with the code base. please review fix, and whether needs fixing in other places.

to reproduce, first create a git repo with a commit that has a small trailing equals-chunk:
```
mkdir git-test-repo
cd git-test-repo/
git init
yes | head -n10 >test.txt
git add test.txt
git commit -m test
(yes | head -n8; echo n; echo y) >test.txt
git commit -m test test.txt
```
now run the test program at the bottom, and observe the crash:
```
$ go run main.go -- git-test-repo/
2018/02/14 18:22:25 patch between commit
commit beccfaa9484487c5adad075ac96308ed9ab897d2
Author: Mechiel Lukkien <mechiel@ueber.net>
Date:   Wed Feb 14 18:10:24 2018 +0100

    test


and
commit c408553d8c54d91bf197fad054541722d16d471e
Author: Mechiel Lukkien <mechiel@ueber.net>
Date:   Wed Feb 14 18:10:24 2018 +0100

    test


panic: runtime error: slice bounds out of range

goroutine 1 [running]:
gopkg.in/src-d/go-git.v4/plumbing/format/diff.(*hunksGenerator).processEqualsLines(0xc4200edd00, 0xc4201b4540, 0x1, 0x2, 0x3)
	/Users/mjl/go/src/gopkg.in/src-d/go-git.v4/plumbing/format/diff/unified_encoder.go:265 +0x59d
gopkg.in/src-d/go-git.v4/plumbing/format/diff.(*hunksGenerator).Generate(0xc4200edd00, 0xc42005bdc0, 0x4, 0x4)
	/Users/mjl/go/src/gopkg.in/src-d/go-git.v4/plumbing/format/diff/unified_encoder.go:180 +0x3f2
gopkg.in/src-d/go-git.v4/plumbing/format/diff.(*UnifiedEncoder).encodeFilePatch(0xc4200d6400, 0xc420124770, 0x1, 0x1, 0x1, 0xc4200d6400)
	/Users/mjl/go/src/gopkg.in/src-d/go-git.v4/plumbing/format/diff/unified_encoder.go:85 +0x208
gopkg.in/src-d/go-git.v4/plumbing/format/diff.(*UnifiedEncoder).Encode(0xc4200d6400, 0x1612a00, 0xc42013e7b0, 0x13e40e0, 0x101)
	/Users/mjl/go/src/gopkg.in/src-d/go-git.v4/plumbing/format/diff/unified_encoder.go:68 +0x65
gopkg.in/src-d/go-git.v4/plumbing/object.(*Patch).Encode(0xc42013e7b0, 0x160e980, 0xc4201b23f0, 0xc4200ede70, 0x10cb200)
	/Users/mjl/go/src/gopkg.in/src-d/go-git.v4/plumbing/object/patch.go:107 +0x7c
gopkg.in/src-d/go-git.v4/plumbing/object.(*Patch).String(0xc42013e7b0, 0x1f, 0xc4200edf50)
	/Users/mjl/go/src/gopkg.in/src-d/go-git.v4/plumbing/object/patch.go:116 +0x5a
main.main()
	/Users/mjl/go/src/test/go-git-diff-bug/main.go:51 +0x3d8
exit status 2
```

then apply the patch in this pull request, and see the expected patch:

```
$ go run main.go -- git-test-repo/
2018/02/14 18:12:35 patch between commit
commit beccfaa9484487c5adad075ac96308ed9ab897d2
Author: Mechiel Lukkien <mechiel@ueber.net>
Date:   Wed Feb 14 18:10:24 2018 +0100

    test


and
commit c408553d8c54d91bf197fad054541722d16d471e
Author: Mechiel Lukkien <mechiel@ueber.net>
Date:   Wed Feb 14 18:10:24 2018 +0100

    test


2018/02/14 18:12:35 diff --git a/test.txt b/test.txt
index db7cbfc682f6343bb0e71e0cf774ba7a1ca1a37b..67c82c94116850ddfcf70fd43ae4ab2eb2242503 100644
--- a/test.txt
+++ b/test.txt
@@ -6,5 +6,5 @@ y
 y
 y
 y
-y
+n
 y
```

and the attached program that triggers the bug:

```
package main

import (
	"flag"
	"log"

	"gopkg.in/src-d/go-git.v4"
	"gopkg.in/src-d/go-git.v4/plumbing/object"
)


func check(err error, msg string) {
	if err != nil {
		log.Fatalf("%s: %s\n", msg, err)
	}
}

func main() {
	flag.Parse()
	args := flag.Args()
	if len(args) != 1 {
		log.Fatalf("pass git repo directory as parameter")
	}
	dir := args[0]
	repo, err := git.PlainOpen(dir)
	check(err, "plainopen")

	iter, err := repo.CommitObjects()
	check(err, "commitobjects")

	c0, err := iter.Next()
	check(err, "commit1")
	c1, err := iter.Next()
	check(err, "commit2")

	commits := []*object.Commit{c0, c1}
	if len(commits[0].ParentHashes) != 0 {
		commits = []*object.Commit{c1, c0}
	}

	t0, err := repo.TreeObject(commits[0].TreeHash)
	check(err, "treeobject first commit")
	t1, err := repo.TreeObject(commits[1].TreeHash)
	check(err, "treeobject second commit")

	p, err := t0.Patch(t1)
	check(err, "patch")

	log.Printf("patch between commit\n%s\nand\n%s\n", commits[0], commits[1])

	diff := p.String() // crashes

	log.Print(diff)
}
```