### PR TITLE
plumbing: ssh, return error when creating public keys from invalid PEM

### DIFF
--- a/plumbing/transport/ssh/auth_method.go
+++ b/plumbing/transport/ssh/auth_method.go
@@ -124,6 +124,9 @@ type PublicKeys struct {
 // (PKCS#1), DSA (OpenSSL), and ECDSA private keys.
 func NewPublicKeys(user string, pemBytes []byte, password string) (*PublicKeys, error) {
 	block, _ := pem.Decode(pemBytes)
+	if block == nil {
+		return nil, errors.New("invalid PEM data")
+	}
 	if x509.IsEncryptedPEMBlock(block) {
 		key, err := x509.DecryptPEMBlock(block, []byte(password))
 		if err != nil {

--- a/plumbing/transport/ssh/auth_method_test.go
+++ b/plumbing/transport/ssh/auth_method_test.go
@@ -143,3 +143,9 @@ func (*SuiteCommon) TestNewPublicKeysFromFile(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(auth, NotNil)
 }
+
+func (*SuiteCommon) TestNewPublicKeysWithInvalidPEM(c *C) {
+	auth, err := NewPublicKeys("foo", []byte("bar"), "")
+	c.Assert(err, NotNil)
+	c.Assert(auth, IsNil)
+}


### PR DESCRIPTION
If the `pemBytes` passed in is not valid, [`pem.Decode` will return nil](https://golang.org/src/encoding/pem/pem.go?s=2199:2247#L68). Passing that to `x509.IsEncryptedPEMBlock` will panic when it [tries to read `Headers`](https://golang.org/src/crypto/x509/pem_decrypt.go?s=2314:2357#L89). This fix returns an error early rather than panicking.