### PR TITLE
plubming: transport, Escape the user and pswd for endpoint. Fixes #723

### DIFF
--- a/plumbing/transport/common.go
+++ b/plumbing/transport/common.go
@@ -128,10 +128,10 @@ func (u *Endpoint) String() string {
 		buf.WriteString("//")
 
 		if u.User != "" || u.Password != "" {
-			buf.WriteString(u.User)
+			buf.WriteString(url.PathEscape(u.User))
 			if u.Password != "" {
 				buf.WriteByte(':')
-				buf.WriteString(u.Password)
+				buf.WriteString(url.PathEscape(u.Password))
 			}
 
 			buf.WriteByte('@')

--- a/plumbing/transport/common_test.go
+++ b/plumbing/transport/common_test.go
@@ -1,6 +1,7 @@
 package transport
 
 import (
+	"net/url"
 	"testing"
 
 	"gopkg.in/src-d/go-git.v4/plumbing/protocol/packp/capability"
@@ -151,6 +152,15 @@ func (s *SuiteCommon) TestNewEndpointFileURL(c *C) {
 	c.Assert(e.Port, Equals, 0)
 	c.Assert(e.Path, Equals, "/foo.git")
 	c.Assert(e.String(), Equals, "file:///foo.git")
+}
+
+func (s *SuiteCommon) TestValidEndpoint(c *C) {
+	e, err := NewEndpoint("http://github.com/user/repository.git")
+	e.User = "person@mail.com"
+	e.Password = " !\"#$%&'()*+,-./:;<=>?@[\\]^_`{|}~"
+	url, err := url.Parse(e.String())
+	c.Assert(err, IsNil)
+	c.Assert(url, NotNil)
 }
 
 func (s *SuiteCommon) TestNewEndpointInvalidURL(c *C) {


### PR DESCRIPTION
When endpoint is generating a url string I made sure that the username and password are escaped properly using the url.PathEscape function. There is also a test to make sure the string representation of the Git URL is a valid URL by parsing it.

Signed-off-by: Zachary Romero <zacromero3@gmail.com>