### PR TITLE
Worktree.Checkout: handling of symlink on Windows

### DIFF
--- a/worktree.go
+++ b/worktree.go
@@ -554,6 +554,22 @@ func (w *Worktree) checkoutFileSymlink(f *object.File) (err error) {
 	}
 
 	err = w.Filesystem.Symlink(string(bytes), f.Name)
+
+	// On windows, this might fail.
+	// Follow Git on Windows behavior by writing the link as it is.
+	if err != nil && isSymlinkWindowsNonAdmin(err) {
+		mode, _ := f.Mode.ToOSFileMode()
+
+		to, err := w.Filesystem.OpenFile(f.Name, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, mode.Perm())
+		if err != nil {
+			return err
+		}
+
+		defer ioutil.CheckClose(to, &err)
+
+		_, err = to.Write(bytes)
+		return err
+	}
 	return
 }
 

--- a/worktree_darwin.go
+++ b/worktree_darwin.go
@@ -20,3 +20,7 @@ func init() {
 		}
 	}
 }
+
+func isSymlinkWindowsNonAdmin(err error) bool {
+	return false
+}

--- a/worktree_linux.go
+++ b/worktree_linux.go
@@ -20,3 +20,7 @@ func init() {
 		}
 	}
 }
+
+func isSymlinkWindowsNonAdmin(err error) bool {
+	return false
+}

--- a/worktree_windows.go
+++ b/worktree_windows.go
@@ -3,6 +3,7 @@
 package git
 
 import (
+	"os"
 	"syscall"
 	"time"
 
@@ -17,4 +18,18 @@ func init() {
 			e.CreatedAt = time.Unix(seconds, nanoseconds)
 		}
 	}
+}
+
+func isSymlinkWindowsNonAdmin(err error) bool {
+	const ERROR_PRIVILEGE_NOT_HELD syscall.Errno = 1314
+
+	if err != nil {
+		if errLink, ok := err.(*os.LinkError); ok {
+			if errNo, ok := errLink.Err.(syscall.Errno); ok {
+				return errNo == ERROR_PRIVILEGE_NOT_HELD
+			}
+		}
+	}
+
+	return false
 }


### PR DESCRIPTION
On Windows, elevated rights are required for symlinks.

If they are missing, which is true for almost all users, the library will fail with "A required privilege is not held by the client." (ERROR_PRIVILEGE_NOT_HELD).

This implementation mimics the behavior of Git on Windows.