### PR TITLE
Fix RefSpec.Src()

### DIFF
--- a/config/refspec.go
+++ b/config/refspec.go
@@ -62,7 +62,13 @@ func (s RefSpec) IsDelete() bool {
 // Src return the src side.
 func (s RefSpec) Src() string {
 	spec := string(s)
-	start := strings.Index(spec, refSpecForce) + 1
+
+	var start int
+	if s.IsForceUpdate() {
+		start = 1
+	} else {
+		start = 0
+	}
 	end := strings.Index(spec, refSpecSeparator)
 
 	return spec[start:end]

--- a/config/refspec_test.go
+++ b/config/refspec_test.go
@@ -62,10 +62,16 @@ func (s *RefSpecSuite) TestRefSpecSrc(c *C) {
 	spec := RefSpec("refs/heads/*:refs/remotes/origin/*")
 	c.Assert(spec.Src(), Equals, "refs/heads/*")
 
+	spec = RefSpec("+refs/heads/*:refs/remotes/origin/*")
+	c.Assert(spec.Src(), Equals, "refs/heads/*")
+
 	spec = RefSpec(":refs/heads/master")
 	c.Assert(spec.Src(), Equals, "")
 
 	spec = RefSpec("refs/heads/love+hate:refs/heads/love+hate")
+	c.Assert(spec.Src(), Equals, "refs/heads/love+hate")
+
+	spec = RefSpec("+refs/heads/love+hate:refs/heads/love+hate")
 	c.Assert(spec.Src(), Equals, "refs/heads/love+hate")
 }
 
@@ -74,11 +80,18 @@ func (s *RefSpecSuite) TestRefSpecMatch(c *C) {
 	c.Assert(spec.Match(plumbing.ReferenceName("refs/heads/foo")), Equals, false)
 	c.Assert(spec.Match(plumbing.ReferenceName("refs/heads/master")), Equals, true)
 
+	spec = RefSpec("+refs/heads/master:refs/remotes/origin/master")
+	c.Assert(spec.Match(plumbing.ReferenceName("refs/heads/foo")), Equals, false)
+	c.Assert(spec.Match(plumbing.ReferenceName("refs/heads/master")), Equals, true)
+
 	spec = RefSpec(":refs/heads/master")
 	c.Assert(spec.Match(plumbing.ReferenceName("")), Equals, true)
 	c.Assert(spec.Match(plumbing.ReferenceName("refs/heads/master")), Equals, false)
 
 	spec = RefSpec("refs/heads/love+hate:heads/love+hate")
+	c.Assert(spec.Match(plumbing.ReferenceName("refs/heads/love+hate")), Equals, true)
+
+	spec = RefSpec("+refs/heads/love+hate:heads/love+hate")
 	c.Assert(spec.Match(plumbing.ReferenceName("refs/heads/love+hate")), Equals, true)
 }
 

--- a/config/refspec_test.go
+++ b/config/refspec_test.go
@@ -64,6 +64,9 @@ func (s *RefSpecSuite) TestRefSpecSrc(c *C) {
 
 	spec = RefSpec(":refs/heads/master")
 	c.Assert(spec.Src(), Equals, "")
+
+	spec = RefSpec("refs/heads/love+hate:refs/heads/love+hate")
+	c.Assert(spec.Src(), Equals, "refs/heads/love+hate")
 }
 
 func (s *RefSpecSuite) TestRefSpecMatch(c *C) {
@@ -74,6 +77,9 @@ func (s *RefSpecSuite) TestRefSpecMatch(c *C) {
 	spec = RefSpec(":refs/heads/master")
 	c.Assert(spec.Match(plumbing.ReferenceName("")), Equals, true)
 	c.Assert(spec.Match(plumbing.ReferenceName("refs/heads/master")), Equals, false)
+
+	spec = RefSpec("refs/heads/love+hate:heads/love+hate")
+	c.Assert(spec.Match(plumbing.ReferenceName("refs/heads/love+hate")), Equals, true)
 }
 
 func (s *RefSpecSuite) TestRefSpecMatchGlob(c *C) {


### PR DESCRIPTION
Previously, the Src() function was assuming there are no “+” characters in the refspec src
and erroneously used the strings.Index() function to compute the start index of src in the
refspec.  This change now uses the IsForceUpdate() method to decide how to elide the
force update token.

Signed-off-by: Alan Cabrera <adc@toolazydogs.com>