### PR TITLE
add PlainOpen variant to find .git in parent dirs

### DIFF
--- a/options.go
+++ b/options.go
@@ -420,3 +420,14 @@ func (o *GrepOptions) Validate(w *Worktree) error {
 
 	return nil
 }
+
+// PlainOpenOptions describes how opening a plain repository should be
+// performed.
+type PlainOpenOptions struct {
+	// DetectDotGit defines whether parent directories should be
+	// walked until a .git directory or file is found.
+	DetectDotGit bool
+}
+
+// Validate validates the fields and sets the default values.
+func (o *PlainOpenOptions) Validate() error { return nil }

--- a/repository_test.go
+++ b/repository_test.go
@@ -407,6 +407,36 @@ func (s *RepositorySuite) TestPlainOpenNotExists(c *C) {
 	c.Assert(r, IsNil)
 }
 
+func (s *RepositorySuite) TestPlainOpenDetectDotGit(c *C) {
+	dir, err := ioutil.TempDir("", "plain-open")
+	c.Assert(err, IsNil)
+	defer os.RemoveAll(dir)
+
+	subdir := filepath.Join(dir, "a", "b")
+	err = os.MkdirAll(subdir, 0755)
+	c.Assert(err, IsNil)
+
+	r, err := PlainInit(dir, false)
+	c.Assert(err, IsNil)
+	c.Assert(r, NotNil)
+
+	opt := &PlainOpenOptions{DetectDotGit: true}
+	r, err = PlainOpenWithOptions(subdir, opt)
+	c.Assert(err, IsNil)
+	c.Assert(r, NotNil)
+}
+
+func (s *RepositorySuite) TestPlainOpenNotExistsDetectDotGit(c *C) {
+	dir, err := ioutil.TempDir("", "plain-open")
+	c.Assert(err, IsNil)
+	defer os.RemoveAll(dir)
+
+	opt := &PlainOpenOptions{DetectDotGit: true}
+	r, err := PlainOpenWithOptions(dir, opt)
+	c.Assert(err, Equals, ErrRepositoryNotExists)
+	c.Assert(r, IsNil)
+}
+
 func (s *RepositorySuite) TestPlainClone(c *C) {
 	r, err := PlainClone(c.MkDir(), false, &CloneOptions{
 		URL: s.GetBasicLocalRepositoryURL(),


### PR DESCRIPTION
This is the git tool's behavior that people are used to; if one runs a
git command in a repository's subdirectory, git still works.

Fixes #765.