### PR TITLE
*: skip time consuming tests

### DIFF
--- a/plumbing/format/packfile/encoder_advanced_test.go
+++ b/plumbing/format/packfile/encoder_advanced_test.go
@@ -3,6 +3,7 @@ package packfile_test
 import (
 	"bytes"
 	"math/rand"
+	"testing"
 
 	"gopkg.in/src-d/go-git.v4/plumbing"
 	. "gopkg.in/src-d/go-git.v4/plumbing/format/packfile"
@@ -21,6 +22,10 @@ type EncoderAdvancedSuite struct {
 var _ = Suite(&EncoderAdvancedSuite{})
 
 func (s *EncoderAdvancedSuite) TestEncodeDecode(c *C) {
+	if testing.Short() {
+		c.Skip("skipping test in short mode.")
+	}
+
 	fixs := fixtures.Basic().ByTag("packfile").ByTag(".git")
 	fixs = append(fixs, fixtures.ByURL("https://github.com/src-d/go-git.git").
 		ByTag("packfile").ByTag(".git").One())
@@ -33,6 +38,10 @@ func (s *EncoderAdvancedSuite) TestEncodeDecode(c *C) {
 }
 
 func (s *EncoderAdvancedSuite) TestEncodeDecodeNoDeltaCompression(c *C) {
+	if testing.Short() {
+		c.Skip("skipping test in short mode.")
+	}
+
 	fixs := fixtures.Basic().ByTag("packfile").ByTag(".git")
 	fixs = append(fixs, fixtures.ByURL("https://github.com/src-d/go-git.git").
 		ByTag("packfile").ByTag(".git").One())

--- a/repository_test.go
+++ b/repository_test.go
@@ -10,6 +10,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"testing"
 	"time"
 
 	"gopkg.in/src-d/go-git.v4/config"
@@ -430,6 +431,10 @@ func (s *RepositorySuite) TestPlainCloneContext(c *C) {
 }
 
 func (s *RepositorySuite) TestPlainCloneWithRecurseSubmodules(c *C) {
+	if testing.Short() {
+		c.Skip("skipping test in short mode.")
+	}
+
 	dir, err := ioutil.TempDir("", "plain-clone-submodule")
 	c.Assert(err, IsNil)
 	defer os.RemoveAll(dir)
@@ -1396,10 +1401,18 @@ func (s *RepositorySuite) testRepackObjects(
 }
 
 func (s *RepositorySuite) TestRepackObjects(c *C) {
+	if testing.Short() {
+		c.Skip("skipping test in short mode.")
+	}
+
 	s.testRepackObjects(c, time.Time{}, 1)
 }
 
 func (s *RepositorySuite) TestRepackObjectsWithNoDelete(c *C) {
+	if testing.Short() {
+		c.Skip("skipping test in short mode.")
+	}
+
 	s.testRepackObjects(c, time.Unix(0, 1), 3)
 }
 

--- a/submodule_test.go
+++ b/submodule_test.go
@@ -5,6 +5,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"testing"
 
 	"gopkg.in/src-d/go-git.v4/plumbing"
 
@@ -66,6 +67,10 @@ func (s *SubmoduleSuite) TestInit(c *C) {
 }
 
 func (s *SubmoduleSuite) TestUpdate(c *C) {
+	if testing.Short() {
+		c.Skip("skipping test in short mode.")
+	}
+
 	sm, err := s.Worktree.Submodule("basic")
 	c.Assert(err, IsNil)
 
@@ -118,6 +123,10 @@ func (s *SubmoduleSuite) TestUpdateWithNotFetch(c *C) {
 }
 
 func (s *SubmoduleSuite) TestUpdateWithRecursion(c *C) {
+	if testing.Short() {
+		c.Skip("skipping test in short mode.")
+	}
+
 	sm, err := s.Worktree.Submodule("itself")
 	c.Assert(err, IsNil)
 
@@ -134,6 +143,10 @@ func (s *SubmoduleSuite) TestUpdateWithRecursion(c *C) {
 }
 
 func (s *SubmoduleSuite) TestUpdateWithInitAndUpdate(c *C) {
+	if testing.Short() {
+		c.Skip("skipping test in short mode.")
+	}
+
 	sm, err := s.Worktree.Submodule("basic")
 	c.Assert(err, IsNil)
 
@@ -193,6 +206,10 @@ func (s *SubmoduleSuite) TestSubmodulesStatus(c *C) {
 }
 
 func (s *SubmoduleSuite) TestSubmodulesUpdateContext(c *C) {
+	if testing.Short() {
+		c.Skip("skipping test in short mode.")
+	}
+
 	sm, err := s.Worktree.Submodules()
 	c.Assert(err, IsNil)
 

--- a/worktree_test.go
+++ b/worktree_test.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"runtime"
+	"testing"
 
 	"gopkg.in/src-d/go-git.v4/config"
 	"gopkg.in/src-d/go-git.v4/plumbing"
@@ -196,6 +197,10 @@ func (s *WorktreeSuite) TestPullProgress(c *C) {
 }
 
 func (s *WorktreeSuite) TestPullProgressWithRecursion(c *C) {
+	if testing.Short() {
+		c.Skip("skipping test in short mode.")
+	}
+
 	path := fixtures.ByTag("submodule").One().Worktree().Root()
 
 	dir, err := ioutil.TempDir("", "plain-clone-submodule")
@@ -613,6 +618,10 @@ func (s *WorktreeSuite) TestCheckoutTag(c *C) {
 }
 
 func (s *WorktreeSuite) TestCheckoutBisect(c *C) {
+	if testing.Short() {
+		c.Skip("skipping test in short mode.")
+	}
+
 	s.testCheckoutBisect(c, "https://github.com/src-d/go-git.git")
 }
 


### PR DESCRIPTION
FIxes #780 

I made a small review of the most time-consuming tests, and I skipped for `-short` executions. Now the root tests take around 5secs, and the whole project 42secs.

```
> env GOCACHE=off go test -short
ok  	gopkg.in/src-d/go-git.v4	9.591s
?   	gopkg.in/src-d/go-git.v4/cli/go-git	[no test files]
ok  	gopkg.in/src-d/go-git.v4/config	0.063s
ok  	gopkg.in/src-d/go-git.v4/internal/revision	0.041s
ok  	gopkg.in/src-d/go-git.v4/plumbing	0.016s
ok  	gopkg.in/src-d/go-git.v4/plumbing/cache	0.066s
ok  	gopkg.in/src-d/go-git.v4/plumbing/filemode	0.027s
ok  	gopkg.in/src-d/go-git.v4/plumbing/format/config	0.052s
ok  	gopkg.in/src-d/go-git.v4/plumbing/format/diff	0.045s
ok  	gopkg.in/src-d/go-git.v4/plumbing/format/gitignore	0.041s
ok  	gopkg.in/src-d/go-git.v4/plumbing/format/idxfile	0.290s
ok  	gopkg.in/src-d/go-git.v4/plumbing/format/index	0.090s
ok  	gopkg.in/src-d/go-git.v4/plumbing/format/objfile	0.059s
ok  	gopkg.in/src-d/go-git.v4/plumbing/format/packfile	0.725s
ok  	gopkg.in/src-d/go-git.v4/plumbing/format/pktline	0.123s
ok  	gopkg.in/src-d/go-git.v4/plumbing/object	1.015s
ok  	gopkg.in/src-d/go-git.v4/plumbing/protocol/packp	0.060s
ok  	gopkg.in/src-d/go-git.v4/plumbing/protocol/packp/capability	0.071s
ok  	gopkg.in/src-d/go-git.v4/plumbing/protocol/packp/sideband	0.035s
ok  	gopkg.in/src-d/go-git.v4/plumbing/revlist	0.104s
ok  	gopkg.in/src-d/go-git.v4/plumbing/storer	0.034s
ok  	gopkg.in/src-d/go-git.v4/plumbing/transport	0.016s
ok  	gopkg.in/src-d/go-git.v4/plumbing/transport/client	0.030s
ok  	gopkg.in/src-d/go-git.v4/plumbing/transport/file	4.389s
ok  	gopkg.in/src-d/go-git.v4/plumbing/transport/git	8.065s
ok  	gopkg.in/src-d/go-git.v4/plumbing/transport/http	4.174s
?   	gopkg.in/src-d/go-git.v4/plumbing/transport/internal/common	[no test files]
ok  	gopkg.in/src-d/go-git.v4/plumbing/transport/server	0.180s
ok  	gopkg.in/src-d/go-git.v4/plumbing/transport/ssh	0.556s
?   	gopkg.in/src-d/go-git.v4/plumbing/transport/test	[no test files]
?   	gopkg.in/src-d/go-git.v4/storage	[no test files]
ok  	gopkg.in/src-d/go-git.v4/storage/filesystem	4.558s
ok  	gopkg.in/src-d/go-git.v4/storage/filesystem/internal/dotgit	0.524s
ok  	gopkg.in/src-d/go-git.v4/storage/memory	0.014s
?   	gopkg.in/src-d/go-git.v4/storage/test	[no test files]
ok  	gopkg.in/src-d/go-git.v4/utils/binary	0.011s
ok  	gopkg.in/src-d/go-git.v4/utils/diff	0.023s
ok  	gopkg.in/src-d/go-git.v4/utils/ioutil	0.013s
ok  	gopkg.in/src-d/go-git.v4/utils/merkletrie	0.026s
ok  	gopkg.in/src-d/go-git.v4/utils/merkletrie/filesystem	0.014s
ok  	gopkg.in/src-d/go-git.v4/utils/merkletrie/index	0.007s
ok  	gopkg.in/src-d/go-git.v4/utils/merkletrie/internal/frame	0.018s
ok  	gopkg.in/src-d/go-git.v4/utils/merkletrie/internal/fsnoder	0.056s
ok  	gopkg.in/src-d/go-git.v4/utils/merkletrie/noder	0.059s
```