### PR TITLE
plumbing: format: pktline, Accept oversized pkt-lines up to 65524 bytes

### DIFF
--- a/plumbing/format/pktline/encoder.go
+++ b/plumbing/format/pktline/encoder.go
@@ -17,6 +17,9 @@ type Encoder struct {
 const (
 	// MaxPayloadSize is the maximum payload size of a pkt-line in bytes.
 	MaxPayloadSize = 65516
+
+	// For compatibility with canonical Git implementation, accept longer pkt-lines
+	OversizePayloadMax = 65520
 )
 
 var (

--- a/plumbing/format/pktline/scanner.go
+++ b/plumbing/format/pktline/scanner.go
@@ -97,7 +97,7 @@ func (s *Scanner) readPayloadLen() (int, error) {
 		return 0, nil
 	case n <= lenSize:
 		return 0, ErrInvalidPktLen
-	case n > MaxPayloadSize+lenSize:
+	case n > OversizePayloadMax+lenSize:
 		return 0, ErrInvalidPktLen
 	default:
 		return n - lenSize, nil

--- a/plumbing/format/pktline/scanner_test.go
+++ b/plumbing/format/pktline/scanner_test.go
@@ -20,7 +20,7 @@ func (s *SuiteScanner) TestInvalid(c *C) {
 	for _, test := range [...]string{
 		"0001", "0002", "0003", "0004",
 		"0001asdfsadf", "0004foo",
-		"fff1", "fff2",
+		"fff5", "ffff",
 		"gorka",
 		"0", "003",
 		"   5a", "5   a", "5   \n",
@@ -31,6 +31,20 @@ func (s *SuiteScanner) TestInvalid(c *C) {
 		_ = sc.Scan()
 		c.Assert(sc.Err(), ErrorMatches, pktline.ErrInvalidPktLen.Error(),
 			Commentf("data = %q", test))
+	}
+}
+
+func (s *SuiteScanner) TestDecodeOversizePktLines(c *C) {
+	for _, test := range [...]string{
+		"fff1" + strings.Repeat("a", 0xfff1),
+		"fff2" + strings.Repeat("a", 0xfff2),
+		"fff3" + strings.Repeat("a", 0xfff3),
+		"fff4" + strings.Repeat("a", 0xfff4),
+	} {
+		r := strings.NewReader(test)
+		sc := pktline.NewScanner(r)
+		_ = sc.Scan()
+		c.Assert(sc.Err(), IsNil)
 	}
 }
 


### PR DESCRIPTION
The canonical Git client successfully decodes sideband packets up to
65524 bytes in length (4-byte header + 65520-byte payload). The Git
protocol documentation was updated in August 2016 to reduce the maximum
payload size to 65516 bytes, however old implementations still exist in
the wild emitting 65520-byte payloads.

As there is no technical difficulty with accepting (not emitting) larger
payload sizes, this change adjusts the limit check to allow successful
decoding of packets up to 65524 bytes. This change increases
compatibility with the current canonical Git implementation.

Doc change from August 2016:
* https://github.com/git/git/commit/7841c4801ce51f1f62d376d164372e8677c6bc94#diff-52695c8fe91b78b70cea44562ae28297L67

Current packet buffer size is still LARGE_PACKET_MAX (+1 null):
* https://github.com/git/git/blob/468165c1d8a442994a825f3684528361727cd8c0/sideband.c#L24
* https://github.com/git/git/blob/468165c1d8a442994a825f3684528361727cd8c0/sideband.c#L36

LARGE_PACKET_MAX definition:
* https://github.com/git/git/blob/468165c1d8a442994a825f3684528361727cd8c0/pkt-line.h#L100