### PR TITLE
dotgit: ignore filenames that don't match a hash

### DIFF
--- a/storage/filesystem/internal/dotgit/dotgit.go
+++ b/storage/filesystem/internal/dotgit/dotgit.go
@@ -162,8 +162,11 @@ func (d *DotGit) ObjectPacks() ([]plumbing.Hash, error) {
 
 		n := f.Name()
 		h := plumbing.NewHash(n[5 : len(n)-5]) //pack-(hash).pack
+		if h.IsZero() {
+			// Ignore files with badly-formatted names.
+			continue
+		}
 		packs = append(packs, h)
-
 	}
 
 	return packs, nil
@@ -255,7 +258,12 @@ func (d *DotGit) ForEachObjectHash(fun func(plumbing.Hash) error) error {
 			}
 
 			for _, o := range d {
-				err = fun(plumbing.NewHash(base + o.Name()))
+				h := plumbing.NewHash(base + o.Name())
+				if h.IsZero() {
+					// Ignore files with badly-formatted names.
+					continue
+				}
+				err = fun(h)
 				if err != nil {
 					return err
 				}

--- a/storage/filesystem/internal/dotgit/dotgit_test.go
+++ b/storage/filesystem/internal/dotgit/dotgit_test.go
@@ -418,7 +418,7 @@ func findReference(refs []*plumbing.Reference, name string) *plumbing.Reference 
 	return nil
 }
 
-func (s *SuiteDotGit) TestObjectsPack(c *C) {
+func (s *SuiteDotGit) TestObjectPacks(c *C) {
 	f := fixtures.Basic().ByTag(".git").One()
 	fs := f.DotGit()
 	dir := New(fs)
@@ -427,6 +427,18 @@ func (s *SuiteDotGit) TestObjectsPack(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(hashes, HasLen, 1)
 	c.Assert(hashes[0], Equals, f.PackfileHash)
+
+	// Make sure that a random file in the pack directory doesn't
+	// break everything.
+	badFile, err := fs.Create("objects/pack/OOPS_THIS_IS_NOT_RIGHT.pack")
+	c.Assert(err, IsNil)
+	err = badFile.Close()
+	c.Assert(err, IsNil)
+
+	hashes2, err := dir.ObjectPacks()
+	c.Assert(err, IsNil)
+	c.Assert(hashes2, HasLen, 1)
+	c.Assert(hashes[0], Equals, hashes2[0])
 }
 
 func (s *SuiteDotGit) TestObjectPack(c *C) {


### PR DESCRIPTION
For both packfiles and object files.

Issue: keybase/client#11366