### PR TITLE
storage: dotgit, init fixtures in benchmark. Fixes #770

### DIFF
--- a/storage/filesystem/internal/dotgit/dotgit_test.go
+++ b/storage/filesystem/internal/dotgit/dotgit_test.go
@@ -151,6 +151,7 @@ func (s *SuiteDotGit) TestRefsFromReferenceFile(c *C) {
 }
 
 func BenchmarkRefMultipleTimes(b *testing.B) {
+	fixtures.Init()
 	fs := fixtures.Basic().ByTag(".git").One().DotGit()
 	refname := plumbing.ReferenceName("refs/remotes/origin/branch")
 


### PR DESCRIPTION
`fixtures` is not initialized in BenchmarkRefMultipleTimes and caused panic.