### PR TITLE
git: remote, Add shallow commits instead of substituting. Fixes #412

### DIFF
--- a/remote.go
+++ b/remote.go
@@ -976,9 +976,24 @@ func pushHashes(
 }
 
 func (r *Remote) updateShallow(o *FetchOptions, resp *packp.UploadPackResponse) error {
-	if o.Depth == 0 {
+	if o.Depth == 0 || len(resp.Shallows) == 0 {
 		return nil
 	}
 
-	return r.s.SetShallow(resp.Shallows)
+	shallows, err := r.s.Shallow()
+	if err != nil {
+		return err
+	}
+
+outer:
+	for _, s := range resp.Shallows {
+		for _, oldS := range shallows {
+			if s == oldS {
+				continue outer
+			}
+		}
+		shallows = append(shallows, s)
+	}
+
+	return r.s.SetShallow(shallows)
 }


### PR DESCRIPTION
`updateShallow` substituted the previous shallow list with the one returned by the `UploadPackResponse`. If the repository had previous shallow commits these are deleted from the list.

This change adds the new shallow hashes to the old ones.

The test `TestBrokenMultipleShallowFetch` is copied from #412. This probably a fix also for #802.