### PR TITLE
plumbing: packp, Report Status should continue decoding after band 1 is flushed. Fixes #787

### DIFF
--- a/plumbing/protocol/packp/report_status_test.go
+++ b/plumbing/protocol/packp/report_status_test.go
@@ -47,6 +47,13 @@ func (s *ReportStatusSuite) testDecodeOk(c *C, expected *ReportStatus, lines ...
 	c.Assert(rs, DeepEquals, expected)
 }
 
+func (s *ReportStatusSuite) testDecodeOkWithSideband(c *C, expected *ReportStatus, lines ...string) {
+	r := toPktLines(c, lines)
+	rs := NewReportStatusWithSideband()
+	c.Assert(rs.Decode(r), IsNil)
+	c.Assert(rs, DeepEquals, expected)
+}
+
 func (s *ReportStatusSuite) testDecodeError(c *C, errorMatch string, lines ...string) {
 	r := toPktLines(c, lines)
 	rs := NewReportStatus()
@@ -302,5 +309,5 @@ func (s *ReportStatusSuite) TestEncodeDecodeOkWithVerboseSideband(c *C) {
 		pktline.FlushString,
 	}
 
-	s.testDecodeOk(c, rs, payloads...)
+	s.testDecodeOkWithSideband(c, rs, payloads...)
 }

--- a/plumbing/protocol/packp/report_status_test.go
+++ b/plumbing/protocol/packp/report_status_test.go
@@ -256,8 +256,33 @@ func (s *ReportStatusSuite) TestDecodeErrorPrematureFlush(c *C) {
 	)
 }
 
-func (s *ReportStatusSuite) TestEncodeDecodeOkWithVerboseSideband(c *C) {
+func (s *ReportStatusSuite) TestEncodeDecodeOkWithoutVerboseSideband(c *C) {
 	rs := NewReportStatus()
+	rs.UnpackStatus = "ok"
+	rs.CommandStatuses = []*CommandStatus{{
+		ReferenceName: plumbing.ReferenceName("refs/heads/develop"),
+		Status:        "ok",
+	}}
+
+	payloads := []string{
+		"unpack ok\n",
+		"ok refs/heads/develop\n",
+		pktline.FlushString,
+		string(sideband.ProgressMessage),
+		"\n",
+		"This is extra information on band 2, the verbose band.\n",
+		"None of this should affect the decoding of band 1, which is the actual data band.\n",
+		"",
+		"",
+		pktline.FlushString,
+	}
+
+	s.testDecodeOk(c, rs, payloads...)
+}
+
+
+func (s *ReportStatusSuite) TestEncodeDecodeOkWithVerboseSideband(c *C) {
+	rs := NewReportStatusWithSideband()
 	rs.UnpackStatus = "ok"
 	rs.CommandStatuses = []*CommandStatus{{
 		ReferenceName: plumbing.ReferenceName("refs/heads/develop"),

--- a/plumbing/transport/http/receive_pack.go
+++ b/plumbing/transport/http/receive_pack.go
@@ -67,7 +67,14 @@ func (s *rpSession) ReceivePack(ctx context.Context, req *packp.ReferenceUpdateR
 
 	rc := ioutil.NewReadCloser(r, res.Body)
 
-	report := packp.NewReportStatus()
+	var report *packp.ReportStatus
+	if req.Capabilities.Supports(capability.Sideband64k) ||
+		req.Capabilities.Supports(capability.Sideband) {
+		report = packp.NewReportStatusWithSideband()
+	} else {
+		report = packp.NewReportStatus()
+	}
+
 	if err := report.Decode(rc); err != nil {
 		return nil, err
 	}

--- a/plumbing/transport/internal/common/common.go
+++ b/plumbing/transport/internal/common/common.go
@@ -317,7 +317,14 @@ func (s *session) ReceivePack(ctx context.Context, req *packp.ReferenceUpdateReq
 		r = d
 	}
 
-	report := packp.NewReportStatus()
+	var report *packp.ReportStatus
+	if req.Capabilities.Supports(capability.Sideband64k) ||
+		req.Capabilities.Supports(capability.Sideband) {
+		report = packp.NewReportStatusWithSideband()
+	} else {
+		report = packp.NewReportStatus()
+	}
+
 	if err := report.Decode(r); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
As described on #787 ReportStatus breaks out before decoding all bands in responses. While I understand the reasoning behind it, it also means that anything on band 2 will never be decoded.

This PR changes that behaviour to keep decoding after the first flush, allowing band 2 to still be output.

I decided to keep this within ReportStatus, as that will be used across transports and is in line with the official Git client. That also always decodes sidebands if support is enabled.