### PR TITLE
config: modules, worktree: Submodule fixes for CVE-2018-11235

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -135,7 +135,7 @@ func (c *Config) Unmarshal(b []byte) error {
 	if err := c.unmarshalPack(); err != nil {
 		return err
 	}
-	c.unmarshalSubmodules()
+	unmarshalSubmodules(c.Raw, c.Submodules)
 
 	if err := c.unmarshalBranches(); err != nil {
 		return err
@@ -182,13 +182,17 @@ func (c *Config) unmarshalRemotes() error {
 	return nil
 }
 
-func (c *Config) unmarshalSubmodules() {
-	s := c.Raw.Section(submoduleSection)
+func unmarshalSubmodules(fc *format.Config, submodules map[string]*Submodule) {
+	s := fc.Section(submoduleSection)
 	for _, sub := range s.Subsections {
 		m := &Submodule{}
 		m.unmarshal(sub)
 
-		c.Submodules[m.Name] = m
+		if m.Validate() == ErrModuleBadPath {
+			continue
+		}
+
+		submodules[m.Name] = m
 	}
 }
 

--- a/config/modules.go
+++ b/config/modules.go
@@ -3,6 +3,7 @@ package config
 import (
 	"bytes"
 	"errors"
+	"regexp"
 
 	format "gopkg.in/src-d/go-git.v4/plumbing/format/config"
 )
@@ -10,6 +11,12 @@ import (
 var (
 	ErrModuleEmptyURL  = errors.New("module config: empty URL")
 	ErrModuleEmptyPath = errors.New("module config: empty path")
+	ErrModuleBadPath   = errors.New("submodule has an invalid path")
+)
+
+var (
+	// Matches module paths with dotdot ".." components.
+	dotdotPath = regexp.MustCompile(`(^|[/\\])\.\.([/\\]|$)`)
 )
 
 // Modules defines the submodules properties, represents a .gitmodules file
@@ -44,14 +51,7 @@ func (m *Modules) Unmarshal(b []byte) error {
 		return err
 	}
 
-	s := m.raw.Section(submoduleSection)
-	for _, sub := range s.Subsections {
-		mod := &Submodule{}
-		mod.unmarshal(sub)
-
-		m.Submodules[mod.Path] = mod
-	}
-
+	unmarshalSubmodules(m.raw, m.Submodules)
 	return nil
 }
 
@@ -100,6 +100,10 @@ func (m *Submodule) Validate() error {
 
 	if m.URL == "" {
 		return ErrModuleEmptyURL
+	}
+
+	if dotdotPath.MatchString(m.Path) {
+		return ErrModuleBadPath
 	}
 
 	return nil

--- a/config/modules_test.go
+++ b/config/modules_test.go
@@ -11,6 +11,29 @@ func (s *ModulesSuite) TestValidateMissingURL(c *C) {
 	c.Assert(m.Validate(), Equals, ErrModuleEmptyURL)
 }
 
+func (s *ModulesSuite) TestValidateBadPath(c *C) {
+	input := []string{
+		`..`,
+		`../`,
+		`../bar`,
+
+		`/..`,
+		`/../bar`,
+
+		`foo/..`,
+		`foo/../`,
+		`foo/../bar`,
+	}
+
+	for _, p := range input {
+		m := &Submodule{
+			Path: p,
+			URL:  "https://example.com/",
+		}
+		c.Assert(m.Validate(), Equals, ErrModuleBadPath)
+	}
+}
+
 func (s *ModulesSuite) TestValidateMissingName(c *C) {
 	m := &Submodule{URL: "bar"}
 	c.Assert(m.Validate(), Equals, ErrModuleEmptyPath)
@@ -39,6 +62,9 @@ func (s *ModulesSuite) TestUnmarshall(c *C) {
         path = foo/bar
         url = https://github.com/foo/bar.git
 		branch = dev
+[submodule "suspicious"]
+        path = ../../foo/bar
+        url = https://github.com/foo/bar.git
 `)
 
 	cfg := NewModules()

--- a/submodule_test.go
+++ b/submodule_test.go
@@ -196,6 +196,21 @@ func (s *SubmoduleSuite) TestSubmodulesInit(c *C) {
 	}
 }
 
+func (s *SubmoduleSuite) TestGitSubmodulesSymlink(c *C) {
+	f, err := s.Worktree.Filesystem.Create("badfile")
+	c.Assert(err, IsNil)
+	defer f.Close()
+
+	err = s.Worktree.Filesystem.Remove(gitmodulesFile)
+	c.Assert(err, IsNil)
+
+	err = s.Worktree.Filesystem.Symlink("badfile", gitmodulesFile)
+	c.Assert(err, IsNil)
+
+	_, err = s.Worktree.Submodules()
+	c.Assert(err, Equals, ErrGitModulesSymlink)
+}
+
 func (s *SubmoduleSuite) TestSubmodulesStatus(c *C) {
 	sm, err := s.Worktree.Submodules()
 	c.Assert(err, IsNil)


### PR DESCRIPTION
This PR contains two fixes addressing [CVE-2018-11235](https://nvd.nist.gov/vuln/detail/CVE-2018-11235):

1. Ignore submodules containing "`..`" in the module path.
2. Do not allow `.gitmodules` to be a symlink.

Both of these changes mirror fixes made by the canonical Git project in response to the CVE.

References:
  * https://blogs.msdn.microsoft.com/devops/2018/05/29/announcing-the-may-2018-git-security-vulnerability/
  * https://security-tracker.debian.org/tracker/CVE-2018-11235
  * https://github.com/git/git/commit/10ecfa76491e4923988337b2e2243b05376b40de
  * https://github.com/git/git/commit/0383bbb9015898cbc79abd7b64316484d7713b44
