### PR TITLE
storage: filesystem, make ObjectStorage constructor public

### DIFF
--- a/storage/filesystem/object.go
+++ b/storage/filesystem/object.go
@@ -26,7 +26,8 @@ type ObjectStorage struct {
 	index map[plumbing.Hash]*packfile.Index
 }
 
-func newObjectStorage(dir *dotgit.DotGit) (ObjectStorage, error) {
+// NewObjectStorage creates a new ObjectStorage with the given .git directory.
+func NewObjectStorage(dir *dotgit.DotGit) (ObjectStorage, error) {
 	s := ObjectStorage{
 		deltaBaseCache: cache.NewObjectLRUDefault(),
 		dir:            dir,
@@ -166,7 +167,7 @@ func (s *ObjectStorage) EncodedObject(t plumbing.ObjectType, h plumbing.Hash) (p
 			// Create a new object storage with the DotGit(s) and check for the
 			// required hash object. Skip when not found.
 			for _, dg := range dotgits {
-				o, oe := newObjectStorage(dg)
+				o, oe := NewObjectStorage(dg)
 				if oe != nil {
 					continue
 				}

--- a/storage/filesystem/object_test.go
+++ b/storage/filesystem/object_test.go
@@ -24,7 +24,7 @@ var _ = Suite(&FsSuite{
 
 func (s *FsSuite) TestGetFromObjectFile(c *C) {
 	fs := fixtures.ByTag(".git").ByTag("unpacked").One().DotGit()
-	o, err := newObjectStorage(dotgit.New(fs))
+	o, err := NewObjectStorage(dotgit.New(fs))
 	c.Assert(err, IsNil)
 
 	expected := plumbing.NewHash("f3dfe29d268303fc6e1bbce268605fc99573406e")
@@ -36,7 +36,7 @@ func (s *FsSuite) TestGetFromObjectFile(c *C) {
 func (s *FsSuite) TestGetFromPackfile(c *C) {
 	fixtures.Basic().ByTag(".git").Test(c, func(f *fixtures.Fixture) {
 		fs := f.DotGit()
-		o, err := newObjectStorage(dotgit.New(fs))
+		o, err := NewObjectStorage(dotgit.New(fs))
 		c.Assert(err, IsNil)
 
 		expected := plumbing.NewHash("6ecf0ef2c2dffb796033e5a02219af86ec6584e5")
@@ -48,7 +48,7 @@ func (s *FsSuite) TestGetFromPackfile(c *C) {
 
 func (s *FsSuite) TestGetFromPackfileMultiplePackfiles(c *C) {
 	fs := fixtures.ByTag(".git").ByTag("multi-packfile").One().DotGit()
-	o, err := newObjectStorage(dotgit.New(fs))
+	o, err := NewObjectStorage(dotgit.New(fs))
 	c.Assert(err, IsNil)
 
 	expected := plumbing.NewHash("8d45a34641d73851e01d3754320b33bb5be3c4d3")
@@ -65,7 +65,7 @@ func (s *FsSuite) TestGetFromPackfileMultiplePackfiles(c *C) {
 func (s *FsSuite) TestIter(c *C) {
 	fixtures.ByTag(".git").ByTag("packfile").Test(c, func(f *fixtures.Fixture) {
 		fs := f.DotGit()
-		o, err := newObjectStorage(dotgit.New(fs))
+		o, err := NewObjectStorage(dotgit.New(fs))
 		c.Assert(err, IsNil)
 
 		iter, err := o.IterEncodedObjects(plumbing.AnyObject)
@@ -86,7 +86,7 @@ func (s *FsSuite) TestIterWithType(c *C) {
 	fixtures.ByTag(".git").Test(c, func(f *fixtures.Fixture) {
 		for _, t := range s.Types {
 			fs := f.DotGit()
-			o, err := newObjectStorage(dotgit.New(fs))
+			o, err := NewObjectStorage(dotgit.New(fs))
 			c.Assert(err, IsNil)
 
 			iter, err := o.IterEncodedObjects(t)

--- a/storage/filesystem/storage.go
+++ b/storage/filesystem/storage.go
@@ -25,7 +25,7 @@ type Storage struct {
 // NewStorage returns a new Storage backed by a given `fs.Filesystem`
 func NewStorage(fs billy.Filesystem) (*Storage, error) {
 	dir := dotgit.New(fs)
-	o, err := newObjectStorage(dir)
+	o, err := NewObjectStorage(dir)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Now that `dotgit` package is public it would be useful to make `ObjectStorage` constructor public as well, since `ObjectStorage` is already public and now it can be used.