### PR TITLE
git: fix documentation for Notes

### DIFF
--- a/repository.go
+++ b/repository.go
@@ -872,7 +872,8 @@ func (r *Repository) Branches() (storer.ReferenceIter, error) {
 		}, refIter), nil
 }
 
-// Notes returns all the References that are Branches.
+// Notes returns all the References that are notes. For more information:
+// https://git-scm.com/docs/git-notes
 func (r *Repository) Notes() (storer.ReferenceIter, error) {
 	refIter, err := r.Storer.IterReferences()
 	if err != nil {


### PR DESCRIPTION
It previously said that it returned all references that are branches, but that's not true.