### PR TITLE
Remote.Fetch: error on missing remote reference

### DIFF
--- a/remote.go
+++ b/remote.go
@@ -630,14 +630,29 @@ func calculateRefs(
 		spec = append(spec, refspecTag)
 	}
 
-	iter, err := remoteRefs.IterReferences()
-	if err != nil {
-		return nil, err
+	refs := make(memory.ReferenceStorage)
+	for _, s := range spec {
+		if err := doCalculateRefs(s, remoteRefs, refs); err != nil {
+			return nil, err
+		}
 	}
 
-	refs := make(memory.ReferenceStorage)
-	return refs, iter.ForEach(func(ref *plumbing.Reference) error {
-		if !config.MatchAny(spec, ref.Name()) {
+	return refs, nil
+}
+
+func doCalculateRefs(
+	s config.RefSpec,
+	remoteRefs storer.ReferenceStorer,
+	refs memory.ReferenceStorage,
+) error {
+	iter, err := remoteRefs.IterReferences()
+	if err != nil {
+		return err
+	}
+
+	var matched bool
+	err = iter.ForEach(func(ref *plumbing.Reference) error {
+		if !s.Match(ref.Name()) {
 			return nil
 		}
 
@@ -654,8 +669,23 @@ func calculateRefs(
 			return nil
 		}
 
-		return refs.SetReference(ref)
+		matched = true
+		if err := refs.SetReference(ref); err != nil {
+			return err
+		}
+
+		if !s.IsWildcard() {
+			return storer.ErrStop
+		}
+
+		return nil
 	})
+
+	if !matched && !s.IsWildcard() {
+		return fmt.Errorf("couldn't find remote ref %q", s.Src())
+	}
+
+	return err
 }
 
 func getWants(localStorer storage.Storer, refs memory.ReferenceStorage) ([]plumbing.Hash, error) {

--- a/remote_test.go
+++ b/remote_test.go
@@ -100,6 +100,20 @@ func (s *RemoteSuite) TestFetch(c *C) {
 	})
 }
 
+func (s *RemoteSuite) TestFetchNonExistantReference(c *C) {
+	r := newRemote(memory.NewStorage(), &config.RemoteConfig{
+		URLs: []string{s.GetLocalRepositoryURL(fixtures.ByTag("tags").One())},
+	})
+
+	err := r.Fetch(&FetchOptions{
+		RefSpecs: []config.RefSpec{
+			config.RefSpec("+refs/heads/foo:refs/remotes/origin/foo"),
+		},
+	})
+
+	c.Assert(err, ErrorMatches, "couldn't find remote ref.*")
+}
+
 func (s *RemoteSuite) TestFetchContext(c *C) {
 	r := newRemote(memory.NewStorage(), &config.RemoteConfig{
 		URLs: []string{s.GetLocalRepositoryURL(fixtures.ByTag("tags").One())},


### PR DESCRIPTION
A Fetch from a remote with a non-wildcard refspec should fail.

 ```
git fetch origin "+refs/pull/1/head:refs/pull/1/head"
fatal: Couldn't find remote ref refs/pull/1/head
```