### PR TITLE
plumbing: object, return ErrFileNotFound in FindEntry. Fixes #883

### DIFF
--- a/plumbing/object/tree.go
+++ b/plumbing/object/tree.go
@@ -25,6 +25,7 @@ var (
 	ErrMaxTreeDepth      = errors.New("maximum tree depth exceeded")
 	ErrFileNotFound      = errors.New("file not found")
 	ErrDirectoryNotFound = errors.New("directory not found")
+	ErrEntryNotFound     = errors.New("entry not found")
 )
 
 // Tree is basically like a directory - it references a bunch of other trees
@@ -166,8 +167,6 @@ func (t *Tree) dir(baseName string) (*Tree, error) {
 	return tree, err
 }
 
-var errEntryNotFound = errors.New("entry not found")
-
 func (t *Tree) entry(baseName string) (*TreeEntry, error) {
 	if t.m == nil {
 		t.buildMap()
@@ -175,7 +174,7 @@ func (t *Tree) entry(baseName string) (*TreeEntry, error) {
 
 	entry, ok := t.m[baseName]
 	if !ok {
-		return nil, errEntryNotFound
+		return nil, ErrEntryNotFound
 	}
 
 	return entry, nil

--- a/plumbing/object/tree_test.go
+++ b/plumbing/object/tree_test.go
@@ -114,6 +114,12 @@ func (s *TreeSuite) TestFindEntry(c *C) {
 	c.Assert(e.Name, Equals, "foo.go")
 }
 
+func (s *TreeSuite) TestFindEntryNotFound(c *C) {
+	e, err := s.Tree.FindEntry("not-found")
+	c.Assert(e, IsNil)
+	c.Assert(err, Equals, ErrEntryNotFound)
+}
+
 // Overrides returned plumbing.EncodedObject for given hash.
 // Otherwise, delegates to actual storer to get real object
 type fakeStorer struct {


### PR DESCRIPTION
FindEntry will return ErrDirNotFound if the directory doesn't exist. But
it doesn't return the corresponding error if the file itself is missing.
This adds the logic to return ErrEntryNotFound, so users can
programmatically check for this condition.