### PR TITLE
added support for quarantine directory

### DIFF
--- a/storage/filesystem/dotgit/dotgit_test.go
+++ b/storage/filesystem/dotgit/dotgit_test.go
@@ -9,11 +9,11 @@ import (
 	"strings"
 	"testing"
 
+	fixtures "gopkg.in/src-d/go-git-fixtures.v3"
 	"gopkg.in/src-d/go-git.v4/plumbing"
 
 	. "gopkg.in/check.v1"
 	"gopkg.in/src-d/go-billy.v4/osfs"
-	"gopkg.in/src-d/go-git-fixtures.v3"
 )
 
 func Test(t *testing.T) { TestingT(t) }
@@ -537,6 +537,53 @@ func (s *SuiteDotGit) TestObject(c *C) {
 		file.Name(), fs.Join("objects", "03", "db8e1fbe133a480f2867aac478fd866686d69e")),
 		Equals, true,
 	)
+	incomingHash := "9d25e0f9bde9f82882b49fe29117b9411cb157b7" //made up hash
+	incomingDirPath := fs.Join("objects", "incoming-123456")
+	incomingFilePath := fs.Join(incomingDirPath, incomingHash[0:2], incomingHash[2:40])
+	fs.MkdirAll(incomingDirPath, os.FileMode(0755))
+	fs.Create(incomingFilePath)
+
+	file, err = dir.Object(plumbing.NewHash(incomingHash))
+	c.Assert(err, IsNil)
+}
+
+func (s *SuiteDotGit) TestObjectStat(c *C) {
+	fs := fixtures.ByTag(".git").ByTag("unpacked").One().DotGit()
+	dir := New(fs)
+
+	hash := plumbing.NewHash("03db8e1fbe133a480f2867aac478fd866686d69e")
+	_, err := dir.ObjectStat(hash)
+	c.Assert(err, IsNil)
+	incomingHash := "9d25e0f9bde9f82882b49fe29117b9411cb157b7" //made up hash
+	incomingDirPath := fs.Join("objects", "incoming-123456")
+	incomingFilePath := fs.Join(incomingDirPath, incomingHash[0:2], incomingHash[2:40])
+	fs.MkdirAll(incomingDirPath, os.FileMode(0755))
+	fs.Create(incomingFilePath)
+
+	_, err = dir.ObjectStat(plumbing.NewHash(incomingHash))
+	c.Assert(err, IsNil)
+}
+
+func (s *SuiteDotGit) TestObjectDelete(c *C) {
+	fs := fixtures.ByTag(".git").ByTag("unpacked").One().DotGit()
+	dir := New(fs)
+
+	hash := plumbing.NewHash("03db8e1fbe133a480f2867aac478fd866686d69e")
+	err := dir.ObjectDelete(hash)
+	c.Assert(err, IsNil)
+	//incomingHash := "9d25e0f9bde9f82882b49fe29117b9411cb157b7" //made up hash
+	//incomingDirPath := fs.Join("objects", "incoming-123456")
+	//incomingSubDirPath := fs.Join(incomingDirPath, incomingHash[0:2])
+	//incomingFilePath := fs.Join(incomingDirPath, incomingHash[2:40])
+	//err = fs.MkdirAll(incomingDirPath, os.FileMode(0755))
+	//c.Assert(err, IsNil)
+	//err = fs.MkdirAll(incomingSubDirPath, os.FileMode(0755))
+	//c.Assert(err, IsNil)
+	//_, err = fs.Create(incomingFilePath)
+	//c.Assert(err, IsNil)
+
+	//err = dir.ObjectDelete(plumbing.NewHash(incomingHash))
+	//c.Assert(err, IsNil)
 }
 
 func (s *SuiteDotGit) TestObjectNotFound(c *C) {

--- a/storage/filesystem/dotgit/dotgit_test.go
+++ b/storage/filesystem/dotgit/dotgit_test.go
@@ -9,11 +9,11 @@ import (
 	"strings"
 	"testing"
 
-	fixtures "gopkg.in/src-d/go-git-fixtures.v3"
 	"gopkg.in/src-d/go-git.v4/plumbing"
 
 	. "gopkg.in/check.v1"
 	"gopkg.in/src-d/go-billy.v4/osfs"
+	"gopkg.in/src-d/go-git-fixtures.v3"
 )
 
 func Test(t *testing.T) { TestingT(t) }
@@ -571,19 +571,23 @@ func (s *SuiteDotGit) TestObjectDelete(c *C) {
 	hash := plumbing.NewHash("03db8e1fbe133a480f2867aac478fd866686d69e")
 	err := dir.ObjectDelete(hash)
 	c.Assert(err, IsNil)
-	//incomingHash := "9d25e0f9bde9f82882b49fe29117b9411cb157b7" //made up hash
-	//incomingDirPath := fs.Join("objects", "incoming-123456")
-	//incomingSubDirPath := fs.Join(incomingDirPath, incomingHash[0:2])
-	//incomingFilePath := fs.Join(incomingDirPath, incomingHash[2:40])
-	//err = fs.MkdirAll(incomingDirPath, os.FileMode(0755))
-	//c.Assert(err, IsNil)
-	//err = fs.MkdirAll(incomingSubDirPath, os.FileMode(0755))
-	//c.Assert(err, IsNil)
-	//_, err = fs.Create(incomingFilePath)
-	//c.Assert(err, IsNil)
 
-	//err = dir.ObjectDelete(plumbing.NewHash(incomingHash))
-	//c.Assert(err, IsNil)
+	incomingHash := "9d25e0f9bde9f82882b49fe29117b9411cb157b7" //made up hash
+	incomingDirPath := fs.Join("objects", "incoming-123456")
+	incomingSubDirPath := fs.Join(incomingDirPath, incomingHash[0:2])
+	incomingFilePath := fs.Join(incomingSubDirPath, incomingHash[2:40])
+
+	err = fs.MkdirAll(incomingSubDirPath, os.FileMode(0755))
+	c.Assert(err, IsNil)
+
+	f, err := fs.Create(incomingFilePath)
+	c.Assert(err, IsNil)
+
+	err = f.Close()
+	c.Assert(err, IsNil)
+
+	err = dir.ObjectDelete(plumbing.NewHash(incomingHash))
+	c.Assert(err, IsNil)
 }
 
 func (s *SuiteDotGit) TestObjectNotFound(c *C) {


### PR DESCRIPTION
This is a part of issue #886 
I have tested this on my local installation and it has allowed me to create a "commitObject" from an object sitting in a quarantine directory as per the git-receive-pack

This code might be put in the wrong place, or implemented differently than you all would like, so feel free to move/alter it.
The idea of it is to check to see if the file whose path you're returning is actually there, and if not to see if there is an `incoming-XXXXXXX` directory and look for the file in there