### PR TITLE
plumbing/transport/internal: common, support Gogs for ErrRepositoryNotFound

### DIFF
--- a/plumbing/transport/internal/common/common.go
+++ b/plumbing/transport/internal/common/common.go
@@ -382,6 +382,7 @@ var (
 	gitProtocolNotFoundErr     = "ERR \n  Repository not found."
 	gitProtocolNoSuchErr       = "ERR no such repository"
 	gitProtocolAccessDeniedErr = "ERR access denied"
+	gogsAccessDeniedErr        = "Gogs: Repository does not exist or you do not have access"
 )
 
 func isRepoNotFoundError(s string) bool {
@@ -406,6 +407,10 @@ func isRepoNotFoundError(s string) bool {
 	}
 
 	if strings.HasPrefix(s, gitProtocolAccessDeniedErr) {
+		return true
+	}
+
+	if strings.HasPrefix(s, gogsAccessDeniedErr) {
 		return true
 	}
 

--- a/plumbing/transport/internal/common/common_test.go
+++ b/plumbing/transport/internal/common/common_test.go
@@ -1,0 +1,78 @@
+package common
+
+import (
+	"fmt"
+	"testing"
+
+	. "gopkg.in/check.v1"
+)
+
+func Test(t *testing.T) { TestingT(t) }
+
+type CommonSuite struct{}
+
+var _ = Suite(&CommonSuite{})
+
+func (s *CommonSuite) TestIsRepoNotFoundErrorForUnknowSource(c *C) {
+	msg := "unknown system is complaining of something very sad :("
+
+	isRepoNotFound := isRepoNotFoundError(msg)
+
+	c.Assert(isRepoNotFound, Equals, false)
+}
+
+func (s *CommonSuite) TestIsRepoNotFoundErrorForGithub(c *C) {
+	msg := fmt.Sprintf("%s : some error stuf", githubRepoNotFoundErr)
+
+	isRepoNotFound := isRepoNotFoundError(msg)
+
+	c.Assert(isRepoNotFound, Equals, true)
+}
+
+func (s *CommonSuite) TestIsRepoNotFoundErrorForBitBucket(c *C) {
+	msg := fmt.Sprintf("%s : some error stuf", bitbucketRepoNotFoundErr)
+
+	isRepoNotFound := isRepoNotFoundError(msg)
+
+	c.Assert(isRepoNotFound, Equals, true)
+}
+
+func (s *CommonSuite) TestIsRepoNotFoundErrorForLocal(c *C) {
+	msg := fmt.Sprintf("some error stuf : %s", localRepoNotFoundErr)
+
+	isRepoNotFound := isRepoNotFoundError(msg)
+
+	c.Assert(isRepoNotFound, Equals, true)
+}
+
+func (s *CommonSuite) TestIsRepoNotFoundErrorForGitProtocolNotFound(c *C) {
+	msg := fmt.Sprintf("%s : some error stuf", gitProtocolNotFoundErr)
+
+	isRepoNotFound := isRepoNotFoundError(msg)
+
+	c.Assert(isRepoNotFound, Equals, true)
+}
+
+func (s *CommonSuite) TestIsRepoNotFoundErrorForGitProtocolNoSuch(c *C) {
+	msg := fmt.Sprintf("%s : some error stuf", gitProtocolNoSuchErr)
+
+	isRepoNotFound := isRepoNotFoundError(msg)
+
+	c.Assert(isRepoNotFound, Equals, true)
+}
+
+func (s *CommonSuite) TestIsRepoNotFoundErrorForGitProtocolAccessDenied(c *C) {
+	msg := fmt.Sprintf("%s : some error stuf", gitProtocolAccessDeniedErr)
+
+	isRepoNotFound := isRepoNotFoundError(msg)
+
+	c.Assert(isRepoNotFound, Equals, true)
+}
+
+func (s *CommonSuite) TestIsRepoNotFoundErrorForGogsAccessDenied(c *C) {
+	msg := fmt.Sprintf("%s : some error stuf", gogsAccessDeniedErr)
+
+	isRepoNotFound := isRepoNotFoundError(msg)
+
+	c.Assert(isRepoNotFound, Equals, true)
+}


### PR DESCRIPTION
get an `ErrRepositoryNotFound` instead of "unknown error" when trying to clone a non-existing repository from Gogs.

In bonus, I add some unit tests for existing case in plumbing/transport/internal/common/common.go#isRepoNotFoundError

NB : I detect this behavior when using Gogs for integration test of git clone with ssh. 