### PR TITLE
plumbing/idxfile: object iterators returns entries in offset order

### DIFF
--- a/plumbing/format/idxfile/idxfile_test.go
+++ b/plumbing/format/idxfile/idxfile_test.go
@@ -115,6 +115,21 @@ func (s *IndexSuite) TestFindHash(c *C) {
 	}
 }
 
+func (s *IndexSuite) TestEntriesByOffset(c *C) {
+	idx, err := fixtureIndex()
+	c.Assert(err, IsNil)
+
+	entries, err := idx.EntriesByOffset()
+	c.Assert(err, IsNil)
+
+	for _, pos := range fixtureOffsets {
+		e, err := entries.Next()
+		c.Assert(err, IsNil)
+
+		c.Assert(e.Offset, Equals, uint64(pos))
+	}
+}
+
 var fixtureHashes = []plumbing.Hash{
 	plumbing.NewHash("303953e5aa461c203a324821bc1717f9b4fff895"),
 	plumbing.NewHash("5296768e3d9f661387ccbff18c4dea6c997fd78c"),

--- a/plumbing/format/packfile/packfile.go
+++ b/plumbing/format/packfile/packfile.go
@@ -394,7 +394,7 @@ func (p *Packfile) GetByType(typ plumbing.ObjectType) (storer.EncodedObjectIter,
 		plumbing.TreeObject,
 		plumbing.CommitObject,
 		plumbing.TagObject:
-		entries, err := p.Entries()
+		entries, err := p.EntriesByOffset()
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
In the latest change the order was changed from offset order in packfiles to hash order. This makes reading all the objects not as efficient as before. It also created problems when the previous order was expected.

Also added `EntriesByOffset` to indexes.