### PR TITLE
plumbing, storage: add bases to the common cache

### DIFF
--- a/plumbing/format/packfile/fsobject.go
+++ b/plumbing/format/packfile/fsobject.go
@@ -47,6 +47,16 @@ func NewFSObject(
 
 // Reader implements the plumbing.EncodedObject interface.
 func (o *FSObject) Reader() (io.ReadCloser, error) {
+	obj, ok := o.cache.Get(o.hash)
+	if ok {
+		reader, err := obj.Reader()
+		if err != nil {
+			return nil, err
+		}
+
+		return reader, nil
+	}
+
 	f, err := o.fs.Open(o.path)
 	if err != nil {
 		return nil, err

--- a/plumbing/format/packfile/packfile.go
+++ b/plumbing/format/packfile/packfile.go
@@ -258,6 +258,19 @@ func (p *Packfile) nextObject() (plumbing.EncodedObject, error) {
 }
 
 func (p *Packfile) getObjectContent(offset int64) (io.ReadCloser, error) {
+	ref, err := p.FindHash(offset)
+	if err == nil {
+		obj, ok := p.cacheGet(ref)
+		if ok {
+			reader, err := obj.Reader()
+			if err != nil {
+				return nil, err
+			}
+
+			return reader, nil
+		}
+	}
+
 	if _, err := p.s.SeekFromStart(offset); err != nil {
 		return nil, err
 	}
@@ -306,6 +319,8 @@ func (p *Packfile) fillRegularObjectContent(obj plumbing.EncodedObject) error {
 	}
 
 	_, _, err = p.s.NextObject(w)
+	p.cachePut(obj)
+
 	return err
 }
 

--- a/storage/filesystem/object.go
+++ b/storage/filesystem/object.go
@@ -295,7 +295,14 @@ func (s *ObjectStorage) decodeObjectAt(
 		return nil, err
 	}
 
-	return packfile.NewPackfile(idx, s.dir.Fs(), f).GetByOffset(offset)
+	var p *packfile.Packfile
+	if s.deltaBaseCache != nil {
+		p = packfile.NewPackfileWithCache(idx, s.dir.Fs(), f, s.deltaBaseCache)
+	} else {
+		p = packfile.NewPackfile(idx, s.dir.Fs(), f)
+	}
+
+	return p.GetByOffset(offset)
 }
 
 func (s *ObjectStorage) decodeDeltaObjectAt(
@@ -486,7 +493,14 @@ func newPackfileIter(
 	index idxfile.Index,
 	cache cache.Object,
 ) (storer.EncodedObjectIter, error) {
-	iter, err := packfile.NewPackfile(index, fs, f).GetByType(t)
+	var p *packfile.Packfile
+	if cache != nil {
+		p = packfile.NewPackfileWithCache(index, fs, f, cache)
+	} else {
+		p = packfile.NewPackfile(index, fs, f)
+	}
+
+	iter, err := p.GetByType(t)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
After clone only resolved deltas were added to the cache. This caused slowdowns accessing objects in small repositories.

It also makes packfiles reuse delta cache from the store. Previously it created a new delta cache each time a packfile object was created. This also slowed down a bit accessing objects and had an impact on memory consumption when bases are added to the cache.

Times to clone and push changes using borges:

| repo | 4.5.0 | 4.6.0 | now |
|----|----|----|----|
| octoprint-tft | 4.5s | 8s | 4.4s |
| upsilon | 0:54 | 1:38 | 0:54 |
| numpy | 3:03 | 3:29 | 3:06 |
| tensorflow | 12:59 | 14:48 | 12:38 |
| bismuth | 14:18 | 7:31 | 7:05 |
