### PR TITLE
Fix `fatal: corrupt patch` error in unified diff format

### DIFF
--- a/plumbing/format/diff/unified_encoder.go
+++ b/plumbing/format/diff/unified_encoder.go
@@ -237,9 +237,13 @@ func (c *hunksGenerator) addLineNumbers(la, lb int, linesBefore int, i int, op O
 	// we need to search for a reference for the next diff
 	switch {
 	case linesBefore != 0 && c.ctxLines != 0:
-		clb = lb - c.ctxLines + 1
+		if lb > c.ctxLines {
+			clb = lb - c.ctxLines + 1
+		} else {
+			clb = 1
+		}
 	case c.ctxLines == 0:
-		clb = lb - c.ctxLines
+		clb = lb
 	case i != len(c.chunks)-1:
 		next := c.chunks[i+1]
 		if next.Type() == op || next.Type() == Equal {

--- a/plumbing/format/diff/unified_encoder_test.go
+++ b/plumbing/format/diff/unified_encoder_test.go
@@ -155,6 +155,43 @@ var fixtures []*fixture = []*fixture{{
 		filePatches: []testFilePatch{{
 			from: &testFile{
 				mode: filemode.Regular,
+				path: "README.md",
+				seed: "hello\nworld\n",
+			},
+			to: &testFile{
+				mode: filemode.Regular,
+				path: "README.md",
+				seed: "hello\nbug\n",
+			},
+			chunks: []testChunk{{
+				content: "hello",
+				op:      Equal,
+			}, {
+				content: "world",
+				op:      Delete,
+			}, {
+				content: "bug",
+				op:      Add,
+			}},
+		}},
+	},
+	desc:    "positive negative number",
+	context: 2,
+	diff: `diff --git a/README.md b/README.md
+index 94954abda49de8615a048f8d2e64b5de848e27a1..f3dad9514629b9ff9136283ae331ad1fc95748a8 100644
+--- a/README.md
++++ b/README.md
+@@ -1,2 +1,2 @@
+ hello
+-world
++bug
+`,
+}, {
+	patch: testPatch{
+		message: "",
+		filePatches: []testFilePatch{{
+			from: &testFile{
+				mode: filemode.Regular,
 				path: "test.txt",
 				seed: "test",
 			},


### PR DESCRIPTION
There may be negative number in the range of unified diff. Negative number occurs when patch changes for example first or second line of file. Bug related to ContextLines number.

Demonstration repo and program to generate wrong patch available here:

https://github.com/flant/go-git-test/

Resulting patch:

```
diff --git a/README.md b/README.md
index 94954abda49de8615a048f8d2e64b5de848e27a1..f3dad9514629b9ff9136283ae331ad1fc95748a8 100644
--- a/README.md
+++ b/README.md
@@ -1,2 +-1,2 @@
 hello
-world
+bug
```

`+-1,2` causes `git apply` to complain:

```
fatal: corrupt patch at line 5
```