### PR TITLE
Remove empty dirs when cleaning with Dir opt.

### DIFF
--- a/status.go
+++ b/status.go
@@ -1,7 +1,10 @@
 package git
 
-import "fmt"
-import "bytes"
+import (
+	"bytes"
+	"fmt"
+	"path/filepath"
+)
 
 // Status represents the current status of a Worktree.
 // The key of the map is the path of the file.
@@ -15,6 +18,12 @@ func (s Status) File(path string) *FileStatus {
 	}
 
 	return s[path]
+}
+
+// IsUntracked checks if file for given path is 'Untracked'
+func (s Status) IsUntracked(path string) bool {
+	stat, ok := (s)[filepath.ToSlash(path)]
+	return ok && stat.Worktree == Untracked
 }
 
 // IsClean returns true if all the files aren't in Unmodified status.

--- a/worktree.go
+++ b/worktree.go
@@ -750,9 +750,7 @@ func (w *Worktree) doClean(status Status, opts *CleanOptions, dir string, files 
 				return err
 			}
 		} else {
-			// check if file is 'Untracked'
-			s, ok := (status)[filepath.ToSlash(path)]
-			if ok && s.Worktree == Untracked {
+			if status.IsUntracked(path) {
 				if err := w.Filesystem.Remove(path); err != nil {
 					return err
 				}

--- a/worktree.go
+++ b/worktree.go
@@ -713,29 +713,56 @@ func (w *Worktree) readGitmodulesFile() (*config.Modules, error) {
 }
 
 // Clean the worktree by removing untracked files.
+// An empty dir could be removed - this is what  `git clean -f -d .` does.
 func (w *Worktree) Clean(opts *CleanOptions) error {
 	s, err := w.Status()
 	if err != nil {
 		return err
 	}
 
-	// Check Worktree status to be Untracked, obtain absolute path and delete.
-	for relativePath, status := range s {
-		// Check if the path contains a directory and if Dir options is false,
-		// skip the path.
-		if relativePath != filepath.Base(relativePath) && !opts.Dir {
+	root := ""
+	files, err := w.Filesystem.ReadDir(root)
+	if err != nil {
+		return err
+	}
+	return w.doClean(s, opts, root, files)
+}
+
+func (w *Worktree) doClean(status Status, opts *CleanOptions, dir string, files []os.FileInfo) error {
+	for _, fi := range files {
+		if fi.Name() == ".git" {
 			continue
 		}
 
-		// Remove the file only if it's an untracked file.
-		if status.Worktree == Untracked {
-			absPath := filepath.Join(w.Filesystem.Root(), relativePath)
-			if err := os.Remove(absPath); err != nil {
+		// relative path under the root
+		path := filepath.Join(dir, fi.Name())
+		if fi.IsDir() {
+			if !opts.Dir {
+				continue
+			}
+
+			subfiles, err := w.Filesystem.ReadDir(path)
+			if err != nil {
 				return err
+			}
+			err = w.doClean(status, opts, path, subfiles)
+			if err != nil {
+				return err
+			}
+		} else {
+			// check if file is 'Untracked'
+			s, ok := (status)[filepath.ToSlash(path)]
+			if ok && s.Worktree == Untracked {
+				if err := w.Filesystem.Remove(path); err != nil {
+					return err
+				}
 			}
 		}
 	}
 
+	if opts.Dir {
+		return doCleanDirectories(w.Filesystem, dir)
+	}
 	return nil
 }
 
@@ -881,15 +908,18 @@ func rmFileAndDirIfEmpty(fs billy.Filesystem, name string) error {
 		return err
 	}
 
-	path := filepath.Dir(name)
-	files, err := fs.ReadDir(path)
+	dir := filepath.Dir(name)
+	return doCleanDirectories(fs, dir)
+}
+
+// doCleanDirectories removes empty subdirs (without files)
+func doCleanDirectories(fs billy.Filesystem, dir string) error {
+	files, err := fs.ReadDir(dir)
 	if err != nil {
 		return err
 	}
-
 	if len(files) == 0 {
-		fs.Remove(path)
+		return fs.Remove(dir)
 	}
-
 	return nil
 }

--- a/worktree_test.go
+++ b/worktree_test.go
@@ -1591,6 +1591,10 @@ func (s *WorktreeSuite) TestClean(c *C) {
 
 	c.Assert(len(status), Equals, 1)
 
+	fi, err := fs.Lstat("pkgA")
+	c.Assert(err, IsNil)
+	c.Assert(fi.IsDir(), Equals, true)
+
 	// Clean with Dir: true.
 	err = wt.Clean(&CleanOptions{Dir: true})
 	c.Assert(err, IsNil)
@@ -1599,6 +1603,11 @@ func (s *WorktreeSuite) TestClean(c *C) {
 	c.Assert(err, IsNil)
 
 	c.Assert(len(status), Equals, 0)
+
+	// An empty dir should be deleted, as well.
+	_, err = fs.Lstat("pkgA")
+	c.Assert(err, ErrorMatches, ".*(no such file or directory.*|.*file does not exist)*.")
+
 }
 
 func (s *WorktreeSuite) TestAlternatesRepo(c *C) {


### PR DESCRIPTION
Signed-off-by: kuba-- <kuba@sourced.tech>
Fixes https://github.com/src-d/go-git/issues/895

When `CleanOptions.Dir` is set on `true` then an empty dir (with subdirs) could be removed (this is what `git clean -f -d .` does).