### PR TITLE
Expose Storage cache.

### DIFF
--- a/common_test.go
+++ b/common_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"gopkg.in/src-d/go-git.v4/plumbing"
+	"gopkg.in/src-d/go-git.v4/plumbing/cache"
 	"gopkg.in/src-d/go-git.v4/plumbing/format/packfile"
 	"gopkg.in/src-d/go-git.v4/plumbing/transport"
 	"gopkg.in/src-d/go-git.v4/storage/filesystem"
@@ -59,10 +60,7 @@ func (s *BaseSuite) NewRepository(f *fixtures.Fixture) *Repository {
 	dotgit = f.DotGit()
 	worktree = memfs.New()
 
-	st, err := filesystem.NewStorage(dotgit)
-	if err != nil {
-		panic(err)
-	}
+	st := filesystem.NewStorage(dotgit, cache.NewObjectLRUDefault())
 
 	r, err := Open(st, worktree)
 	if err != nil {
@@ -89,10 +87,7 @@ func (s *BaseSuite) NewRepositoryWithEmptyWorktree(f *fixtures.Fixture) *Reposit
 
 	worktree := memfs.New()
 
-	st, err := filesystem.NewStorage(dotgit)
-	if err != nil {
-		panic(err)
-	}
+	st := filesystem.NewStorage(dotgit, cache.NewObjectLRUDefault())
 
 	r, err := Open(st, worktree)
 	if err != nil {

--- a/plumbing/format/packfile/encoder_advanced_test.go
+++ b/plumbing/format/packfile/encoder_advanced_test.go
@@ -8,6 +8,7 @@ import (
 
 	"gopkg.in/src-d/go-billy.v4/memfs"
 	"gopkg.in/src-d/go-git.v4/plumbing"
+	"gopkg.in/src-d/go-git.v4/plumbing/cache"
 	"gopkg.in/src-d/go-git.v4/plumbing/format/idxfile"
 	. "gopkg.in/src-d/go-git.v4/plumbing/format/packfile"
 	"gopkg.in/src-d/go-git.v4/plumbing/storer"
@@ -32,8 +33,7 @@ func (s *EncoderAdvancedSuite) TestEncodeDecode(c *C) {
 	fixs = append(fixs, fixtures.ByURL("https://github.com/src-d/go-git.git").
 		ByTag("packfile").ByTag(".git").One())
 	fixs.Test(c, func(f *fixtures.Fixture) {
-		storage, err := filesystem.NewStorage(f.DotGit())
-		c.Assert(err, IsNil)
+		storage := filesystem.NewStorage(f.DotGit(), cache.NewObjectLRUDefault())
 		s.testEncodeDecode(c, storage, 10)
 	})
 }
@@ -47,8 +47,7 @@ func (s *EncoderAdvancedSuite) TestEncodeDecodeNoDeltaCompression(c *C) {
 	fixs = append(fixs, fixtures.ByURL("https://github.com/src-d/go-git.git").
 		ByTag("packfile").ByTag(".git").One())
 	fixs.Test(c, func(f *fixtures.Fixture) {
-		storage, err := filesystem.NewStorage(f.DotGit())
-		c.Assert(err, IsNil)
+		storage := filesystem.NewStorage(f.DotGit(), cache.NewObjectLRUDefault())
 		s.testEncodeDecode(c, storage, 0)
 	})
 }

--- a/plumbing/object/change_adaptor_test.go
+++ b/plumbing/object/change_adaptor_test.go
@@ -4,6 +4,7 @@ import (
 	"sort"
 
 	"gopkg.in/src-d/go-git.v4/plumbing"
+	"gopkg.in/src-d/go-git.v4/plumbing/cache"
 	"gopkg.in/src-d/go-git.v4/plumbing/filemode"
 	"gopkg.in/src-d/go-git.v4/plumbing/storer"
 	"gopkg.in/src-d/go-git.v4/storage/filesystem"
@@ -23,8 +24,7 @@ type ChangeAdaptorSuite struct {
 func (s *ChangeAdaptorSuite) SetUpSuite(c *C) {
 	s.Suite.SetUpSuite(c)
 	s.Fixture = fixtures.Basic().One()
-	sto, err := filesystem.NewStorage(s.Fixture.DotGit())
-	c.Assert(err, IsNil)
+	sto := filesystem.NewStorage(s.Fixture.DotGit(), cache.NewObjectLRUDefault())
 	s.Storer = sto
 }
 

--- a/plumbing/object/change_test.go
+++ b/plumbing/object/change_test.go
@@ -5,6 +5,7 @@ import (
 	"sort"
 
 	"gopkg.in/src-d/go-git.v4/plumbing"
+	"gopkg.in/src-d/go-git.v4/plumbing/cache"
 	"gopkg.in/src-d/go-git.v4/plumbing/filemode"
 	"gopkg.in/src-d/go-git.v4/plumbing/format/diff"
 	"gopkg.in/src-d/go-git.v4/plumbing/storer"
@@ -25,8 +26,7 @@ func (s *ChangeSuite) SetUpSuite(c *C) {
 	s.Suite.SetUpSuite(c)
 	s.Fixture = fixtures.ByURL("https://github.com/src-d/go-git.git").
 		ByTag(".git").One()
-	sto, err := filesystem.NewStorage(s.Fixture.DotGit())
-	c.Assert(err, IsNil)
+	sto := filesystem.NewStorage(s.Fixture.DotGit(), cache.NewObjectLRUDefault())
 	s.Storer = sto
 }
 
@@ -253,8 +253,7 @@ func (s *ChangeSuite) TestNoFileFilemodes(c *C) {
 	s.Suite.SetUpSuite(c)
 	f := fixtures.ByURL("https://github.com/git-fixtures/submodule.git").One()
 
-	sto, err := filesystem.NewStorage(f.DotGit())
-	c.Assert(err, IsNil)
+	sto := filesystem.NewStorage(f.DotGit(), cache.NewObjectLRUDefault())
 
 	iter, err := sto.IterEncodedObjects(plumbing.AnyObject)
 	c.Assert(err, IsNil)

--- a/plumbing/object/commit_test.go
+++ b/plumbing/object/commit_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"gopkg.in/src-d/go-git.v4/plumbing"
+	"gopkg.in/src-d/go-git.v4/plumbing/cache"
 
 	. "gopkg.in/check.v1"
 	"gopkg.in/src-d/go-git-fixtures.v3"
@@ -247,8 +248,7 @@ func (s *SuiteCommit) TestStringMultiLine(c *C) {
 	hash := plumbing.NewHash("e7d896db87294e33ca3202e536d4d9bb16023db3")
 
 	f := fixtures.ByURL("https://github.com/src-d/go-git.git").One()
-	sto, err := filesystem.NewStorage(f.DotGit())
-	c.Assert(err, IsNil)
+	sto := filesystem.NewStorage(f.DotGit(), cache.NewObjectLRUDefault())
 
 	o, err := sto.EncodedObject(plumbing.CommitObject, hash)
 	c.Assert(err, IsNil)

--- a/plumbing/object/difftree_test.go
+++ b/plumbing/object/difftree_test.go
@@ -4,6 +4,7 @@ import (
 	"sort"
 
 	"gopkg.in/src-d/go-git.v4/plumbing"
+	"gopkg.in/src-d/go-git.v4/plumbing/cache"
 	"gopkg.in/src-d/go-git.v4/plumbing/filemode"
 	"gopkg.in/src-d/go-git.v4/plumbing/format/packfile"
 	"gopkg.in/src-d/go-git.v4/plumbing/storer"
@@ -25,8 +26,7 @@ type DiffTreeSuite struct {
 func (s *DiffTreeSuite) SetUpSuite(c *C) {
 	s.Suite.SetUpSuite(c)
 	s.Fixture = fixtures.Basic().One()
-	sto, err := filesystem.NewStorage(s.Fixture.DotGit())
-	c.Assert(err, IsNil)
+	sto := filesystem.NewStorage(s.Fixture.DotGit(), cache.NewObjectLRUDefault())
 	s.Storer = sto
 	s.cache = make(map[string]storer.EncodedObjectStorer)
 }

--- a/plumbing/object/file_test.go
+++ b/plumbing/object/file_test.go
@@ -4,6 +4,7 @@ import (
 	"io"
 
 	"gopkg.in/src-d/go-git.v4/plumbing"
+	"gopkg.in/src-d/go-git.v4/plumbing/cache"
 	"gopkg.in/src-d/go-git.v4/plumbing/filemode"
 	"gopkg.in/src-d/go-git.v4/plumbing/storer"
 	"gopkg.in/src-d/go-git.v4/storage/filesystem"
@@ -44,8 +45,7 @@ var fileIterTests = []struct {
 func (s *FileSuite) TestIter(c *C) {
 	for i, t := range fileIterTests {
 		f := fixtures.ByURL(t.repo).One()
-		sto, err := filesystem.NewStorage(f.DotGit())
-		c.Assert(err, IsNil)
+		sto := filesystem.NewStorage(f.DotGit(), cache.NewObjectLRUDefault())
 
 		h := plumbing.NewHash(t.commit)
 		commit, err := GetCommit(sto, h)
@@ -106,8 +106,7 @@ hs_err_pid*
 func (s *FileSuite) TestContents(c *C) {
 	for i, t := range contentsTests {
 		f := fixtures.ByURL(t.repo).One()
-		sto, err := filesystem.NewStorage(f.DotGit())
-		c.Assert(err, IsNil)
+		sto := filesystem.NewStorage(f.DotGit(), cache.NewObjectLRUDefault())
 
 		h := plumbing.NewHash(t.commit)
 		commit, err := GetCommit(sto, h)
@@ -160,8 +159,7 @@ var linesTests = []struct {
 func (s *FileSuite) TestLines(c *C) {
 	for i, t := range linesTests {
 		f := fixtures.ByURL(t.repo).One()
-		sto, err := filesystem.NewStorage(f.DotGit())
-		c.Assert(err, IsNil)
+		sto := filesystem.NewStorage(f.DotGit(), cache.NewObjectLRUDefault())
 
 		h := plumbing.NewHash(t.commit)
 		commit, err := GetCommit(sto, h)
@@ -195,8 +193,7 @@ var ignoreEmptyDirEntriesTests = []struct {
 func (s *FileSuite) TestIgnoreEmptyDirEntries(c *C) {
 	for i, t := range ignoreEmptyDirEntriesTests {
 		f := fixtures.ByURL(t.repo).One()
-		sto, err := filesystem.NewStorage(f.DotGit())
-		c.Assert(err, IsNil)
+		sto := filesystem.NewStorage(f.DotGit(), cache.NewObjectLRUDefault())
 
 		h := plumbing.NewHash(t.commit)
 		commit, err := GetCommit(sto, h)
@@ -251,9 +248,7 @@ func (s *FileSuite) TestFileIter(c *C) {
 
 func (s *FileSuite) TestFileIterSubmodule(c *C) {
 	dotgit := fixtures.ByURL("https://github.com/git-fixtures/submodule.git").One().DotGit()
-	st, err := filesystem.NewStorage(dotgit)
-
-	c.Assert(err, IsNil)
+	st := filesystem.NewStorage(dotgit, cache.NewObjectLRUDefault())
 
 	hash := plumbing.NewHash("b685400c1f9316f350965a5993d350bc746b0bf4")
 	commit, err := GetCommit(st, hash)

--- a/plumbing/object/object_test.go
+++ b/plumbing/object/object_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"gopkg.in/src-d/go-git.v4/plumbing"
+	"gopkg.in/src-d/go-git.v4/plumbing/cache"
 	"gopkg.in/src-d/go-git.v4/plumbing/filemode"
 	"gopkg.in/src-d/go-git.v4/plumbing/storer"
 	"gopkg.in/src-d/go-git.v4/storage/filesystem"
@@ -26,8 +27,7 @@ type BaseObjectsSuite struct {
 func (s *BaseObjectsSuite) SetUpSuite(c *C) {
 	s.Suite.SetUpSuite(c)
 	s.Fixture = fixtures.Basic().One()
-	storer, err := filesystem.NewStorage(s.Fixture.DotGit())
-	c.Assert(err, IsNil)
+	storer := filesystem.NewStorage(s.Fixture.DotGit(), cache.NewObjectLRUDefault())
 	s.Storer = storer
 }
 

--- a/plumbing/object/patch_test.go
+++ b/plumbing/object/patch_test.go
@@ -4,6 +4,7 @@ import (
 	. "gopkg.in/check.v1"
 	fixtures "gopkg.in/src-d/go-git-fixtures.v3"
 	"gopkg.in/src-d/go-git.v4/plumbing"
+	"gopkg.in/src-d/go-git.v4/plumbing/cache"
 	"gopkg.in/src-d/go-git.v4/storage/filesystem"
 )
 
@@ -14,8 +15,8 @@ type PatchSuite struct {
 var _ = Suite(&PatchSuite{})
 
 func (s *PatchSuite) TestStatsWithSubmodules(c *C) {
-	storer, err := filesystem.NewStorage(
-		fixtures.ByURL("https://github.com/git-fixtures/submodule.git").One().DotGit())
+	storer := filesystem.NewStorage(
+		fixtures.ByURL("https://github.com/git-fixtures/submodule.git").One().DotGit(), cache.NewObjectLRUDefault())
 
 	commit, err := GetCommit(storer, plumbing.NewHash("b685400c1f9316f350965a5993d350bc746b0bf4"))
 

--- a/plumbing/object/tag_test.go
+++ b/plumbing/object/tag_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"gopkg.in/src-d/go-git.v4/plumbing"
+	"gopkg.in/src-d/go-git.v4/plumbing/cache"
 	"gopkg.in/src-d/go-git.v4/storage/filesystem"
 	"gopkg.in/src-d/go-git.v4/storage/memory"
 
@@ -22,9 +23,7 @@ var _ = Suite(&TagSuite{})
 
 func (s *TagSuite) SetUpSuite(c *C) {
 	s.BaseObjectsSuite.SetUpSuite(c)
-	storer, err := filesystem.NewStorage(
-		fixtures.ByURL("https://github.com/git-fixtures/tags.git").One().DotGit())
-	c.Assert(err, IsNil)
+	storer := filesystem.NewStorage(fixtures.ByURL("https://github.com/git-fixtures/tags.git").One().DotGit(), cache.NewObjectLRUDefault())
 	s.Storer = storer
 }
 

--- a/plumbing/object/tree_test.go
+++ b/plumbing/object/tree_test.go
@@ -5,6 +5,7 @@ import (
 	"io"
 
 	"gopkg.in/src-d/go-git.v4/plumbing"
+	"gopkg.in/src-d/go-git.v4/plumbing/cache"
 	"gopkg.in/src-d/go-git.v4/plumbing/filemode"
 	"gopkg.in/src-d/go-git.v4/plumbing/storer"
 	"gopkg.in/src-d/go-git.v4/storage/filesystem"
@@ -341,8 +342,7 @@ func (s *TreeSuite) TestTreeWalkerNextNonRecursive(c *C) {
 
 func (s *TreeSuite) TestTreeWalkerNextSubmodule(c *C) {
 	dotgit := fixtures.ByURL("https://github.com/git-fixtures/submodule.git").One().DotGit()
-	st, err := filesystem.NewStorage(dotgit)
-	c.Assert(err, IsNil)
+	st := filesystem.NewStorage(dotgit, cache.NewObjectLRUDefault())
 
 	hash := plumbing.NewHash("b685400c1f9316f350965a5993d350bc746b0bf4")
 	commit, err := GetCommit(st, hash)

--- a/plumbing/revlist/revlist_test.go
+++ b/plumbing/revlist/revlist_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"gopkg.in/src-d/go-git.v4/plumbing"
+	"gopkg.in/src-d/go-git.v4/plumbing/cache"
 	"gopkg.in/src-d/go-git.v4/plumbing/object"
 	"gopkg.in/src-d/go-git.v4/plumbing/storer"
 	"gopkg.in/src-d/go-git.v4/storage/filesystem"
@@ -51,8 +52,7 @@ const (
 
 func (s *RevListSuite) SetUpTest(c *C) {
 	s.Suite.SetUpSuite(c)
-	sto, err := filesystem.NewStorage(fixtures.Basic().One().DotGit())
-	c.Assert(err, IsNil)
+	sto := filesystem.NewStorage(fixtures.Basic().One().DotGit(), cache.NewObjectLRUDefault())
 	s.Storer = sto
 }
 
@@ -67,8 +67,7 @@ func (s *RevListSuite) TestRevListObjects_Submodules(c *C) {
 		"6ecf0ef2c2dffb796033e5a02219af86ec6584e5": true,
 	}
 
-	sto, err := filesystem.NewStorage(fixtures.ByTag("submodule").One().DotGit())
-	c.Assert(err, IsNil)
+	sto := filesystem.NewStorage(fixtures.ByTag("submodule").One().DotGit(), cache.NewObjectLRUDefault())
 
 	ref, err := storer.ResolveReference(sto, plumbing.HEAD)
 	c.Assert(err, IsNil)
@@ -109,10 +108,9 @@ func (s *RevListSuite) TestRevListObjects(c *C) {
 }
 
 func (s *RevListSuite) TestRevListObjectsTagObject(c *C) {
-	sto, err := filesystem.NewStorage(
+	sto := filesystem.NewStorage(
 		fixtures.ByTag("tags").
-			ByURL("https://github.com/git-fixtures/tags.git").One().DotGit())
-	c.Assert(err, IsNil)
+			ByURL("https://github.com/git-fixtures/tags.git").One().DotGit(), cache.NewObjectLRUDefault())
 
 	expected := map[string]bool{
 		"70846e9a10ef7b41064b40f07713d5b8b9a8fc73": true,

--- a/plumbing/transport/server/loader.go
+++ b/plumbing/transport/server/loader.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"gopkg.in/src-d/go-git.v4/plumbing/cache"
 	"gopkg.in/src-d/go-git.v4/plumbing/storer"
 	"gopkg.in/src-d/go-git.v4/plumbing/transport"
 	"gopkg.in/src-d/go-git.v4/storage/filesystem"
@@ -43,7 +44,7 @@ func (l *fsLoader) Load(ep *transport.Endpoint) (storer.Storer, error) {
 		return nil, transport.ErrRepositoryNotFound
 	}
 
-	return filesystem.NewStorage(fs)
+	return filesystem.NewStorage(fs, cache.NewObjectLRUDefault()), nil
 }
 
 // MapLoader is a Loader that uses a lookup map of storer.Storer by

--- a/plumbing/transport/server/server_test.go
+++ b/plumbing/transport/server/server_test.go
@@ -3,6 +3,7 @@ package server_test
 import (
 	"testing"
 
+	"gopkg.in/src-d/go-git.v4/plumbing/cache"
 	"gopkg.in/src-d/go-git.v4/plumbing/transport"
 	"gopkg.in/src-d/go-git.v4/plumbing/transport/client"
 	"gopkg.in/src-d/go-git.v4/plumbing/transport/server"
@@ -53,8 +54,7 @@ func (s *BaseSuite) prepareRepositories(c *C) {
 	fs := fixtures.Basic().One().DotGit()
 	s.Endpoint, err = transport.NewEndpoint(fs.Root())
 	c.Assert(err, IsNil)
-	s.loader[s.Endpoint.String()], err = filesystem.NewStorage(fs)
-	c.Assert(err, IsNil)
+	s.loader[s.Endpoint.String()] = filesystem.NewStorage(fs, cache.NewObjectLRUDefault())
 
 	s.EmptyEndpoint, err = transport.NewEndpoint("/empty.git")
 	c.Assert(err, IsNil)

--- a/prune_test.go
+++ b/prune_test.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	"gopkg.in/src-d/go-git.v4/plumbing"
+	"gopkg.in/src-d/go-git.v4/plumbing/cache"
 	"gopkg.in/src-d/go-git.v4/plumbing/storer"
 	"gopkg.in/src-d/go-git.v4/storage"
 	"gopkg.in/src-d/go-git.v4/storage/filesystem"
@@ -22,8 +23,7 @@ func (s *PruneSuite) testPrune(c *C, deleteTime time.Time) {
 	srcFs := fixtures.ByTag("unpacked").One().DotGit()
 	var sto storage.Storer
 	var err error
-	sto, err = filesystem.NewStorage(srcFs)
-	c.Assert(err, IsNil)
+	sto = filesystem.NewStorage(srcFs, cache.NewObjectLRUDefault())
 
 	los := sto.(storer.LooseObjectStorer)
 	c.Assert(los, NotNil)

--- a/repository.go
+++ b/repository.go
@@ -13,6 +13,7 @@ import (
 	"gopkg.in/src-d/go-git.v4/config"
 	"gopkg.in/src-d/go-git.v4/internal/revision"
 	"gopkg.in/src-d/go-git.v4/plumbing"
+	"gopkg.in/src-d/go-git.v4/plumbing/cache"
 	"gopkg.in/src-d/go-git.v4/plumbing/format/packfile"
 	"gopkg.in/src-d/go-git.v4/plumbing/object"
 	"gopkg.in/src-d/go-git.v4/plumbing/storer"
@@ -220,10 +221,7 @@ func PlainInit(path string, isBare bool) (*Repository, error) {
 		dot, _ = wt.Chroot(GitDirName)
 	}
 
-	s, err := filesystem.NewStorage(dot)
-	if err != nil {
-		return nil, err
-	}
+	s := filesystem.NewStorage(dot, cache.NewObjectLRUDefault())
 
 	return Init(s, wt)
 }
@@ -251,10 +249,7 @@ func PlainOpenWithOptions(path string, o *PlainOpenOptions) (*Repository, error)
 		return nil, err
 	}
 
-	s, err := filesystem.NewStorage(dot)
-	if err != nil {
-		return nil, err
-	}
+	s := filesystem.NewStorage(dot, cache.NewObjectLRUDefault())
 
 	return Open(s, wt)
 }

--- a/storage/filesystem/dotgit/dotgit.go
+++ b/storage/filesystem/dotgit/dotgit.go
@@ -92,8 +92,8 @@ func New(fs billy.Filesystem) *DotGit {
 	return NewWithOptions(fs, Options{})
 }
 
-// NewWithOptions creates a new DotGit and sets non default configuration
-// options. See New for complete help.
+// NewWithOptions sets non default configuration options.
+// See New for complete help.
 func NewWithOptions(fs billy.Filesystem, o Options) *DotGit {
 	return &DotGit{
 		options: o,

--- a/storage/filesystem/module.go
+++ b/storage/filesystem/module.go
@@ -1,6 +1,7 @@
 package filesystem
 
 import (
+	"gopkg.in/src-d/go-git.v4/plumbing/cache"
 	"gopkg.in/src-d/go-git.v4/storage"
 	"gopkg.in/src-d/go-git.v4/storage/filesystem/dotgit"
 )
@@ -15,5 +16,5 @@ func (s *ModuleStorage) Module(name string) (storage.Storer, error) {
 		return nil, err
 	}
 
-	return NewStorage(fs)
+	return NewStorage(fs, cache.NewObjectLRUDefault()), nil
 }

--- a/storage/filesystem/storage.go
+++ b/storage/filesystem/storage.go
@@ -2,6 +2,7 @@
 package filesystem
 
 import (
+	"gopkg.in/src-d/go-git.v4/plumbing/cache"
 	"gopkg.in/src-d/go-git.v4/storage/filesystem/dotgit"
 
 	"gopkg.in/src-d/go-billy.v4"
@@ -32,38 +33,35 @@ type Options struct {
 	KeepDescriptors bool
 }
 
-// NewStorage returns a new Storage backed by a given `fs.Filesystem`
-func NewStorage(fs billy.Filesystem) (*Storage, error) {
-	return NewStorageWithOptions(fs, Options{})
+// NewStorage returns a new Storage backed by a given `fs.Filesystem` and cache.
+func NewStorage(fs billy.Filesystem, cache cache.Object) *Storage {
+	return NewStorageWithOptions(fs, cache, Options{})
 }
 
-// NewStorageWithOptions returns a new Storage backed by a given `fs.Filesystem`
-func NewStorageWithOptions(
-	fs billy.Filesystem,
-	ops Options,
-) (*Storage, error) {
+// NewStorageWithOptions returns a new Storage with extra options,
+// backed by a given `fs.Filesystem` and cache.
+func NewStorageWithOptions(fs billy.Filesystem, cache cache.Object, ops Options) *Storage {
 	dirOps := dotgit.Options{
 		ExclusiveAccess: ops.ExclusiveAccess,
 		KeepDescriptors: ops.KeepDescriptors,
 	}
-
 	dir := dotgit.NewWithOptions(fs, dirOps)
-	o, err := NewObjectStorageWithOptions(dir, ops)
-	if err != nil {
-		return nil, err
-	}
 
 	return &Storage{
 		fs:  fs,
 		dir: dir,
 
-		ObjectStorage:    o,
+		ObjectStorage: ObjectStorage{
+			options:        ops,
+			deltaBaseCache: cache,
+			dir:            dir,
+		},
 		ReferenceStorage: ReferenceStorage{dir: dir},
 		IndexStorage:     IndexStorage{dir: dir},
 		ShallowStorage:   ShallowStorage{dir: dir},
 		ConfigStorage:    ConfigStorage{dir: dir},
 		ModuleStorage:    ModuleStorage{dir: dir},
-	}, nil
+	}
 }
 
 // Filesystem returns the underlying filesystem
@@ -71,6 +69,7 @@ func (s *Storage) Filesystem() billy.Filesystem {
 	return s.fs
 }
 
+// Init initializes .git directory
 func (s *Storage) Init() error {
 	return s.dir.Initialize()
 }

--- a/storage/filesystem/storage_test.go
+++ b/storage/filesystem/storage_test.go
@@ -4,6 +4,7 @@ import (
 	"io/ioutil"
 	"testing"
 
+	"gopkg.in/src-d/go-git.v4/plumbing/cache"
 	"gopkg.in/src-d/go-git.v4/plumbing/storer"
 	"gopkg.in/src-d/go-git.v4/storage/test"
 
@@ -23,8 +24,7 @@ var _ = Suite(&StorageSuite{})
 
 func (s *StorageSuite) SetUpTest(c *C) {
 	s.dir = c.MkDir()
-	storage, err := NewStorage(osfs.New(s.dir))
-	c.Assert(err, IsNil)
+	storage := NewStorage(osfs.New(s.dir), cache.NewObjectLRUDefault())
 
 	setUpTest(s, c, storage)
 }
@@ -44,8 +44,7 @@ func setUpTest(s *StorageSuite, c *C, storage *Storage) {
 
 func (s *StorageSuite) TestFilesystem(c *C) {
 	fs := memfs.New()
-	storage, err := NewStorage(fs)
-	c.Assert(err, IsNil)
+	storage := NewStorage(fs, cache.NewObjectLRUDefault())
 
 	c.Assert(storage.Filesystem(), Equals, fs)
 }
@@ -64,10 +63,10 @@ var _ = Suite(&StorageExclusiveSuite{})
 
 func (s *StorageExclusiveSuite) SetUpTest(c *C) {
 	s.dir = c.MkDir()
-	storage, err := NewStorageWithOptions(
+	storage := NewStorageWithOptions(
 		osfs.New(s.dir),
+		cache.NewObjectLRUDefault(),
 		Options{ExclusiveAccess: true})
-	c.Assert(err, IsNil)
 
 	setUpTest(&s.StorageSuite, c, storage)
 }

--- a/worktree_commit_test.go
+++ b/worktree_commit_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"gopkg.in/src-d/go-git.v4/plumbing"
+	"gopkg.in/src-d/go-git.v4/plumbing/cache"
 	"gopkg.in/src-d/go-git.v4/plumbing/object"
 	"gopkg.in/src-d/go-git.v4/plumbing/storer"
 	"gopkg.in/src-d/go-git.v4/storage/filesystem"
@@ -205,8 +206,7 @@ func (s *WorktreeSuite) TestCommitTreeSort(c *C) {
 	path, err := ioutil.TempDir(os.TempDir(), "test-commit-tree-sort")
 	c.Assert(err, IsNil)
 	fs := osfs.New(path)
-	st, err := filesystem.NewStorage(fs)
-	c.Assert(err, IsNil)
+	st := filesystem.NewStorage(fs, cache.NewObjectLRUDefault())
 	r, err := Init(st, nil)
 	c.Assert(err, IsNil)
 


### PR DESCRIPTION
Signed-off-by: kuba-- <kuba@sourced.tech>

If we want to let apps. adjust cache size (or pass own implementation) we need to expose it somehow.
It's related to src-d/gitbase#440
Also we don't need to return an error from constructors like `NewStorage`.