### PR TITLE
storage/filesystem: keep packs open in PackfileIter

### DIFF
--- a/storage/filesystem/object.go
+++ b/storage/filesystem/object.go
@@ -476,15 +476,18 @@ func (it *lazyPackfilesIter) Close() {
 }
 
 type packfileIter struct {
-	pack     billy.File
-	iter     storer.EncodedObjectIter
-	seen     map[plumbing.Hash]struct{}
+	pack billy.File
+	iter storer.EncodedObjectIter
+	seen map[plumbing.Hash]struct{}
+
+	// tells whether the pack file should be left open after iteration or not
 	keepPack bool
 }
 
 // NewPackfileIter returns a new EncodedObjectIter for the provided packfile
 // and object type. Packfile and index file will be closed after they're
-// used.
+// used. If keepPack is true the packfile won't be closed after the iteration
+// finished.
 func NewPackfileIter(
 	fs billy.Filesystem,
 	f billy.File,


### PR DESCRIPTION
PackfileIter was not taking into account the option KeepDescriptors and was always closing the file. This caused "file already closed" errors when iterating packfiles in with KeepDescriptors active.