### PR TITLE
plumbing: format/packfile, performance optimizations for reading large commit histories

### DIFF
--- a/plumbing/format/packfile/fsobject.go
+++ b/plumbing/format/packfile/fsobject.go
@@ -48,7 +48,7 @@ func NewFSObject(
 // Reader implements the plumbing.EncodedObject interface.
 func (o *FSObject) Reader() (io.ReadCloser, error) {
 	obj, ok := o.cache.Get(o.hash)
-	if ok {
+	if ok && obj != o {
 		reader, err := obj.Reader()
 		if err != nil {
 			return nil, err

--- a/plumbing/format/packfile/packfile.go
+++ b/plumbing/format/packfile/packfile.go
@@ -180,7 +180,7 @@ func (p *Packfile) objectAtOffset(offset int64) (plumbing.EncodedObject, error) 
 
 	// If we have no filesystem, we will return a MemoryObject instead
 	// of an FSObject.
-	if p.fs == nil || h.Length <= 16 * 1024 {
+	if p.fs == nil || h.Length <= 16*1024 {
 		return p.getNextObject(h)
 	}
 
@@ -319,8 +319,6 @@ func (p *Packfile) fillOFSDeltaObjectContent(obj plumbing.EncodedObject, offset 
 		if err != nil {
 			return err
 		}
-
-		p.cachePut(base)
 	}
 
 	obj.SetType(base.Type())

--- a/plumbing/format/packfile/packfile.go
+++ b/plumbing/format/packfile/packfile.go
@@ -190,7 +190,14 @@ func (p *Packfile) objectAtOffset(offset int64) (plumbing.EncodedObject, error) 
 
 	// If we have no filesystem, we will return a MemoryObject instead
 	// of an FSObject.
-	if p.fs == nil || h.Length <= smallObjectThreshold {
+	if p.fs == nil {
+		return p.getNextObject(h)
+	}
+
+	// If the object is not a delta and it's small enough then read it
+	// completely into memory now since it is already read from disk
+	// into buffer anyway.
+	if h.Length <= smallObjectThreshold && h.Type != plumbing.OFSDeltaObject && h.Type != plumbing.REFDeltaObject {
 		return p.getNextObject(h)
 	}
 

--- a/plumbing/format/packfile/packfile.go
+++ b/plumbing/format/packfile/packfile.go
@@ -180,7 +180,7 @@ func (p *Packfile) objectAtOffset(offset int64) (plumbing.EncodedObject, error) 
 
 	// If we have no filesystem, we will return a MemoryObject instead
 	// of an FSObject.
-	if p.fs == nil {
+	if p.fs == nil || h.Length <= 16 * 1024 {
 		return p.getNextObject(h)
 	}
 

--- a/plumbing/format/packfile/parser.go
+++ b/plumbing/format/packfile/parser.go
@@ -398,11 +398,7 @@ func (p *Parser) readData(o *objectInfo) ([]byte, error) {
 		return data, nil
 	}
 
-	if _, err := p.scanner.SeekFromStart(o.Offset); err != nil {
-		return nil, err
-	}
-
-	if _, err := p.scanner.NextObjectHeader(); err != nil {
+	if _, err := p.scanner.SeekObjectHeader(o.Offset); err != nil {
 		return nil, err
 	}
 

--- a/plumbing/format/packfile/scanner.go
+++ b/plumbing/format/packfile/scanner.go
@@ -141,7 +141,7 @@ func (s *Scanner) readCount() (uint32, error) {
 // SeekObjectHeader seeks to specified offset and returns the ObjectHeader
 // for the next object in the reader
 func (s *Scanner) SeekObjectHeader(offset int64) (*ObjectHeader, error) {
-	// if seeking we assume that you are not interested on the header
+	// if seeking we assume that you are not interested in the header
 	if s.version == 0 {
 		s.version = VersionSupported
 	}
@@ -150,8 +150,8 @@ func (s *Scanner) SeekObjectHeader(offset int64) (*ObjectHeader, error) {
 		return nil, err
 	}
 
-	h, err := s.nextObjectHeader();
-	if  err != nil {
+	h, err := s.nextObjectHeader()
+	if err != nil {
 		return nil, err
 	}
 
@@ -165,13 +165,13 @@ func (s *Scanner) NextObjectHeader() (*ObjectHeader, error) {
 		return nil, err
 	}
 
-	offset, err := s.r.Seek(0, io.SeekCurrent);
-	if  err != nil {
+	offset, err := s.r.Seek(0, io.SeekCurrent)
+	if err != nil {
 		return nil, err
 	}
 
-	h, err := s.nextObjectHeader();
-	if  err != nil {
+	h, err := s.nextObjectHeader()
+	if err != nil {
 		return nil, err
 	}
 
@@ -346,7 +346,7 @@ var byteSlicePool = sync.Pool{
 // SeekFromStart sets a new offset from start, returns the old position before
 // the change.
 func (s *Scanner) SeekFromStart(offset int64) (previous int64, err error) {
-	// if seeking we assume that you are not interested on the header
+	// if seeking we assume that you are not interested in the header
 	if s.version == 0 {
 		s.version = VersionSupported
 	}

--- a/plumbing/format/packfile/scanner.go
+++ b/plumbing/format/packfile/scanner.go
@@ -423,7 +423,7 @@ type bufferedSeeker struct {
 }
 
 func (r *bufferedSeeker) Seek(offset int64, whence int) (int64, error) {
-	if whence == io.SeekCurrent {
+	if whence == io.SeekCurrent && offset == 0 {
 		current, err := r.r.Seek(offset, whence)
 		if err != nil {
 			return current, err

--- a/plumbing/format/packfile/scanner_test.go
+++ b/plumbing/format/packfile/scanner_test.go
@@ -118,6 +118,23 @@ func (s *ScannerSuite) TestNextObjectHeaderWithOutReadObjectNonSeekable(c *C) {
 	c.Assert(n, Equals, f.PackfileHash)
 }
 
+func (s *ScannerSuite) TestSeekObjectHeader(c *C) {
+	r := fixtures.Basic().One().Packfile()
+	p := NewScanner(r)
+
+	h, err := p.SeekObjectHeader(expectedHeadersOFS[4].Offset)
+	c.Assert(err, IsNil)
+	c.Assert(h, DeepEquals, &expectedHeadersOFS[4])
+}
+
+func (s *ScannerSuite) TestSeekObjectHeaderNonSeekable(c *C) {
+	r := io.MultiReader(fixtures.Basic().One().Packfile())
+	p := NewScanner(r)
+
+	_, err := p.SeekObjectHeader(expectedHeadersOFS[4].Offset)
+	c.Assert(err, Equals, ErrSeekNotSupported)
+}
+
 var expectedHeadersOFS = []ObjectHeader{
 	{Type: plumbing.CommitObject, Offset: 12, Length: 254},
 	{Type: plumbing.OFSDeltaObject, Offset: 186, Length: 93, OffsetReference: 12},

--- a/storage/filesystem/object.go
+++ b/storage/filesystem/object.go
@@ -207,7 +207,7 @@ func (s *ObjectStorage) encodedObjectSizeFromPackfile(h plumbing.Hash) (
 	idx := s.index[pack]
 	hash, err := idx.FindHash(offset)
 	if err == nil {
-		obj, ok := s.deltaBaseCache.Get(hash)
+		obj, ok := s.objectCache.Get(hash)
 		if ok {
 			return obj.Size(), nil
 		}
@@ -216,8 +216,8 @@ func (s *ObjectStorage) encodedObjectSizeFromPackfile(h plumbing.Hash) (
 	}
 
 	var p *packfile.Packfile
-	if s.deltaBaseCache != nil {
-		p = packfile.NewPackfileWithCache(idx, s.dir.Fs(), f, s.deltaBaseCache)
+	if s.objectCache != nil {
+		p = packfile.NewPackfileWithCache(idx, s.dir.Fs(), f, s.objectCache)
 	} else {
 		p = packfile.NewPackfile(idx, s.dir.Fs(), f)
 	}
@@ -342,7 +342,7 @@ func (s *ObjectStorage) getFromUnpacked(h plumbing.Hash) (obj plumbing.EncodedOb
 		return nil, err
 	}
 
-	s.objectCache.Put(obj);
+	s.objectCache.Put(obj)
 
 	_, err = io.Copy(w, r)
 	return obj, err
@@ -417,7 +417,7 @@ func (s *ObjectStorage) decodeDeltaObjectAt(
 	}
 
 	p := packfile.NewScanner(f)
-	header, err := p.SeekObjectHeader(offset);
+	header, err := p.SeekObjectHeader(offset)
 	if err != nil {
 		return nil, err
 	}

--- a/storage/filesystem/object.go
+++ b/storage/filesystem/object.go
@@ -244,9 +244,19 @@ func (s *ObjectStorage) EncodedObjectSize(h plumbing.Hash) (
 // EncodedObject returns the object with the given hash, by searching for it in
 // the packfile and the git object directories.
 func (s *ObjectStorage) EncodedObject(t plumbing.ObjectType, h plumbing.Hash) (plumbing.EncodedObject, error) {
-	obj, err := s.getFromUnpacked(h)
-	if err == plumbing.ErrObjectNotFound {
+	var obj plumbing.EncodedObject
+	var err error
+
+	if s.index != nil {
 		obj, err = s.getFromPackfile(h, false)
+		if err == plumbing.ErrObjectNotFound {
+			obj, err = s.getFromUnpacked(h)
+		}
+	} else {
+		obj, err = s.getFromUnpacked(h)
+		if err == plumbing.ErrObjectNotFound {
+			obj, err = s.getFromPackfile(h, false)
+		}
 	}
 
 	// If the error is still object not found, check if it's a shared object

--- a/storage/filesystem/object.go
+++ b/storage/filesystem/object.go
@@ -400,11 +400,7 @@ func (s *ObjectStorage) decodeDeltaObjectAt(
 	}
 
 	p := packfile.NewScanner(f)
-	if _, err := p.SeekFromStart(offset); err != nil {
-		return nil, err
-	}
-
-	header, err := p.NextObjectHeader()
+	header, err := p.SeekObjectHeader(offset);
 	if err != nil {
 		return nil, err
 	}

--- a/storage/filesystem/storage.go
+++ b/storage/filesystem/storage.go
@@ -51,11 +51,7 @@ func NewStorageWithOptions(fs billy.Filesystem, cache cache.Object, ops Options)
 		fs:  fs,
 		dir: dir,
 
-		ObjectStorage: ObjectStorage{
-			options:        ops,
-			deltaBaseCache: cache,
-			dir:            dir,
-		},
+		ObjectStorage:    *NewObjectStorageWithOptions(dir, cache, ops),
 		ReferenceStorage: ReferenceStorage{dir: dir},
 		IndexStorage:     IndexStorage{dir: dir},
 		ShallowStorage:   ShallowStorage{dir: dir},


### PR DESCRIPTION
We have recently evaluated using [Gitea](https://gitea.io/en-us/) as our Git hosting solution. It turned out to have quite a few performance bottlenecks stemming from the fact that it invokes the `git` command line tool for all operations. In one of the tracking issues go-git was suggested as one way of speeding it up. Over the weekend I prototyped computing the directory listing with last commit for each file on top of go-git (https://gist.github.com/filipnavara/8e6fdf980130d6ca120bfda4c25481e9). The speed improvement seemed promising enough that yesterday I proceeded further and reimplemented part of Gitea to use go-git (https://github.com/filipnavara/gitea/tree/perf-read). Overall I am seeing about 10x improvement on page load times for directory listings on our repository.

As part of the experiment I hit couple of bottlenecks in the go-git itself and I think it would make sense to resolve them. The proposed solutions may not necessarily be the best for general use, but I would like to spark a discussion about it at least.

1. Profiling the I/O showed a lot of `Seek(0, io.SeekCurrent)` calls that were unnecessary since the offset was either not used and thrown away or already known in the code path. This accounted for up to 5% of the history traversal.
_Proposed solution:_ I added `SeekObjectHeader` to `packfile/scanner` that combines seeking in the file and then reading the object header at that position into one call. This should not adversly affect any workloads. Related to that I found that `Seek(<non-zero integer>, io.SeekCurrent)` was implemented incorrectly. It is never used in the code base, but should probably be fixed nevertheless.

2. Iterating over commits using the `repository.log`, `object.NewCommitIterCTime` or other iterators always loads the commit objects from disk for loose objects. Since we examined the commit parents inside the iterator we were essentially loading all the commits from disk twice. It is possible to rewrite our algorithms/loops to avoid that, but it seemed that the use case could be better serviced within the library.
_Proposed solution:_ Add small cache for the loaded loose objects. It is more efficient to keep couple of them in the memory instead of reading them from disk. This could probably be tweaked to cache only small objects where the I/O and syscalls are going to be most expensive compared to memory cost.

3. Iterating deep in the history eventually started hitting the packfiles. The profiler and Process Monitor showed that there was significant time spent in `OpenFile` calls. Most of these `OpenFile` calls failed because the objects were stored in the packfiles and not as loose objects.
_Proposed solution:_ If the packfile indexes are already loaded then prefer them to loose object lookup. For our use case it improves the hit rate to almost 100% and avoids the unnecessary I/O calls. The indexes are already loaded in memory and should be cheap to check compared to hitting syscalls and disk. It may not be too efficient if many packfiles are present, but then the probability of objects being in the packfile is higher anyway. This simple optimization improved our algorithm performance by nearly 30%.

4. The I/O patterns for reading small objects from packfiles was quite erratic. It resulted in almost 3x as much disk reads performed than necessary (checked by `timeit` tool) and it often loaded 4k buffered blocks only to seek back in the file and read an overlapping block again (seen in Process Monitor on Windows). It turned out to be caused by the way `FSObject` is implemented. There's potential for significant improvement.
_Proposed solution:_ For small objects use `MemoryObject` instead and read the content right away since it's already buffered in memory. I chose an arbitrary threshold of 16 Kb, which may not be ideal. Something like (4Kb - header size) would be a conservative value that would work for our use case too. 

5. Pack file index reading is done in 4Kb chunks, but it is mostly sequential reads that could easily use bigger buffer. This is not addressed within the PR.