### PR TITLE
Remove multiple instances of the word "the"

### DIFF
--- a/blame.go
+++ b/blame.go
@@ -141,7 +141,7 @@ type blame struct {
 	path string
 	// the commit of the final revision of the file to blame
 	fRev *object.Commit
-	// the chain of revisions affecting the the file to blame
+	// the chain of revisions affecting the file to blame
 	revs []*object.Commit
 	// the contents of the file across all its revisions
 	data []string

--- a/repository.go
+++ b/repository.go
@@ -1333,7 +1333,7 @@ func (r *Repository) RepackObjects(cfg *RepackConfig) (err error) {
 }
 
 // createNewObjectPack is a helper for RepackObjects taking care
-// of creating a new pack. It is used so the the PackfileWriter
+// of creating a new pack. It is used so the PackfileWriter
 // deferred close has the right scope.
 func (r *Repository) createNewObjectPack(cfg *RepackConfig) (h plumbing.Hash, err error) {
 	ow := newObjectWalker(r.Storer)


### PR DESCRIPTION
Remove multiple instances of the word "the" within the code comments.