### PR TITLE
Fix space-prefixed commit header line handling in decoding

### DIFF
--- a/plumbing/object/commit.go
+++ b/plumbing/object/commit.go
@@ -192,12 +192,17 @@ func (c *Commit) Decode(o plumbing.EncodedObject) (err error) {
 		}
 
 		if !message {
-			line = bytes.TrimSpace(line)
+			line = bytes.TrimSuffix(line, []byte{'\n'})
 			if len(line) == 0 {
 				message = true
 				continue
 			}
 
+			if line[0] == byte(' ') {
+				continue
+			}
+
+			line = bytes.TrimSpace(line)
 			split := bytes.SplitN(line, []byte{' '}, 2)
 
 			var data []byte


### PR DESCRIPTION
GPG signatures (and maybe other commit header extensions) use space-prefixes lines for multi-line values. Compare e.g. (with `$` as the line end):

```
> git show --format=raw 7b8bb6e7d3345b04678d96a721f651a4a68eb1dd | sed 's/$/$/'
commit 7b8bb6e7d3345b04678d96a721f651a4a68eb1dd$
tree 45c1bcc6a707d9060419cc169484f511cd3baf20$
parent d723028d09d2fd3faa177782de8e444ac64f5875$
parent f952b093a7faa62323617a684e7f6a58d863f42f$
author Kubernetes Submit Queue <k8s-merge-robot@users.noreply.github.com> 1526444292 -0700$
committer GitHub <noreply@github.com> 1526444292 -0700$
gpgsig -----BEGIN PGP SIGNATURE-----$
 $
 wsBcBAABCAAQBQJa+7EECRBK7hj4Ov3rIwAAdHIIAACfUDQrBSxbrKOdxPVDJh31$
 S6ZvJjmEp3ha3p59YqJ740SWvdKbykb2IreMUHuIFV87N0OHlh1SonSiZKlANC7z$
 QyZcfS7O6PTMnRaLpHlLkV3rTr0gE0aNmiokFCpJJF1l0ULHv5H4OLOktNWrISdO$
 kFNrBSmqlbmndBTRQoMMaRSD9W71VqzDn9rFcPqkaz+Fu0NX7ztIwyUQQ1gcvpto$
 fowgR3TiOaUMci0lXRdv2aPchBHYHhidPTe6x5HDtciEd+LX0R2d3w2JnXaeuzKQ$
 x4M35+xt3bC3SG9dWPVyPi0nV+pMTfdHNJqLehNZQayBSSHfMeQ3TaybOyBJF8E=$
 =HoUx$
 -----END PGP SIGNATURE-----$
 $
$
    Merge pull request #63357 from Random-Liu/install-and-use-crictl$
```