### PR TITLE
git: Fix Status.IsClean() documentation

### DIFF
--- a/status.go
+++ b/status.go
@@ -26,7 +26,7 @@ func (s Status) IsUntracked(path string) bool {
 	return ok && stat.Worktree == Untracked
 }
 
-// IsClean returns true if all the files aren't in Unmodified status.
+// IsClean returns true if all the files are in Unmodified status.
 func (s Status) IsClean() bool {
 	for _, status := range s {
 		if status.Worktree != Unmodified || status.Staging != Unmodified {


### PR DESCRIPTION
The documentation of the IsClean Method contained a negation, so it was
describing the opposite of its actual behavior.

Fixes #838

Signed-off-by: David Url <david@urld.io>