### PR TITLE
plumbing: object, Add support for Log with filenames. Fixes #826

### DIFF
--- a/options.go
+++ b/options.go
@@ -330,6 +330,8 @@ type LogOptions struct {
 	// set Order=LogOrderCommitterTime for ordering by committer time (more compatible with `git log`)
 	// set Order=LogOrderBSF for Breadth-first search
 	Order LogOrder
+
+	FileName *string
 }
 
 var (

--- a/options.go
+++ b/options.go
@@ -331,6 +331,8 @@ type LogOptions struct {
 	// set Order=LogOrderBSF for Breadth-first search
 	Order LogOrder
 
+	// Show only those commits in which the specified file was inserted/updated.
+	// It is equivalent to running `git log -- <file-name>`.
 	FileName *string
 }
 

--- a/plumbing/object/commit_walker_file.go
+++ b/plumbing/object/commit_walker_file.go
@@ -1,0 +1,114 @@
+package object
+
+import (
+	"gopkg.in/src-d/go-git.v4/plumbing/storer"
+	"io"
+)
+
+type commitFileIter struct {
+	fileName      string
+	sourceIter    CommitIter
+	currentCommit *Commit
+}
+
+// NewCommitFileIterFromIter returns a commit iterator which performs diffTree between
+// successive trees returned from the commit iterator from the argument. The purpose of this is
+// to find the commits that explain how the files that match the path came to be.
+func NewCommitFileIterFromIter(fileName string, commitIter CommitIter) CommitIter {
+	iterator := new(commitFileIter)
+	iterator.sourceIter = commitIter
+	iterator.fileName = fileName
+	return iterator
+}
+
+func (c *commitFileIter) Next() (*Commit, error) {
+	var err error
+	if c.currentCommit == nil {
+		c.currentCommit, err = c.sourceIter.Next()
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	for {
+		// Parent-commit can be nil if the current-commit is the initial commit
+		parentCommit, parentCommitErr := c.sourceIter.Next()
+		if parentCommitErr != nil {
+			if parentCommitErr != io.EOF {
+				err = parentCommitErr
+				break
+			}
+			parentCommit = nil
+		}
+
+		// Fetch the trees of the current and parent commits
+		currentTree, currTreeErr := c.currentCommit.Tree()
+		if currTreeErr != nil {
+			err = currTreeErr
+			break
+		}
+
+		var parentTree *Tree
+		if parentCommit != nil {
+			var parentTreeErr error
+			parentTree, parentTreeErr = parentCommit.Tree()
+			if parentTreeErr != nil {
+				err = parentTreeErr
+				break
+			}
+		}
+
+		// Find diff between current and parent trees
+		changes, diffErr := DiffTree(currentTree, parentTree)
+		if diffErr != nil {
+			err = diffErr
+			break
+		}
+
+		foundChangeForFile := false
+		for _, change := range changes {
+			if change.name() == c.fileName {
+				foundChangeForFile = true
+				break
+			}
+		}
+
+		// Storing the current-commit in-case a change is found, and
+		// Updating the current-commit for the next-iteration
+		prevCommit := c.currentCommit
+		c.currentCommit = parentCommit
+
+		if foundChangeForFile == true {
+			return prevCommit, nil
+		}
+
+		// If there are no more commits to be found, then return with EOF
+		if parentCommit == nil {
+			err = io.EOF
+			break
+		}
+	}
+
+	// Setting current-commit to nil to prevent unwanted states when errors are raised
+	c.currentCommit = nil
+	return nil, err
+}
+
+func (c *commitFileIter) ForEach(cb func(*Commit) error) error {
+	for {
+		commit, nextErr := c.Next()
+		if nextErr != nil {
+			return nextErr
+		}
+		err := cb(commit)
+		if err == storer.ErrStop {
+			return nil
+		} else if err != nil {
+			return err
+		}
+	}
+}
+
+func (c *commitFileIter) Close() {
+	c.sourceIter.Close()
+}

--- a/repository.go
+++ b/repository.go
@@ -965,19 +965,26 @@ func (r *Repository) Log(o *LogOptions) (object.CommitIter, error) {
 		return nil, err
 	}
 
+	var commitIter object.CommitIter
 	switch o.Order {
 	case LogOrderDefault:
-		return object.NewCommitPreorderIter(commit, nil, nil), nil
+		commitIter = object.NewCommitPreorderIter(commit, nil, nil)
 	case LogOrderDFS:
-		return object.NewCommitPreorderIter(commit, nil, nil), nil
+		commitIter = object.NewCommitPreorderIter(commit, nil, nil)
 	case LogOrderDFSPost:
-		return object.NewCommitPostorderIter(commit, nil), nil
+		commitIter = object.NewCommitPostorderIter(commit, nil)
 	case LogOrderBSF:
-		return object.NewCommitIterBSF(commit, nil, nil), nil
+		commitIter = object.NewCommitIterBSF(commit, nil, nil)
 	case LogOrderCommitterTime:
-		return object.NewCommitIterCTime(commit, nil, nil), nil
+		commitIter = object.NewCommitIterCTime(commit, nil, nil)
+	default:
+		return nil, fmt.Errorf("invalid Order=%v", o.Order)
 	}
-	return nil, fmt.Errorf("invalid Order=%v", o.Order)
+
+	if o.FileName == nil {
+		return commitIter, nil
+	}
+	return object.NewCommitFileIterFromIter(*o.FileName, commitIter), nil
 }
 
 // Tags returns all the tag References in a repository.


### PR DESCRIPTION
Hi,
This is in reference to #826 
This commit basically performs what `git log -- <filename>` should do.

I've added a new class called `commit_walker_file`, which wraps around the iterator of the original `Log` function and returns those commits whose `Difftree` contains the file-path specified. I've added tests for scenarios I could think of.

Kindly let me know if there's something I can do better here.

Signed-off-by: Nithin <nithin.linkin@gmail.com>