### PR TITLE
repository: allow open non-bare repositories as bare

### DIFF
--- a/repository.go
+++ b/repository.go
@@ -175,15 +175,6 @@ func Open(s storage.Storer, worktree billy.Filesystem) (*Repository, error) {
 		return nil, err
 	}
 
-	cfg, err := s.Config()
-	if err != nil {
-		return nil, err
-	}
-
-	if !cfg.Core.IsBare && worktree == nil {
-		return nil, ErrWorktreeNotProvided
-	}
-
 	return newRepository(s, worktree), nil
 }
 
@@ -335,6 +326,8 @@ func dotGitFileToOSFilesystem(path string, fs billy.Filesystem) (bfs billy.Files
 // PlainClone a repository into the path with the given options, isBare defines
 // if the new repository will be bare or normal. If the path is not empty
 // ErrRepositoryAlreadyExists is returned.
+//
+// TODO(mcuadros): move isBare to CloneOptions in v5
 func PlainClone(path string, isBare bool, o *CloneOptions) (*Repository, error) {
 	return PlainCloneContext(context.Background(), path, isBare, o)
 }
@@ -346,6 +339,8 @@ func PlainClone(path string, isBare bool, o *CloneOptions) (*Repository, error) 
 // The provided Context must be non-nil. If the context expires before the
 // operation is complete, an error is returned. The context only affects to the
 // transport operations.
+//
+// TODO(mcuadros): move isBare to CloneOptions in v5
 func PlainCloneContext(ctx context.Context, path string, isBare bool, o *CloneOptions) (*Repository, error) {
 	r, err := PlainInit(path, isBare)
 	if err != nil {

--- a/repository_test.go
+++ b/repository_test.go
@@ -143,7 +143,7 @@ func (s *RepositorySuite) TestOpenBare(c *C) {
 	c.Assert(r, NotNil)
 }
 
-func (s *RepositorySuite) TestOpenMissingWorktree(c *C) {
+func (s *RepositorySuite) TestOpenBareMissingWorktree(c *C) {
 	st := memory.NewStorage()
 
 	r, err := Init(st, memfs.New())
@@ -151,8 +151,8 @@ func (s *RepositorySuite) TestOpenMissingWorktree(c *C) {
 	c.Assert(r, NotNil)
 
 	r, err = Open(st, nil)
-	c.Assert(err, Equals, ErrWorktreeNotProvided)
-	c.Assert(r, IsNil)
+	c.Assert(err, IsNil)
+	c.Assert(r, NotNil)
 }
 
 func (s *RepositorySuite) TestOpenNotExists(c *C) {
@@ -425,8 +425,8 @@ func (s *RepositorySuite) TestPlainOpenNotBare(c *C) {
 	c.Assert(r, NotNil)
 
 	r, err = PlainOpen(filepath.Join(dir, ".git"))
-	c.Assert(err, Equals, ErrWorktreeNotProvided)
-	c.Assert(r, IsNil)
+	c.Assert(err, IsNil)
+	c.Assert(r, NotNil)
 }
 
 func (s *RepositorySuite) testPlainOpenGitFile(c *C, f func(string, string) string) {


### PR DESCRIPTION
This mimics the behavior of cgit. 