### PR TITLE
repository: improve CheckoutOption.Hash doc

### DIFF
--- a/options.go
+++ b/options.go
@@ -231,8 +231,9 @@ var (
 
 // CheckoutOptions describes how a checkout 31operation should be performed.
 type CheckoutOptions struct {
-	// Hash to be checked out, if used HEAD will in detached mode. Branch and
-	// Hash are mutually exclusive, if Create is not used.
+	// Hash is the hash of the commit to be checked out. If used, HEAD will be
+	// in detached mode. If Create is not used, Branch and Hash are mutually
+	// exclusive.
 	Hash plumbing.Hash
 	// Branch to be checked out, if Branch and Hash are empty is set to `master`.
 	Branch plumbing.ReferenceName


### PR DESCRIPTION
The `CheckoutOption.Hash` can be used only with hash commits, this PR clarifies this on the documentation.

https://github.com/src-d/go-git/issues/954