### PR TITLE
git: enables building on OpenBSD, Dragonfly BSD and Solaris

### DIFF
--- a/worktree_unix_other.go
+++ b/worktree_unix_other.go
@@ -1,4 +1,4 @@
-// +build darwin freebsd netbsd
+// +build openbsd dragonfly solaris
 
 package git
 
@@ -12,7 +12,7 @@ import (
 func init() {
 	fillSystemInfo = func(e *index.Entry, sys interface{}) {
 		if os, ok := sys.(*syscall.Stat_t); ok {
-			e.CreatedAt = time.Unix(int64(os.Atimespec.Sec), int64(os.Atimespec.Nsec))
+			e.CreatedAt = time.Unix(int64(os.Atim.Sec), int64(os.Atim.Nsec))
 			e.Dev = uint32(os.Dev)
 			e.Inode = uint32(os.Ino)
 			e.GID = os.Gid


### PR DESCRIPTION
Fixes #843 

This PR uses `os.Atim` instead of `os.Atimspec` for OpenBSD, Dragonfly BSD and Solaris targets (using the fix in #843) so makes this package buildable on those platforms.

For Solaris, an additional PR needs to be merged to `go-billy`: https://github.com/src-d/go-billy/pull/63