### PR TITLE
Update COMPATIBILITY.md

### DIFF
--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -12,7 +12,7 @@ is supported by go-git.
 | init                                  | ✔ | Plain init and `--bare` are supported. Flags `--template`, `--separate-git-dir` and `--shared` are not. |
 | clone                                 | ✔ | Plain clone and equivalents to `--progress`,  `--single-branch`, `--depth`, `--origin`, `--recurse-submodules` are supported. Others are not. |
 | **basic snapshotting** |
-| add                                   | ✔ | Plain add is supported. Any other flag aren't supported |
+| add                                   | ✔ | Plain add is supported. Any other flag isn't supported |
 | status                                | ✔ |
 | commit                                | ✔ |
 | reset                                 | ✔ |


### PR DESCRIPTION
If flags are plural, then usage of aren't is warranted. If it is a single flag, we should use isn't
