### PR TITLE
storage/filesystem: Added reindex method to  reindex packfiles

### DIFF
--- a/storage/filesystem/object.go
+++ b/storage/filesystem/object.go
@@ -61,6 +61,11 @@ func (s *ObjectStorage) requireIndex() error {
 	return nil
 }
 
+// Reindex indexes again all packfiles. Useful if git changed packfiles externally
+func (s *ObjectStorage) Reindex() {
+	s.index = nil
+}
+
 func (s *ObjectStorage) loadIdxFile(h plumbing.Hash) (err error) {
 	f, err := s.dir.ObjectPackIdx(h)
 	if err != nil {


### PR DESCRIPTION
This PR adds a simple method to the Filesystem `ObjectStorage` object so the user can invoke a reindex of all packfiles. This is useful in repos in which go-git does not have exclusive access and git manipulates packfiles, such as when using `git bundle`, or repacking externally.