### PR TITLE
Implement git log --all

### DIFF
--- a/options.go
+++ b/options.go
@@ -335,6 +335,10 @@ type LogOptions struct {
 	// Show only those commits in which the specified file was inserted/updated.
 	// It is equivalent to running `git log -- <file-name>`.
 	FileName *string
+
+	// Pretend as if all the refs in refs/, along with HEAD, are listed on the command line as <commit>.
+	// It is equivalent to running `git log --all`.
+	All bool
 }
 
 var (

--- a/plumbing/object/commit_walker_file.go
+++ b/plumbing/object/commit_walker_file.go
@@ -1,8 +1,9 @@
 package object
 
 import (
-	"gopkg.in/src-d/go-git.v4/plumbing/storer"
 	"io"
+
+	"gopkg.in/src-d/go-git.v4/plumbing/storer"
 )
 
 type commitFileIter struct {

--- a/repository_test.go
+++ b/repository_test.go
@@ -1251,6 +1251,43 @@ func (s *RepositorySuite) TestLog(c *C) {
 	c.Assert(err, Equals, io.EOF)
 }
 
+func (s *RepositorySuite) TestLogAll(c *C) {
+	r, _ := Init(memory.NewStorage(), nil)
+	err := r.clone(context.Background(), &CloneOptions{
+		URL: s.GetBasicLocalRepositoryURL(),
+	})
+
+	c.Assert(err, IsNil)
+
+	cIter, err := r.Log(&LogOptions{
+		From:  plumbing.NewHash("b8e471f58bcbca63b07bda20e428190409c2db47"),
+		Order: LogOrderCommitterTime,
+		All:   true,
+	})
+
+	c.Assert(err, IsNil)
+
+	commitOrder := []plumbing.Hash{
+		plumbing.NewHash("6ecf0ef2c2dffb796033e5a02219af86ec6584e5"),
+		plumbing.NewHash("e8d3ffab552895c19b9fcf7aa264d277cde33881"),
+		plumbing.NewHash("918c48b83bd081e863dbe1b80f8998f058cd8294"),
+		plumbing.NewHash("af2d6a6954d532f8ffb47615169c8fdf9d383a1a"),
+		plumbing.NewHash("1669dce138d9b841a518c64b10914d88f5e488ea"),
+		plumbing.NewHash("a5b8b09e2f8fcb0bb99d3ccb0958157b40890d69"),
+		plumbing.NewHash("35e85108805c84807bc66a02d91535e1e24b38b9"),
+		plumbing.NewHash("b8e471f58bcbca63b07bda20e428190409c2db47"),
+		plumbing.NewHash("b029517f6300c2da0f4b651b8642506cd6aaf45d"),
+	}
+
+	for _, o := range commitOrder {
+		commit, err := cIter.Next()
+		c.Assert(err, IsNil)
+		c.Assert(commit.Hash, Equals, o)
+	}
+	_, err = cIter.Next()
+	c.Assert(err, Equals, io.EOF)
+}
+
 func (s *RepositorySuite) TestLogHead(c *C) {
 	r, _ := Init(memory.NewStorage(), nil)
 	err := r.clone(context.Background(), &CloneOptions{
@@ -1272,6 +1309,42 @@ func (s *RepositorySuite) TestLogHead(c *C) {
 		plumbing.NewHash("b029517f6300c2da0f4b651b8642506cd6aaf45d"),
 		plumbing.NewHash("a5b8b09e2f8fcb0bb99d3ccb0958157b40890d69"),
 		plumbing.NewHash("b8e471f58bcbca63b07bda20e428190409c2db47"),
+	}
+
+	for _, o := range commitOrder {
+		commit, err := cIter.Next()
+		c.Assert(err, IsNil)
+		c.Assert(commit.Hash, Equals, o)
+	}
+	_, err = cIter.Next()
+	c.Assert(err, Equals, io.EOF)
+}
+
+func (s *RepositorySuite) TestLogAllHead(c *C) {
+	r, _ := Init(memory.NewStorage(), nil)
+	err := r.clone(context.Background(), &CloneOptions{
+		URL: s.GetBasicLocalRepositoryURL(),
+	})
+
+	c.Assert(err, IsNil)
+
+	cIter, err := r.Log(&LogOptions{
+		Order: LogOrderCommitterTime,
+		All:   true,
+	})
+
+	c.Assert(err, IsNil)
+
+	commitOrder := []plumbing.Hash{
+		plumbing.NewHash("6ecf0ef2c2dffb796033e5a02219af86ec6584e5"),
+		plumbing.NewHash("e8d3ffab552895c19b9fcf7aa264d277cde33881"),
+		plumbing.NewHash("918c48b83bd081e863dbe1b80f8998f058cd8294"),
+		plumbing.NewHash("af2d6a6954d532f8ffb47615169c8fdf9d383a1a"),
+		plumbing.NewHash("1669dce138d9b841a518c64b10914d88f5e488ea"),
+		plumbing.NewHash("a5b8b09e2f8fcb0bb99d3ccb0958157b40890d69"),
+		plumbing.NewHash("35e85108805c84807bc66a02d91535e1e24b38b9"),
+		plumbing.NewHash("b8e471f58bcbca63b07bda20e428190409c2db47"),
+		plumbing.NewHash("b029517f6300c2da0f4b651b8642506cd6aaf45d"),
 	}
 
 	for _, o := range commitOrder {


### PR DESCRIPTION
Signed-off-by: kuba-- <kuba@sourced.tech>

This PR implements `git log --all`.
It closes https://github.com/src-d/go-git/issues/1024
It's also related to https://github.com/src-d/go-git/issues/1023

Please take a look carefully if it can be done in more optimal way.