### PR TITLE
Implement git log --all

### DIFF
--- a/options.go
+++ b/options.go
@@ -335,6 +335,11 @@ type LogOptions struct {
 	// Show only those commits in which the specified file was inserted/updated.
 	// It is equivalent to running `git log -- <file-name>`.
 	FileName *string
+
+	// Pretend as if all the refs in refs/, along with HEAD, are listed on the command line as <commit>.
+	// It is equivalent to running `git log --all`.
+	// If set on true, the From option will be ignored.
+	All bool
 }
 
 var (

--- a/plumbing/object/commit_walker.go
+++ b/plumbing/object/commit_walker.go
@@ -1,10 +1,12 @@
 package object
 
 import (
+	"container/list"
 	"io"
 
 	"gopkg.in/src-d/go-git.v4/plumbing"
 	"gopkg.in/src-d/go-git.v4/plumbing/storer"
+	"gopkg.in/src-d/go-git.v4/storage"
 )
 
 type commitPreIterator struct {
@@ -181,3 +183,127 @@ func (w *commitPostIterator) ForEach(cb func(*Commit) error) error {
 }
 
 func (w *commitPostIterator) Close() {}
+
+// commitAllIterator stands for commit iterator for all refs.
+type commitAllIterator struct {
+	// el points to the current commit.
+	el *list.Element
+}
+
+// NewCommitAllIter returns a new commit iterator for all refs.
+// s is a repo Storer used to get commits and references.
+// fn is a commit iterator function, used to iterate through ref commits in chosen order
+func NewCommitAllIter(s storage.Storer, fn func(*Commit) CommitIter) (CommitIter, error) {
+	l := list.New()
+	m := make(map[plumbing.Hash]*list.Element)
+
+	// ...along with the HEAD
+	head, err := storer.ResolveReference(s, plumbing.HEAD)
+	if err != nil {
+		return nil, err
+	}
+	headCommit, err := GetCommit(s, head.Hash())
+	if err != nil {
+		return nil, err
+	}
+	err = fn(headCommit).ForEach(func(c *Commit) error {
+		el := l.PushBack(c)
+		m[c.Hash] = el
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	refIter, err := s.IterReferences()
+	if err != nil {
+		return nil, err
+	}
+	defer refIter.Close()
+	err = refIter.ForEach(func(r *plumbing.Reference) error {
+		if r.Hash() == head.Hash() {
+			// we already have the HEAD
+			return nil
+		}
+		c, _ := GetCommit(s, r.Hash())
+		// if it's not a commit - skip it.
+		if c == nil {
+			return nil
+		}
+
+		el, ok := m[c.Hash]
+		if ok {
+			return nil
+		}
+
+		var refCommits []*Commit
+		cit := fn(c)
+		for c, e := cit.Next(); e == nil; {
+			el, ok = m[c.Hash]
+			if ok {
+				break
+			}
+			refCommits = append(refCommits, c)
+			c, e = cit.Next()
+		}
+		cit.Close()
+
+		if el == nil {
+			// push back all commits from this ref.
+			for _, c := range refCommits {
+				el = l.PushBack(c)
+				m[c.Hash] = el
+			}
+		} else {
+			// insert ref's commits into the list
+			for i := len(refCommits) - 1; i >= 0; i-- {
+				c := refCommits[i]
+				el = l.InsertBefore(c, el)
+				m[c.Hash] = el
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return &commitAllIterator{l.Front()}, nil
+}
+
+func (it *commitAllIterator) Next() (*Commit, error) {
+	if it.el == nil {
+		return nil, io.EOF
+	}
+
+	c := it.el.Value.(*Commit)
+	it.el = it.el.Next()
+
+	return c, nil
+}
+
+func (it *commitAllIterator) ForEach(cb func(*Commit) error) error {
+	for {
+		c, err := it.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return err
+		}
+
+		err = cb(c)
+		if err == storer.ErrStop {
+			break
+		}
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (it *commitAllIterator) Close() {
+	it.el = nil
+}

--- a/plumbing/object/commit_walker.go
+++ b/plumbing/object/commit_walker.go
@@ -225,18 +225,18 @@ func NewCommitAllIter(s storage.Storer, fn func(*Commit) CommitIter) (CommitIter
 			// we already have the HEAD
 			return nil
 		}
-		c, _ := GetCommit(s, r.Hash())
-		// if it's not a commit - skip it.
-		if c == nil {
-			return nil
-		}
 
-		el, ok := m[c.Hash]
+		el, ok := m[r.Hash()]
 		if ok {
 			return nil
 		}
 
 		var refCommits []*Commit
+		c, _ := GetCommit(s, r.Hash())
+		// if it's not a commit - skip it.
+		if c == nil {
+			return nil
+		}
 		cit := fn(c)
 		for c, e := cit.Next(); e == nil; {
 			el, ok = m[c.Hash]

--- a/plumbing/object/commit_walker_file.go
+++ b/plumbing/object/commit_walker_file.go
@@ -3,6 +3,8 @@ package object
 import (
 	"io"
 
+	"gopkg.in/src-d/go-git.v4/plumbing"
+
 	"gopkg.in/src-d/go-git.v4/plumbing/storer"
 )
 
@@ -10,17 +12,19 @@ type commitFileIter struct {
 	fileName      string
 	sourceIter    CommitIter
 	currentCommit *Commit
-	all           bool
+	checkParent   bool
 }
 
 // NewCommitFileIterFromIter returns a commit iterator which performs diffTree between
 // successive trees returned from the commit iterator from the argument. The purpose of this is
 // to find the commits that explain how the files that match the path came to be.
-func NewCommitFileIterFromIter(fileName string, commitIter CommitIter, all bool) CommitIter {
+// If checkParent is true then the function double checks if potential parent (next commit in a path)
+// is one of the parents in the tree (it's used by `git log --all`).
+func NewCommitFileIterFromIter(fileName string, commitIter CommitIter, checkParent bool) CommitIter {
 	iterator := new(commitFileIter)
 	iterator.sourceIter = commitIter
 	iterator.fileName = fileName
-	iterator.all = all
+	iterator.checkParent = checkParent
 	return iterator
 }
 
@@ -74,36 +78,14 @@ func (c *commitFileIter) getNextFileCommit() (*Commit, error) {
 			return nil, diffErr
 		}
 
-		foundChangeForFile := false
-		for _, change := range changes {
-			if change.name() != c.fileName {
-				continue
-			}
-
-			// filename matches, now check if source iterator contains all commits (from all refs)
-			if c.all {
-				// for `git log --all` also check if the next commit comes from the same parent
-				for _, h := range c.currentCommit.ParentHashes {
-					if h == parentCommit.Hash {
-						foundChangeForFile = true
-						break
-					}
-				}
-			} else {
-				foundChangeForFile = true
-			}
-
-			if foundChangeForFile {
-				break
-			}
-		}
+		found := c.hasFileChange(changes, parentCommit)
 
 		// Storing the current-commit in-case a change is found, and
 		// Updating the current-commit for the next-iteration
 		prevCommit := c.currentCommit
 		c.currentCommit = parentCommit
 
-		if foundChangeForFile == true {
+		if found {
 			return prevCommit, nil
 		}
 
@@ -112,6 +94,35 @@ func (c *commitFileIter) getNextFileCommit() (*Commit, error) {
 			return nil, io.EOF
 		}
 	}
+}
+
+func (c *commitFileIter) hasFileChange(changes Changes, parent *Commit) bool {
+	for _, change := range changes {
+		if change.name() != c.fileName {
+			continue
+		}
+
+		// filename matches, now check if source iterator contains all commits (from all refs)
+		if c.checkParent {
+			if parent != nil && isParentHash(parent.Hash, c.currentCommit) {
+				return true
+			}
+			continue
+		}
+
+		return true
+	}
+
+	return false
+}
+
+func isParentHash(hash plumbing.Hash, commit *Commit) bool {
+	for _, h := range commit.ParentHashes {
+		if h == hash {
+			return true
+		}
+	}
+	return false
 }
 
 func (c *commitFileIter) ForEach(cb func(*Commit) error) error {


### PR DESCRIPTION
Signed-off-by: kuba-- <kuba@sourced.tech>

This PR implements git log --all.
It closes #1024
It's also related to #1023

`git log --all` pretends as if all the refs in refs/, along with HEAD, are listed on the command line as <commit>. We start from the HEAD, so `From` hash is ignored for `--all` option.

Please take a look carefully if it can be done in more optimal way.
For _filter by file_ (`git log --all --filename`) we have to double check if the parent commit comes from the real commit (not just the next object returned by iterator). 