### PR TITLE
packfile: get object size correctly for delta objects

### DIFF
--- a/plumbing/format/packfile/packfile.go
+++ b/plumbing/format/packfile/packfile.go
@@ -107,7 +107,7 @@ func (p *Packfile) GetSizeByOffset(o int64) (size int64, err error) {
 	if err != nil {
 		return 0, err
 	}
-	return h.Length, nil
+	return p.getObjectSize(h)
 }
 
 func (p *Packfile) objectHeaderAtOffset(offset int64) (*ObjectHeader, error) {


### PR DESCRIPTION
Signed-off-by: Jeremy Stribling <strib@alum.mit.edu>