### PR TITLE
Add two getters to the Commit type

### DIFF
--- a/plumbing/object/commit.go
+++ b/plumbing/object/commit.go
@@ -150,6 +150,20 @@ func (c *Commit) ID() plumbing.Hash {
 	return c.Hash
 }
 
+// Message returns the commit message.
+//
+// Message is present to fulfill external interfaces.
+func (c *Commit) GetMessage() string {
+	return c.Message
+}
+
+// ParentHashes returns the hashes of the parent commits.
+//
+// ParentHashes is present to fulfill external interfaces.
+func (c *Commit) GetParentHashes() []plumbing.Hash {
+	return c.ParentHashes
+}
+
 // Type returns the type of object. It always returns plumbing.CommitObject.
 //
 // Type is present to fulfill the Object interface.


### PR DESCRIPTION
In the beginning, I want to thank you for this very awesome project. It makes life easier :)

I'm depending on this project for mining git history.  I propose adding getters for `Message` and `ParentHashes` to allow more extensibility for dependent applications. This will allow the `Commit` type to fulfill interfaces that need to access `ParentHashes` or `Message` without the need to write wrappers to do do that. 

As a benefit for users, will be easier for them to test their code my mocking their interface instead of mocking the `Commit` type. Also, the design will have less coupling with the dependency when by putting it behind an interface. 

> I Know that it's idiomatic to put `Get` into the getter's name. However, because the fields are exposed, we need to have a different name.   

Thank you.

Signed-off-by: Suhaib Mujahid <suhaibmujahid@gmail.com>