### PR TITLE
worktree: add sentinel error for non-fast-forward pull

### DIFF
--- a/worktree.go
+++ b/worktree.go
@@ -25,10 +25,11 @@ import (
 )
 
 var (
-	ErrWorktreeNotClean  = errors.New("worktree is not clean")
-	ErrSubmoduleNotFound = errors.New("submodule not found")
-	ErrUnstagedChanges   = errors.New("worktree contains unstaged changes")
-	ErrGitModulesSymlink = errors.New(gitmodulesFile + " is a symlink")
+	ErrWorktreeNotClean     = errors.New("worktree is not clean")
+	ErrSubmoduleNotFound    = errors.New("submodule not found")
+	ErrUnstagedChanges      = errors.New("worktree contains unstaged changes")
+	ErrGitModulesSymlink    = errors.New(gitmodulesFile + " is a symlink")
+	ErrNonFastForwardUpdate = errors.New("non-fast-forward update")
 )
 
 // Worktree represents a git worktree.
@@ -101,7 +102,7 @@ func (w *Worktree) PullContext(ctx context.Context, o *PullOptions) error {
 		}
 
 		if !ff {
-			return fmt.Errorf("non-fast-forward update")
+			return ErrNonFastForwardUpdate
 		}
 	}
 

--- a/worktree_test.go
+++ b/worktree_test.go
@@ -119,7 +119,7 @@ func (s *WorktreeSuite) TestPullNonFastForward(c *C) {
 	c.Assert(err, IsNil)
 
 	err = w.Pull(&PullOptions{})
-	c.Assert(err, ErrorMatches, "non-fast-forward update")
+	c.Assert(err, Equals, ErrNonFastForwardUpdate)
 }
 
 func (s *WorktreeSuite) TestPullUpdateReferencesIfNeeded(c *C) {


### PR DESCRIPTION
Signed-off-by: Alexey Smirnov <unlinkat@gmail.com>