### PR TITLE
worktree: allow manual ignore patterns when no .gitignore is available

### DIFF
--- a/worktree_status.go
+++ b/worktree_status.go
@@ -142,11 +142,15 @@ func (w *Worktree) diffStagingWithWorktree(reverse bool) (merkletrie.Changes, er
 
 func (w *Worktree) excludeIgnoredChanges(changes merkletrie.Changes) merkletrie.Changes {
 	patterns, err := gitignore.ReadPatterns(w.Filesystem, nil)
-	if err != nil || len(patterns) == 0 {
+	if err != nil {
 		return changes
 	}
 
 	patterns = append(patterns, w.Excludes...)
+
+	if len(patterns) == 0 {
+		return changes
+	}
 
 	m := gitignore.NewMatcher(patterns)
 


### PR DESCRIPTION
I am using go-git as a library for a personal project and noticed hard-coded excluded patterns are ignored when no `.gitignore` file exists at the root of the repository.

This PR fixes this behavior and allows hard-coded ignore patterns even when no `.gitignore` file is present 