### PR TITLE
Add merge-base command example

### DIFF
--- a/_examples/merge_base/main.go
+++ b/_examples/merge_base/main.go
@@ -1,0 +1,133 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"gopkg.in/src-d/go-git.v4"
+	"gopkg.in/src-d/go-git.v4/_examples/merge_base/repository"
+	"gopkg.in/src-d/go-git.v4/plumbing"
+	"gopkg.in/src-d/go-git.v4/plumbing/object"
+
+	. "gopkg.in/src-d/go-git.v4/_examples"
+)
+
+func helpAndExit(s string, exitCode int) {
+	if s != "" {
+		Warning("%s", s)
+	}
+
+	Warning("%s %s", os.Args[0], "<path> <baseRev> <headRev>")
+	Warning("%s %s", os.Args[0], "<path> --is-ancestor <baseRev> <headRev>")
+	Warning("%s %s", os.Args[0], "<path> --independent <commitRev>...")
+
+	os.Exit(exitCode)
+}
+
+// Command that mimics `git merge-base <baseRev> <headRev>`
+// Command that mimics `git merge-base --is-ancestor <baseRev> <headRev>`
+// Command that mimics `git merge-base --independent <commitRev>...`
+func main() {
+
+	if len(os.Args) < 2 || os.Args[1] == "--help" || os.Args[1] == "-h" {
+		helpAndExit("Returns the merge-base between two commits:", 0)
+	}
+
+	if len(os.Args) < 4 {
+		helpAndExit("Wrong syntax, Usage:", 1)
+	}
+
+	path := os.Args[1]
+
+	var modeIndependent, modeAncestor bool
+	var commitRevs []string
+	var res []*object.Commit
+
+	switch os.Args[2] {
+	case "--independent":
+		modeIndependent = true
+		commitRevs = os.Args[3:]
+	case "--is-ancestor":
+		modeAncestor = true
+		commitRevs = os.Args[3:]
+		if len(os.Args) != 5 {
+			helpAndExit("Wrong syntax, Usage:", 1)
+		}
+	default:
+		commitRevs = os.Args[2:]
+		if len(os.Args) != 4 {
+			helpAndExit("Wrong syntax, Usage:", 1)
+		}
+	}
+
+	// Open a git repository from the given path
+	repo, err := git.PlainOpen(path)
+	CheckIfError(err)
+
+	// Get the hashes of the passed revisions
+	var hashes []*plumbing.Hash
+	for _, rev := range commitRevs {
+		hash, err := repo.ResolveRevision(plumbing.Revision(rev))
+		CheckIfError(wrappErr(err, "could not parse revision '%s'", rev))
+		hashes = append(hashes, hash)
+	}
+
+	// Get the commits identified by the passed hashes
+	var commits []*object.Commit
+	for _, hash := range hashes {
+		commit, err := repo.CommitObject(*hash)
+		CheckIfError(wrappErr(err, "could not find commit '%s'", hash.String()))
+		commits = append(commits, commit)
+	}
+
+	if modeAncestor {
+		isAncestor, err := repository.IsAncestor(commits[0], commits[1])
+		CheckIfError(err)
+
+		if !isAncestor {
+			Warning("%s is not ancestor of %s", commitRevs[0], commitRevs[1])
+			os.Exit(1)
+		}
+
+		os.Exit(0)
+	}
+
+	if modeIndependent {
+		res, err = repository.Independents(commits)
+		CheckIfError(err)
+	} else {
+		// REVIEWER: store param wouldn't be needed if MergeBase were part of git.Repository
+		res, err = repository.MergeBase(repo.Storer, commits[0], commits[1])
+		CheckIfError(err)
+
+		if len(res) == 0 {
+			os.Exit(1)
+		}
+	}
+
+	for _, commit := range res {
+		print(commit)
+	}
+}
+
+func wrappErr(err error, s string, v ...interface{}) error {
+	if err != nil {
+		return fmt.Errorf("%s: %s", fmt.Sprintf(s, v...), err)
+	}
+
+	return nil
+}
+
+func print(c *object.Commit) {
+	if os.Getenv("LOG_LEVEL") == "verbose" {
+		fmt.Printf(
+			"\x1b[36;1m%s \x1b[90;21m%s\x1b[0m %s\n",
+			c.Hash.String()[:7],
+			c.Hash.String(),
+			strings.Split(c.Message, "\n")[0],
+		)
+	} else {
+		fmt.Println(c.Hash.String())
+	}
+}

--- a/_examples/merge_base/plumbing/object/commit_walker_bfs_filtered.go
+++ b/_examples/merge_base/plumbing/object/commit_walker_bfs_filtered.go
@@ -1,0 +1,181 @@
+package object
+
+import (
+	"io"
+
+	"gopkg.in/src-d/go-git.v4/plumbing"
+	"gopkg.in/src-d/go-git.v4/plumbing/object"
+	"gopkg.in/src-d/go-git.v4/plumbing/storer"
+)
+
+// NewFilterCommitIter returns a CommitIter that walks the commit history,
+// starting at the passed commit and visiting its parents in Breadth-first order.
+// The commits returned by the CommitIter will validate the passed CommitFilter.
+// The history won't be transversed beyond a commit if isLimit is true for it.
+// Each commit will be visited only once.
+// If the commit history can not be traversed, or the Close() method is called,
+// the CommitIter won't return more commits.
+// If no isValid is passed, all ancestors of from commit will be valid.
+// If no isLimit is limmit, all ancestors of all commits will be visited.
+func NewFilterCommitIter(
+	// REVIEWER: store argument wouldn't be needed if this were part of go-git/plumbing/object package
+	store storer.EncodedObjectStorer,
+	from *object.Commit,
+	isValid *CommitFilter,
+	isLimit *CommitFilter,
+) object.CommitIter {
+	var validFilter CommitFilter
+	if isValid == nil {
+		validFilter = func(_ *object.Commit) bool {
+			return true
+		}
+	} else {
+		validFilter = *isValid
+	}
+
+	var limitFilter CommitFilter
+	if isLimit == nil {
+		limitFilter = func(_ *object.Commit) bool {
+			return false
+		}
+	} else {
+		limitFilter = *isLimit
+	}
+
+	return &filterCommitIter{
+		// REVIEWER: store wouldn't be needed if this were part of go-git/plumbing/object package
+		store:   store,
+		isValid: validFilter,
+		isLimit: limitFilter,
+		visited: map[plumbing.Hash]bool{},
+		queue:   []*object.Commit{from},
+	}
+}
+
+// CommitFilter returns a boolean for the passed Commit
+type CommitFilter func(*object.Commit) bool
+
+// filterCommitIter implments object.CommitIter
+type filterCommitIter struct {
+	// REVIEWER: store wouldn't be needed if this were part of go-git/plumbing/object package
+	store   storer.EncodedObjectStorer
+	isValid CommitFilter
+	isLimit CommitFilter
+	visited map[plumbing.Hash]bool
+	queue   []*object.Commit
+	lastErr error
+}
+
+// Next returns the next commit of the CommitIter.
+// It will return io.EOF if there are no more commits to visit,
+// or an error if the history could not be traversed.
+func (w *filterCommitIter) Next() (*object.Commit, error) {
+	var commit *object.Commit
+	var err error
+	for {
+		commit, err = w.popNewFromQueue()
+		if err != nil {
+			return nil, w.close(err)
+		}
+
+		w.visited[commit.Hash] = true
+
+		if !w.isLimit(commit) {
+			// REVIEWER: first argument would be commit.s if this were part of object.Commit
+			err = w.addToQueue(w.store, commit.ParentHashes...)
+			if err != nil {
+				return nil, w.close(err)
+			}
+		}
+
+		if w.isValid(commit) {
+			return commit, nil
+		}
+	}
+}
+
+// ForEach runs the passed callback over each Commit returned by the CommitIter
+// until the callback returns an error or there is no more commits to traverse.
+func (w *filterCommitIter) ForEach(cb func(*object.Commit) error) error {
+	for {
+		commit, err := w.Next()
+		if err == io.EOF {
+			break
+		}
+
+		if err != nil {
+			return err
+		}
+
+		if err := cb(commit); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// Error returns the error that caused that the CommitIter is no longer returning commits
+func (w *filterCommitIter) Error() error {
+	return w.lastErr
+}
+
+// Close closes the CommitIter
+func (w *filterCommitIter) Close() {
+	w.visited = map[plumbing.Hash]bool{}
+	w.queue = []*object.Commit{}
+	w.isLimit = nil
+	w.isValid = nil
+}
+
+// close closes the CommitIter with an error
+func (w *filterCommitIter) close(err error) error {
+	w.Close()
+	w.lastErr = err
+	return err
+}
+
+// popNewFromQueue returns the first new commit from the internal fifo queue, or
+// an io.EOF error if the queue is empty
+func (w *filterCommitIter) popNewFromQueue() (*object.Commit, error) {
+	var first *object.Commit
+	for {
+		if len(w.queue) == 0 {
+			if w.lastErr != nil {
+				return nil, w.lastErr
+			}
+
+			return nil, io.EOF
+		}
+
+		first = w.queue[0]
+		w.queue = w.queue[1:]
+		if w.visited[first.Hash] {
+			continue
+		}
+
+		return first, nil
+	}
+}
+
+// addToQueue adds the passed commits to the internal fifo queue if they weren'r already seen
+// or returns an error if the passed hashes could not be used to get valid commits
+func (w *filterCommitIter) addToQueue(
+	store storer.EncodedObjectStorer,
+	hashes ...plumbing.Hash,
+) error {
+	for _, hash := range hashes {
+		if w.visited[hash] {
+			continue
+		}
+
+		commit, err := object.GetCommit(store, hash)
+		if err != nil {
+			return err
+		}
+
+		w.queue = append(w.queue, commit)
+	}
+
+	return nil
+}

--- a/_examples/merge_base/plumbing/object/commit_walker_bfs_filtered_test.go
+++ b/_examples/merge_base/plumbing/object/commit_walker_bfs_filtered_test.go
@@ -1,0 +1,166 @@
+package object
+
+import (
+	. "gopkg.in/check.v1"
+
+	"gopkg.in/src-d/go-git.v4/_examples/merge_base/testing"
+	"gopkg.in/src-d/go-git.v4/plumbing"
+	"gopkg.in/src-d/go-git.v4/plumbing/object"
+)
+
+/*
+// TestCase history
+
+* 6ecf0ef2c2dffb796033e5a02219af86ec6584e5 <- HEAD
+|
+| * e8d3ffab552895c19b9fcf7aa264d277cde33881
+|/
+* 918c48b83bd081e863dbe1b80f8998f058cd8294
+|
+* af2d6a6954d532f8ffb47615169c8fdf9d383a1a
+|
+* 1669dce138d9b841a518c64b10914d88f5e488ea
+|\
+| * a5b8b09e2f8fcb0bb99d3ccb0958157b40890d69	// isLimit
+| |\
+| | * b8e471f58bcbca63b07bda20e428190409c2db47  // ignored if isLimit is passed
+| |/
+* | 35e85108805c84807bc66a02d91535e1e24b38b9	// isValid; ignored if passed as !isValid
+|/
+* b029517f6300c2da0f4b651b8642506cd6aaf45d
+*/
+
+func validIfCommit(ignored plumbing.Hash) CommitFilter {
+	return func(c *object.Commit) bool {
+		if c.Hash == ignored {
+			return true
+		}
+
+		return false
+	}
+}
+
+func not(filter CommitFilter) CommitFilter {
+	return func(c *object.Commit) bool {
+		return !filter(c)
+	}
+}
+
+// TestFilterCommitIter asserts that FilterCommitIter returns all commits from
+// history, but e8d3ffab552895c19b9fcf7aa264d277cde33881, that is not reachable
+// from HEAD
+func (s *filterCommitIterSuite) TestFilterCommitIter(c *C) {
+	commit := s.commit(c, s.fixture.Head)
+
+	commits, err := commitsFromIter(NewFilterCommitIter(s.storer, commit, nil, nil))
+	c.Assert(err, IsNil)
+
+	expected := []string{
+		"6ecf0ef2c2dffb796033e5a02219af86ec6584e5",
+		"918c48b83bd081e863dbe1b80f8998f058cd8294",
+		"af2d6a6954d532f8ffb47615169c8fdf9d383a1a",
+		"1669dce138d9b841a518c64b10914d88f5e488ea",
+		"35e85108805c84807bc66a02d91535e1e24b38b9",
+		"a5b8b09e2f8fcb0bb99d3ccb0958157b40890d69",
+		"b029517f6300c2da0f4b651b8642506cd6aaf45d",
+		"b8e471f58bcbca63b07bda20e428190409c2db47",
+	}
+
+	testing.AssertCommits(c, commits, expected)
+}
+
+// TestFilterCommitIterWithValid asserts that FilterCommitIter returns only commits
+// that matches the passed isValid filter; in this testcase, it was filtered out
+// all commits but one from history
+func (s *filterCommitIterSuite) TestFilterCommitIterWithValid(c *C) {
+	commit := s.commit(c, s.fixture.Head)
+
+	validIf := validIfCommit(plumbing.NewHash("35e85108805c84807bc66a02d91535e1e24b38b9"))
+	commits, err := commitsFromIter(NewFilterCommitIter(s.storer, commit, &validIf, nil))
+	c.Assert(err, IsNil)
+
+	expected := []string{
+		"35e85108805c84807bc66a02d91535e1e24b38b9",
+	}
+
+	testing.AssertCommits(c, commits, expected)
+}
+
+// that matches the passed isValid filter; in this testcase, it was filtered out
+// only one commit from history
+func (s *filterCommitIterSuite) TestFilterCommitIterWithInvalid(c *C) {
+	commit := s.commit(c, s.fixture.Head)
+
+	validIf := validIfCommit(plumbing.NewHash("35e85108805c84807bc66a02d91535e1e24b38b9"))
+	validIfNot := not(validIf)
+	commits, err := commitsFromIter(NewFilterCommitIter(s.storer, commit, &validIfNot, nil))
+	c.Assert(err, IsNil)
+
+	expected := []string{
+		"6ecf0ef2c2dffb796033e5a02219af86ec6584e5",
+		"918c48b83bd081e863dbe1b80f8998f058cd8294",
+		"af2d6a6954d532f8ffb47615169c8fdf9d383a1a",
+		"1669dce138d9b841a518c64b10914d88f5e488ea",
+		"a5b8b09e2f8fcb0bb99d3ccb0958157b40890d69",
+		"b029517f6300c2da0f4b651b8642506cd6aaf45d",
+		"b8e471f58bcbca63b07bda20e428190409c2db47",
+	}
+
+	testing.AssertCommits(c, commits, expected)
+}
+
+// TestFilterCommitIterWithNoValidCommits asserts that FilterCommitIter returns
+// no commits if the passed isValid filter does not allow any commit
+func (s *filterCommitIterSuite) TestFilterCommitIterWithNoValidCommits(c *C) {
+	commit := s.commit(c, s.fixture.Head)
+
+	validIf := validIfCommit(plumbing.NewHash("THIS_COMMIT_DOES_NOT_EXIST"))
+	commits, err := commitsFromIter(NewFilterCommitIter(s.storer, commit, &validIf, nil))
+	c.Assert(err, IsNil)
+	c.Assert(commits, HasLen, 0)
+}
+
+// TestFilterCommitIterWithStopAt asserts that FilterCommitIter returns only commits
+// are not beyond a isLimit filter
+func (s *filterCommitIterSuite) TestFilterCommitIterWithStopAt(c *C) {
+	commit := s.commit(c, s.fixture.Head)
+
+	stopAtRule := validIfCommit(plumbing.NewHash("a5b8b09e2f8fcb0bb99d3ccb0958157b40890d69"))
+	commits, err := commitsFromIter(NewFilterCommitIter(s.storer, commit, nil, &stopAtRule))
+	c.Assert(err, IsNil)
+
+	expected := []string{
+		"6ecf0ef2c2dffb796033e5a02219af86ec6584e5",
+		"918c48b83bd081e863dbe1b80f8998f058cd8294",
+		"af2d6a6954d532f8ffb47615169c8fdf9d383a1a",
+		"1669dce138d9b841a518c64b10914d88f5e488ea",
+		"35e85108805c84807bc66a02d91535e1e24b38b9",
+		"a5b8b09e2f8fcb0bb99d3ccb0958157b40890d69",
+		"b029517f6300c2da0f4b651b8642506cd6aaf45d",
+	}
+
+	testing.AssertCommits(c, commits, expected)
+}
+
+// TestFilterCommitIterWithStopAt asserts that FilterCommitIter works properly
+// with isValid and isLimit filters
+func (s *filterCommitIterSuite) TestFilterCommitIterWithInvalidAndStopAt(c *C) {
+	commit := s.commit(c, s.fixture.Head)
+
+	stopAtRule := validIfCommit(plumbing.NewHash("a5b8b09e2f8fcb0bb99d3ccb0958157b40890d69"))
+	validIf := validIfCommit(plumbing.NewHash("35e85108805c84807bc66a02d91535e1e24b38b9"))
+	validIfNot := not(validIf)
+	commits, err := commitsFromIter(NewFilterCommitIter(s.storer, commit, &validIfNot, &stopAtRule))
+	c.Assert(err, IsNil)
+
+	expected := []string{
+		"6ecf0ef2c2dffb796033e5a02219af86ec6584e5",
+		"918c48b83bd081e863dbe1b80f8998f058cd8294",
+		"af2d6a6954d532f8ffb47615169c8fdf9d383a1a",
+		"1669dce138d9b841a518c64b10914d88f5e488ea",
+		"a5b8b09e2f8fcb0bb99d3ccb0958157b40890d69",
+		"b029517f6300c2da0f4b651b8642506cd6aaf45d",
+	}
+
+	testing.AssertCommits(c, commits, expected)
+}

--- a/_examples/merge_base/plumbing/object/common_test.go
+++ b/_examples/merge_base/plumbing/object/common_test.go
@@ -1,0 +1,58 @@
+package object
+
+import (
+	"testing"
+
+	. "gopkg.in/check.v1"
+	"gopkg.in/src-d/go-git-fixtures.v3"
+
+	"gopkg.in/src-d/go-git.v4/plumbing"
+	"gopkg.in/src-d/go-git.v4/plumbing/cache"
+	"gopkg.in/src-d/go-git.v4/plumbing/object"
+	"gopkg.in/src-d/go-git.v4/plumbing/storer"
+	"gopkg.in/src-d/go-git.v4/storage/filesystem"
+)
+
+/*
+REVIEWER: This file contains mostly a bunch of copy-paste from:
+ - plumbing/object/object_test.go
+ - plumbing/object/commit_walker_test.go
+If this package is moved into 'plumbing/object' package most of this could be deleted
+*/
+
+var _ = Suite(&filterCommitIterSuite{})
+
+func Test(t *testing.T) { TestingT(t) }
+
+type filterCommitIterSuite struct {
+	baseTestSuite
+}
+
+type baseTestSuite struct {
+	fixtures.Suite
+	storer  storer.EncodedObjectStorer
+	fixture *fixtures.Fixture
+}
+
+func (s *baseTestSuite) SetUpSuite(c *C) {
+	s.Suite.SetUpSuite(c)
+	s.fixture = fixtures.Basic().One()
+	storer := filesystem.NewStorage(s.fixture.DotGit(), cache.NewObjectLRUDefault())
+	s.storer = storer
+}
+
+func (s *baseTestSuite) commit(c *C, h plumbing.Hash) *object.Commit {
+	commit, err := object.GetCommit(s.storer, h)
+	c.Assert(err, IsNil)
+	return commit
+}
+
+func commitsFromIter(iter object.CommitIter) ([]*object.Commit, error) {
+	var commits []*object.Commit
+	err := iter.ForEach(func(c *object.Commit) error {
+		commits = append(commits, c)
+		return nil
+	})
+
+	return commits, err
+}

--- a/_examples/merge_base/repository/common_test.go
+++ b/_examples/merge_base/repository/common_test.go
@@ -1,0 +1,92 @@
+package repository
+
+import (
+	"testing"
+
+	. "gopkg.in/check.v1"
+	"gopkg.in/src-d/go-billy.v4"
+	"gopkg.in/src-d/go-billy.v4/memfs"
+	"gopkg.in/src-d/go-git-fixtures.v3"
+
+	"gopkg.in/src-d/go-git.v4"
+	"gopkg.in/src-d/go-git.v4/plumbing"
+	"gopkg.in/src-d/go-git.v4/plumbing/cache"
+	"gopkg.in/src-d/go-git.v4/plumbing/object"
+	"gopkg.in/src-d/go-git.v4/storage/filesystem"
+)
+
+/*
+REVIEWER: This file contains mostly a bunch of copy-paste from:
+ - common_test.go
+ - repository_test.go
+If this package is moved into 'git' package most of this could be deleted
+*/
+
+var _ = Suite(&repositorySuite{})
+
+func Test(t *testing.T) { TestingT(t) }
+
+type repositorySuite struct {
+	baseSuite
+}
+
+type baseSuite struct {
+	fixtures.Suite
+	repository *git.Repository
+}
+
+func (s *baseSuite) SetUpSuite(c *C) {
+	s.Suite.SetUpSuite(c)
+	s.buildBasicRepository(c)
+}
+
+func (s *baseSuite) TearDownSuite(c *C) {
+	s.Suite.TearDownSuite(c)
+}
+
+func (s *baseSuite) buildBasicRepository(c *C) {
+	f := fixtures.Basic().One()
+	s.repository = newRepository(f)
+}
+
+// NewRepository returns a new repository using the .git folder, if the fixture
+// is tagged as worktree the filesystem from fixture is used, otherwise a new
+// memfs filesystem is used as worktree.
+func newRepository(f *fixtures.Fixture) *git.Repository {
+	var worktree, dotgit billy.Filesystem
+	if f.Is("worktree") {
+		r, err := git.PlainOpen(f.Worktree().Root())
+		if err != nil {
+			panic(err)
+		}
+
+		return r
+	}
+
+	dotgit = f.DotGit()
+	worktree = memfs.New()
+
+	st := filesystem.NewStorage(dotgit, cache.NewObjectLRUDefault())
+
+	r, err := git.Open(st, worktree)
+
+	if err != nil {
+		panic(err)
+	}
+
+	return r
+}
+
+func commitsFromHashes(repo *git.Repository, hashes []string) ([]*object.Commit, error) {
+	var commits []*object.Commit
+	for _, hash := range hashes {
+		commit, err := repo.CommitObject(plumbing.NewHash(hash))
+		if err != nil {
+			return nil, err
+		}
+
+		commits = append(commits, commit)
+	}
+
+	return commits, nil
+}

--- a/_examples/merge_base/repository/merge_base.go
+++ b/_examples/merge_base/repository/merge_base.go
@@ -1,0 +1,150 @@
+package repository
+
+import (
+	"fmt"
+
+	obj "gopkg.in/src-d/go-git.v4/_examples/merge_base/plumbing/object"
+	"gopkg.in/src-d/go-git.v4/plumbing"
+	"gopkg.in/src-d/go-git.v4/plumbing/object"
+	"gopkg.in/src-d/go-git.v4/plumbing/storer"
+)
+
+// errIsReachable is thrown when first commit is an ancestor of the second
+var errIsReachable = fmt.Errorf("first is reachable from second")
+
+// MergeBase mimics the behavior of `git merge-base first second`, returning the
+// best common ancestor of the two passed commits
+// The best common ancestors can not be reached from other common ancestors
+func MergeBase(
+	// REVIEWER: store param wouldn't be needed if MergeBase were part of go-git/git.Repository
+	store storer.EncodedObjectStorer,
+	first *object.Commit,
+	second *object.Commit,
+) ([]*object.Commit, error) {
+
+	secondHistory, err := ancestorsIndex(first, second)
+	if err == errIsReachable {
+		return []*object.Commit{first}, nil
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	var res []*object.Commit
+	inSecondHistory := isInIndexCommitFilter(secondHistory)
+	// REVIEWER: store argument wouldn't be needed if this were part of go-git/plumbing/object package
+	resIter := obj.NewFilterCommitIter(store, first, &inSecondHistory, &inSecondHistory)
+	err = resIter.ForEach(func(commit *object.Commit) error {
+		res = append(res, commit)
+		return nil
+	})
+
+	return Independents(res)
+}
+
+// IsAncestor returns true if the first commit is ancestor of the second one
+// It returns an error if the history is not transversable
+// It mimics the behavior of `git merge --is-ancestor first second`
+func IsAncestor(
+	first *object.Commit,
+	second *object.Commit,
+) (bool, error) {
+	_, err := ancestorsIndex(first, second)
+	if err == errIsReachable {
+		return true, nil
+	}
+
+	return false, nil
+}
+
+// ancestorsIndex returns a map with the ancestors of the first commit if the
+// second one is not one of them. It returns errIsReachable if the second one is
+// ancestor, or another error if the history is not transversable
+func ancestorsIndex(first, second *object.Commit) (map[plumbing.Hash]bool, error) {
+	if first.Hash.String() == second.Hash.String() {
+		return nil, errIsReachable
+	}
+
+	secondHistory := map[plumbing.Hash]bool{}
+	secondIter := object.NewCommitIterBSF(second, nil, nil)
+	err := secondIter.ForEach(func(commit *object.Commit) error {
+		if commit.Hash == first.Hash {
+			return errIsReachable
+		}
+
+		secondHistory[commit.Hash] = true
+		return nil
+	})
+
+	if err == errIsReachable {
+		return nil, errIsReachable
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	return secondHistory, nil
+}
+
+// Independents returns a subset of the passed commits, that are not reachable from any other
+// It mimics the behavior of `git merge-base --independent commit...`
+func Independents(commits []*object.Commit) ([]*object.Commit, error) {
+	return independents(commits, 0)
+}
+
+func independents(commits []*object.Commit, start int) ([]*object.Commit, error) {
+	if len(commits) == 1 {
+		return commits, nil
+	}
+
+	res := commits
+	for i := start; i < len(commits); i++ {
+		from := commits[i]
+		fromHistoryIter := object.NewCommitIterBSF(from, nil, nil)
+		err := fromHistoryIter.ForEach(func(fromAncestor *object.Commit) error {
+			for _, other := range commits {
+				if from.Hash != other.Hash && fromAncestor.Hash == other.Hash {
+					res = remove(res, other)
+				}
+			}
+
+			if len(res) == 1 {
+				return storer.ErrStop
+			}
+
+			return nil
+		})
+
+		if err != nil {
+			return nil, err
+		}
+
+		if len(res) < len(commits) {
+			return independents(res, start)
+		}
+
+	}
+
+	return commits, nil
+}
+
+func remove(commits []*object.Commit, toDelete *object.Commit) []*object.Commit {
+	var res []*object.Commit
+	for _, commit := range commits {
+		if toDelete.Hash != commit.Hash {
+			res = append(res, commit)
+		}
+	}
+
+	return res
+}
+
+// isInIndexCommitFilter returns a commitFilter that returns true
+// if the commit is in the passed index.
+func isInIndexCommitFilter(index map[plumbing.Hash]bool) obj.CommitFilter {
+	return func(c *object.Commit) bool {
+		return index[c.Hash]
+	}
+}

--- a/_examples/merge_base/repository/merge_base_test.go
+++ b/_examples/merge_base/repository/merge_base_test.go
@@ -1,0 +1,104 @@
+package repository
+
+import (
+	. "gopkg.in/check.v1"
+	"gopkg.in/src-d/go-git.v4/_examples/merge_base/testing"
+)
+
+/*
+// TestCase history
+
+* 6ecf0ef2c2dffb796033e5a02219af86ec6584e5 		// first
+|
+| * e8d3ffab552895c19b9fcf7aa264d277cde33881	// second
+|/
+* 918c48b83bd081e863dbe1b80f8998f058cd8294		// merge-base first second
+|
+* af2d6a6954d532f8ffb47615169c8fdf9d383a1a		// firstAncestor -> merge-base first firstAncestor
+|
+* 1669dce138d9b841a518c64b10914d88f5e488ea
+|\
+| * a5b8b09e2f8fcb0bb99d3ccb0958157b40890d69
+| |\
+| | * b8e471f58bcbca63b07bda20e428190409c2db47	// beyondMerge -> merge-base first beyondMerge
+| |/
+* | 35e85108805c84807bc66a02d91535e1e24b38b9
+|/
+* b029517f6300c2da0f4b651b8642506cd6aaf45d
+*/
+
+// TestMergeBase validates a simple merge-base case: between first and second commits
+func (s *repositorySuite) TestMergeBase(c *C) {
+	hashes := []string{
+		"6ecf0ef2c2dffb796033e5a02219af86ec6584e5", // first
+		"e8d3ffab552895c19b9fcf7aa264d277cde33881", // second
+	}
+	commits, err := commitsFromHashes(s.repository, hashes)
+	c.Assert(err, IsNil)
+
+	commits, err = MergeBase(s.repository.Storer, commits[0], commits[1])
+	c.Assert(err, IsNil)
+
+	expected := []string{
+		"918c48b83bd081e863dbe1b80f8998f058cd8294", // merge-base first second
+	}
+
+	testing.AssertCommits(c, commits, expected)
+}
+
+// TestMergeBaseSelf asserts that merge-base between a commit and self, is the same commit
+func (s *repositorySuite) TestMergeBaseSelf(c *C) {
+	hashes := []string{
+		"6ecf0ef2c2dffb796033e5a02219af86ec6584e5", // first
+		"6ecf0ef2c2dffb796033e5a02219af86ec6584e5", // first
+	}
+	commits, err := commitsFromHashes(s.repository, hashes)
+	c.Assert(err, IsNil)
+
+	commits, err = MergeBase(s.repository.Storer, commits[0], commits[1])
+	c.Assert(err, IsNil)
+
+	expected := []string{
+		"6ecf0ef2c2dffb796033e5a02219af86ec6584e5", // first
+	}
+
+	testing.AssertCommits(c, commits, expected)
+}
+
+// TestMergeBaseAncestor asserts that merge-base between a commit and one ancestor, is the ancestor
+func (s *repositorySuite) TestMergeBaseAncestor(c *C) {
+	hashes := []string{
+		"6ecf0ef2c2dffb796033e5a02219af86ec6584e5", // first
+		"af2d6a6954d532f8ffb47615169c8fdf9d383a1a", // firstAncestor
+	}
+	commits, err := commitsFromHashes(s.repository, hashes)
+	c.Assert(err, IsNil)
+
+	commits, err = MergeBase(s.repository.Storer, commits[0], commits[1])
+	c.Assert(err, IsNil)
+
+	expected := []string{
+		"af2d6a6954d532f8ffb47615169c8fdf9d383a1a", // firstAncestor
+	}
+
+	testing.AssertCommits(c, commits, expected)
+}
+
+// TestMergeBaseWithMerges validates a merge-base between first and an ancestor of first that is beyond a merge
+func (s *repositorySuite) TestMergeBaseWithMerges(c *C) {
+	hashes := []string{
+		"6ecf0ef2c2dffb796033e5a02219af86ec6584e5", // first
+		"b8e471f58bcbca63b07bda20e428190409c2db47", // beyondMerge
+	}
+	commits, err := commitsFromHashes(s.repository, hashes)
+	c.Assert(err, IsNil)
+
+	commits, err = MergeBase(s.repository.Storer, commits[0], commits[1])
+	c.Assert(err, IsNil)
+
+	expected := []string{
+		"b8e471f58bcbca63b07bda20e428190409c2db47", // beyondMerge
+	}
+
+	testing.AssertCommits(c, commits, expected)
+}

--- a/_examples/merge_base/testing/common.go
+++ b/_examples/merge_base/testing/common.go
@@ -1,0 +1,14 @@
+package testing
+
+import (
+	"gopkg.in/check.v1"
+	"gopkg.in/src-d/go-git.v4/plumbing/object"
+)
+
+func AssertCommits(c *check.C, commits []*object.Commit, hashes []string) {
+	c.Assert(commits, check.HasLen, len(hashes))
+	for i, commit := range commits {
+		c.Assert(hashes[i], check.Equals, commit.Hash.String())
+	}
+}
+


### PR DESCRIPTION
Command example implementing `git merge-base` behavior, with `--is-ancestor` and `--independent` modifiers.

usage: 
```shell
$ ./merge_base --help

./merge_base --helpReturns the merge-base between two commits:
./merge_base <path> <baseRev> <headRev>
./merge_base <path> --is-ancestor <baseRev> <headRev>
./merge_base <path> --independent <commitRev>...
```

To offer those features, it was implemented a new walker `filterCommitIter` (like `bfsCommitIterator` one), and three functions `MergeBase`, `IsAncestor` and `Independents`.
- `filterCommitIter` 
  > _it's a `CommitIter` that walks the commit history (in Breadth-first order) of the passed commit. It only returns the commits that validate the passed `isValid CommitFilter`, and only traverse the commits that do not validate `isLimit CommitFilter`._
- `MergeBase(first, second *object.Commit) ([]*object.Commit, error)`
  > _it mimics the behavior of `git merge-base a b`, returning the best common ancestor of the two passed commits; the best common ancestor cannot be reached from other common ancestors._
- `IsAncestor(first, second *object.Commit) (bool, error)` 
  > _it returns `true` if the first commit is an ancestor of the second one, like `git merge --is-ancestor` does_
- `Independents(commits []*object.Commit) ([]*object.Commit, error)` 
  > _it returns a subset of the passed commits, that are not reachable from any other, as `git merge-base --independent commit...` does_



## alternative:

imo the new feature could be part of `go-git` itself, instead of being an `_example`; to do so, I think that `filterCommitIter` could replace `bfsCommitIterator` or be moved into `go-git/plumbing/object` package, and `MergeBase`, `IsAncestor` and `Independents` could be moved into `git.Repository` struct.

If you think it could be feasible as proposed, or with any change, let me know and will work over it during the next OSD :tada:
