### PR TITLE
git: fix goroutine block while pushing a remote

### DIFF
--- a/remote.go
+++ b/remote.go
@@ -1020,7 +1020,12 @@ func pushHashes(
 	if err != nil {
 		return nil, err
 	}
-	done := make(chan error)
+
+	// Set buffer size to 1 so the error message can be written when
+	// ReceivePack fails. Otherwise the goroutine will be blocked writing
+	// to the channel.
+	done := make(chan error, 1)
+
 	go func() {
 		e := packfile.NewEncoder(wr, s, useRefDeltas)
 		if _, err := e.Encode(hs, config.Pack.Window); err != nil {
@@ -1033,6 +1038,8 @@ func pushHashes(
 
 	rs, err := sess.ReceivePack(ctx, req)
 	if err != nil {
+		// close the pipe to unlock encode write
+		_ = rd.Close()
 		return nil, err
 	}
 


### PR DESCRIPTION
On session.ReceivePack error the gororutine doing the encoding got blocked either writing objects to the pipe or sending error to the done channel. The problem did not cause a perceived problem but left blocked goroutines.