### PR TITLE
git: remove potentially duplicate check for unstaged files

### DIFF
--- a/worktree.go
+++ b/worktree.go
@@ -152,17 +152,6 @@ func (w *Worktree) Checkout(opts *CheckoutOptions) error {
 		}
 	}
 
-	if !opts.Force {
-		unstaged, err := w.containsUnstagedChanges()
-		if err != nil {
-			return err
-		}
-
-		if unstaged {
-			return ErrUnstagedChanges
-		}
-	}
-
 	c, err := w.getCommitFromCheckoutOptions(opts)
 	if err != nil {
 		return err


### PR DESCRIPTION
When you checkout a branch, you already look in the `Reset` method for unstaged files
(https://github.com/meinto/go-git/blob/master/worktree.go#L272-L281).

```go
if opts.Mode == MergeReset {
	unstaged, err := w.containsUnstagedChanges()
	if err != nil {
		return err
	}

	if unstaged {
		return ErrUnstagedChanges
	}
}
```

That's why I think the check in the `Checkout` method is not necessary. 

This would also increase the performance of the `Checkout` method, because `containsUnstagedChanges` contains a method call of `merkletrie.DiffTree` which takes very long on large projects:
https://github.com/src-d/go-git/issues/758#issuecomment-469867095