### PR TITLE
Increase diffmatchcpatch timeout

### DIFF
--- a/utils/diff/diff.go
+++ b/utils/diff/diff.go
@@ -14,10 +14,24 @@ import (
 )
 
 // Do computes the (line oriented) modifications needed to turn the src
-// string into the dst string.
+// string into the dst string. The underlying algorithm is Meyers,
+// its complexity is O(N*d) where N is min(lines(src), lines(dst)) and d
+// is the size of the diff.
 func Do(src, dst string) (diffs []diffmatchpatch.Diff) {
+	// the default timeout is time.Second which may be too small under heavy load
+	return DoWithTimeout(src, dst, time.Hour)
+}
+
+// DoWithTimeout computes the (line oriented) modifications needed to turn the src
+// string into the dst string. The `timeout` argument specifies the maximum
+// amount of time it is allowed to spend in this function. If the timeout
+// is exceeded, the parts of the strings which were not considered are turned into
+// a bulk delete+insert and the half-baked suboptimal result is returned at once.
+// The underlying algorithm is Meyers, its complexity is O(N*d) where N is
+// min(lines(src), lines(dst)) and d is the size of the diff.
+func DoWithTimeout (src, dst string, timeout time.Duration) (diffs []diffmatchpatch.Diff) {
 	dmp := diffmatchpatch.New()
-	dmp.DiffTimeout = time.Hour  // the default is time.Second which may be too little under heavy load
+	dmp.DiffTimeout = timeout
 	wSrc, wDst, warray := dmp.DiffLinesToRunes(src, dst)
 	diffs = dmp.DiffMainRunes(wSrc, wDst, false)
 	diffs = dmp.DiffCharsToLines(diffs, warray)

--- a/utils/diff/diff.go
+++ b/utils/diff/diff.go
@@ -8,6 +8,7 @@ package diff
 
 import (
 	"bytes"
+	"time"
 
 	"github.com/sergi/go-diff/diffmatchpatch"
 )
@@ -16,6 +17,7 @@ import (
 // string into the dst string.
 func Do(src, dst string) (diffs []diffmatchpatch.Diff) {
 	dmp := diffmatchpatch.New()
+	dmp.DiffTimeout = time.Hour  // the default is time.Second which may be too little under heavy load
 	wSrc, wDst, warray := dmp.DiffLinesToRunes(src, dst)
 	diffs = dmp.DiffMainRunes(wSrc, wDst, false)
 	diffs = dmp.DiffCharsToLines(diffs, warray)


### PR DESCRIPTION
Fixes https://github.com/src-d/go-git/issues/1083

Signed-off-by: Vadim Markovtsev <vadim@sourced.tech>

I can add a test, but it requires running 100 goroutines under `-race` and increases Travis run time by 10 minutes.