### PR TITLE
fix "reference delta not found" when cloning from aws codecommit

### DIFF
--- a/plumbing/format/packfile/parser.go
+++ b/plumbing/format/packfile/parser.go
@@ -286,6 +286,18 @@ func (p *Parser) resolveDeltas() error {
 				if err := p.resolveObject(ioutil.Discard, child, content); err != nil {
 					return err
 				}
+
+				extRef, ok := p.oiByHash[child.SHA1]
+				if ok && extRef.ExternalRef {
+					// replace parent placeholder
+					p.oiByHash[child.SHA1] = child
+
+					// adopt children
+					child.Children = extRef.Children
+					for _, c := range child.Children {
+						c.Parent = child
+					}
+				}
 			}
 
 			// Remove the delta from the cache.


### PR DESCRIPTION
The existing code does not handle the case where a ref delta refers to another
deltified object.  Once the "parent" was undeltified, not attempt was made to
resolve references to that object's SHA1.

This change simply checks to see if there is an ExternalRef to the object just
resolved, and if so, replaces it and adopts its children.

I'm not an expert in the bowels of git, but this fixed my inability to clone
from codecommit.