### PR TITLE
ssh: leverage proxy from environment

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module gopkg.in/src-d/go-git.v4
 require (
 	github.com/alcortesm/tgz v0.0.0-20161220082320-9c5fe88206d7 // indirect
 	github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239 // indirect
+	github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/emirpasic/gods v1.12.0
 	github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568 // indirect
@@ -19,7 +20,7 @@ require (
 	github.com/stretchr/testify v1.3.0 // indirect
 	github.com/xanzy/ssh-agent v0.2.1
 	golang.org/x/crypto v0.0.0-20190422183909-d864b10871cd
-	golang.org/x/net v0.0.0-20190420063019-afa5a82059c6 // indirect
+	golang.org/x/net v0.0.0-20190502183928-7f726cade0ab
 	golang.org/x/sys v0.0.0-20190422165155-953cdadca894 // indirect
 	golang.org/x/text v0.3.0
 	gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ github.com/alcortesm/tgz v0.0.0-20161220082320-9c5fe88206d7 h1:uSoVVbwJiQipAclBb
 github.com/alcortesm/tgz v0.0.0-20161220082320-9c5fe88206d7/go.mod h1:6zEj6s6u/ghQa61ZWa/C2Aw3RkjiTBOix7dkqa1VLIs=
 github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239 h1:kFOfPq6dUM1hTo4JG6LR5AXSUEsOjtdm0kw0FtQtMJA=
 github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239/go.mod h1:2FmKhYUyUczH0OGQWaF5ceTx0UBShxjsH6f8oGKYe2c=
+github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
+github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -48,6 +50,8 @@ golang.org/x/crypto v0.0.0-20190422183909-d864b10871cd/go.mod h1:yigFU9vqHzYiE8U
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190420063019-afa5a82059c6 h1:HdqqaWmYAUI7/dmByKKEw+yxDksGSo+9GjkUc9Zp34E=
 golang.org/x/net v0.0.0-20190420063019-afa5a82059c6/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
+golang.org/x/net v0.0.0-20190502183928-7f726cade0ab h1:9RfW3ktsOZxgo9YNbBAjq1FWzc/igwEcUzZz8IXgSbk=
+golang.org/x/net v0.0.0-20190502183928-7f726cade0ab/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/sys v0.0.0-20180903190138-2b024373dcd9 h1:lkiLiLBHGoH3XnqSLUIaBsilGMUjI+Uy2Xu2JLUtTas=
 golang.org/x/sys v0.0.0-20180903190138-2b024373dcd9/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=

--- a/plumbing/transport/ssh/common.go
+++ b/plumbing/transport/ssh/common.go
@@ -2,6 +2,7 @@
 package ssh
 
 import (
+	"context"
 	"fmt"
 	"reflect"
 	"strconv"
@@ -11,6 +12,7 @@ import (
 
 	"github.com/kevinburke/ssh_config"
 	"golang.org/x/crypto/ssh"
+	"golang.org/x/net/proxy"
 )
 
 // DefaultClient is the default SSH client.
@@ -115,7 +117,7 @@ func (c *command) connect() error {
 
 	overrideConfig(c.config, config)
 
-	c.client, err = ssh.Dial("tcp", c.getHostWithPort(), config)
+	c.client, err = dial("tcp", c.getHostWithPort(), config)
 	if err != nil {
 		return err
 	}
@@ -128,6 +130,29 @@ func (c *command) connect() error {
 
 	c.connected = true
 	return nil
+}
+
+func dial(network, addr string, config *ssh.ClientConfig) (*ssh.Client, error) {
+	var (
+		ctx    = context.Background()
+		cancel context.CancelFunc
+	)
+	if config.Timeout > 0 {
+		ctx, cancel = context.WithTimeout(ctx, config.Timeout)
+	} else {
+		ctx, cancel = context.WithCancel(ctx)
+	}
+	defer cancel()
+
+	conn, err := proxy.Dial(ctx, network, addr)
+	if err != nil {
+		return nil, err
+	}
+	c, chans, reqs, err := ssh.NewClientConn(conn, addr, config)
+	if err != nil {
+		return nil, err
+	}
+	return ssh.NewClient(c, chans, reqs), nil
 }
 
 func (c *command) getHostWithPort() string {

--- a/plumbing/transport/ssh/proxy_test.go
+++ b/plumbing/transport/ssh/proxy_test.go
@@ -1,0 +1,36 @@
+package ssh
+
+import (
+	"fmt"
+	"log"
+	"net"
+	"os"
+
+	"github.com/armon/go-socks5"
+	. "gopkg.in/check.v1"
+)
+
+type ProxySuite struct {
+	UploadPackSuite
+}
+
+var _ = Suite(&ProxySuite{})
+
+func (s *ProxySuite) SetUpSuite(c *C) {
+	s.UploadPackSuite.SetUpSuite(c)
+
+	l, err := net.Listen("tcp", "localhost:0")
+	c.Assert(err, IsNil)
+
+	server, err := socks5.New(&socks5.Config{})
+	c.Assert(err, IsNil)
+
+	port := l.Addr().(*net.TCPAddr).Port
+
+	err = os.Setenv("ALL_PROXY", fmt.Sprintf("socks5://localhost:%d", port))
+	c.Assert(err, IsNil)
+
+	go func() {
+		log.Fatal(server.Serve(l))
+	}()
+}


### PR DESCRIPTION
I was working on [a little git-cli drop-in](/dweomer/git-semver) that creates an orphan branch for tracking (per-branch) versioning information when I realized that it did not work for clone/pull/push with SSH URLs in a proxied environment (good ole SOCKS5). I made a small change in `ssh.command#connect()` to replace the invocation of `ssh.Dial()` to a copy of that function that uses `golang.org/x/net/proxy.FromEnvironment()` to get a dialer and then hands off the dialed connection to `ssh.NewClientConn`. This breaks the connection timeout facility because `proxy.FromEnvironment()` returns a `proxy.Dialer` which is a single-method interface type (that doesn't support a timeout or context arg).

The cool thing about `proxy.FromEnvironment()` is that it returns a working `Dialer` (i.e. directly connecting) if no proxy details are found or the setup for recognized proxy details fails for any reason.

There are some existing issues tracking some sort of `proxy.DialContext` implementation:

* golang/go#17759
* golang/go#19688

I am not confident that the Go folks will be tackling this lack of a timeout-capable dialer in `x/net/proxy` anytime soon so I understand if the behavioral breakage in this proposed change is not acceptable.

Signed-off-by: Jacob Blain Christen <dweomer5@gmail.com>