### PR TITLE
travis: drop go1.10 add go1.12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: go
 
 go:
-  - "1.10"
   - "1.11"
+  - "1.12"
 
 go_import_path: gopkg.in/src-d/go-git.v4
 


### PR DESCRIPTION
Since go 1.12 is already there, it may worth to bump the supported version here