### PR TITLE
plumbing: object, Fix tag message decoding

### DIFF
--- a/plumbing/object/tag.go
+++ b/plumbing/object/tag.go
@@ -141,7 +141,7 @@ func (t *Tag) Decode(o plumbing.EncodedObject) (err error) {
 			if pgpsig {
 				if bytes.Contains(l, []byte(endpgp)) {
 					t.PGPSignature += endpgp + "\n"
-					pgpsig = false
+					break
 				} else {
 					t.PGPSignature += string(l) + "\n"
 				}


### PR DESCRIPTION
The `Decode` method was adding one too many newlines to the tag message, causing signature verification to fail. This is because in signed tags produced by `git`, there is a newline after the PGP signature block, resulting in `messageAndSig` having one extra (empty) `[]byte` element. This caused `t.Message` to receive one extra newline.