### PR TITLE
storage: keep a certain amount of pack files open by default

### DIFF
--- a/repository.go
+++ b/repository.go
@@ -224,7 +224,9 @@ func PlainInit(path string, isBare bool) (*Repository, error) {
 		dot, _ = wt.Chroot(GitDirName)
 	}
 
-	s := filesystem.NewStorage(dot, cache.NewObjectLRUDefault())
+	s := filesystem.NewStorageWithOptions(dot, cache.NewObjectLRUDefault(), filesystem.Options{
+		MaxOpenDescriptors: 100,
+	})
 
 	return Init(s, wt)
 }
@@ -252,7 +254,9 @@ func PlainOpenWithOptions(path string, o *PlainOpenOptions) (*Repository, error)
 		return nil, err
 	}
 
-	s := filesystem.NewStorage(dot, cache.NewObjectLRUDefault())
+	s := filesystem.NewStorageWithOptions(dot, cache.NewObjectLRUDefault(), filesystem.Options{
+		MaxOpenDescriptors: 100,
+	})
 
 	return Open(s, wt)
 }

--- a/storage/filesystem/object.go
+++ b/storage/filesystem/object.go
@@ -366,7 +366,7 @@ func (s *ObjectStorage) getFromPackfile(h plumbing.Hash, canBeDelta bool) (
 		return nil, err
 	}
 
-	if !s.options.KeepDescriptors {
+	if !s.options.KeepDescriptors && s.options.MaxOpenDescriptors == 0 {
 		defer ioutil.CheckClose(f, &err)
 	}
 

--- a/storage/filesystem/storage.go
+++ b/storage/filesystem/storage.go
@@ -31,6 +31,9 @@ type Options struct {
 	// KeepDescriptors makes the file descriptors to be reused but they will
 	// need to be manually closed calling Close().
 	KeepDescriptors bool
+	// MaxOpenDescriptors is the max number of file descriptors to keep
+	// open. If KeepDescriptors is true, all file descriptors will remain open.
+	MaxOpenDescriptors int
 }
 
 // NewStorage returns a new Storage backed by a given `fs.Filesystem` and cache.
@@ -42,8 +45,9 @@ func NewStorage(fs billy.Filesystem, cache cache.Object) *Storage {
 // backed by a given `fs.Filesystem` and cache.
 func NewStorageWithOptions(fs billy.Filesystem, cache cache.Object, ops Options) *Storage {
 	dirOps := dotgit.Options{
-		ExclusiveAccess: ops.ExclusiveAccess,
-		KeepDescriptors: ops.KeepDescriptors,
+		ExclusiveAccess:    ops.ExclusiveAccess,
+		KeepDescriptors:    ops.KeepDescriptors,
+		MaxOpenDescriptors: ops.MaxOpenDescriptors,
 	}
 	dir := dotgit.NewWithOptions(fs, dirOps)
 


### PR DESCRIPTION
The `MaxOpenDescriptors` option provides a middle ground solution between keeping all pack files open (as offered by the `KeepDescriptors` option) and keeping none open.

By default, 100 pack files can be kept open. Files are closed in a FIFO fashion, so the oldest files opened are the first closed. 

In addition to this, this change uses the packfile's hash as the map key, instead of the path name. This results in a nice performance boost when iterating over many files, as `objectPackPath` (using path.Join) isn't as fast as you'd imagine. If this PR isn't accepted, that modification will probably still be worth doing.

The `MaxOpenDescriptors` being set to 100 is pretty arbitrary, but it feels like lots of people get a large performance penalty when they don't enable `KeepDescriptors`, and I guess enabling that by default is going to lead to max file open errors.


