### PR TITLE
plumbing: commit.StatsContext and fix for orphan commit

### DIFF
--- a/plumbing/object/commit.go
+++ b/plumbing/object/commit.go
@@ -297,7 +297,7 @@ func (c *Commit) Stats() (FileStats, error) {
 }
 
 // StatsContext returns the stats of a commit. Error will be return if context
-// expires. Provided context must be non-nil
+// expires. Provided context must be non-nil.
 func (c *Commit) StatsContext(ctx context.Context) (FileStats, error) {
 	fromTree, err := c.Tree()
 	if err != nil {

--- a/plumbing/object/commit.go
+++ b/plumbing/object/commit.go
@@ -76,7 +76,7 @@ func (c *Commit) Tree() (*Tree, error) {
 	return GetTree(c.s, c.TreeHash)
 }
 
-// Patch returns the Patch between the actual commit and the provided one.
+// PatchContext returns the Patch between the actual commit and the provided one.
 // Error will be return if context expires. Provided context must be non-nil
 func (c *Commit) PatchContext(ctx context.Context, to *Commit) (*Patch, error) {
 	fromTree, err := c.Tree()
@@ -291,25 +291,33 @@ func (b *Commit) encode(o plumbing.EncodedObject, includeSig bool) (err error) {
 	return err
 }
 
-// Stats shows the status of commit.
+// Stats returns the stats of a commit.
 func (c *Commit) Stats() (FileStats, error) {
-	// Get the previous commit.
-	ci := c.Parents()
-	parentCommit, err := ci.Next()
+	return c.StatsContext(context.Background())
+}
+
+// StatsContext returns the stats of a commit. Error will be return if context
+// expires. Provided context must be non-nil
+func (c *Commit) StatsContext(ctx context.Context) (FileStats, error) {
+	fromTree, err := c.Tree()
 	if err != nil {
-		if err == io.EOF {
-			emptyNoder := treeNoder{}
-			parentCommit = &Commit{
-				Hash: emptyNoder.hash,
-				// TreeHash: emptyNoder.parent.Hash,
-				s: c.s,
-			}
-		} else {
+		return nil, err
+	}
+
+	toTree := &Tree{}
+	if c.NumParents() != 0 {
+		firstParent, err := c.Parents().Next()
+		if err != nil {
+			return nil, err
+		}
+
+		toTree, err = firstParent.Tree()
+		if err != nil {
 			return nil, err
 		}
 	}
 
-	patch, err := parentCommit.Patch(c)
+	patch, err := toTree.PatchContext(ctx, fromTree)
 	if err != nil {
 		return nil, err
 	}

--- a/plumbing/object/commit.go
+++ b/plumbing/object/commit.go
@@ -77,7 +77,7 @@ func (c *Commit) Tree() (*Tree, error) {
 }
 
 // PatchContext returns the Patch between the actual commit and the provided one.
-// Error will be return if context expires. Provided context must be non-nil
+// Error will be return if context expires. Provided context must be non-nil.
 func (c *Commit) PatchContext(ctx context.Context, to *Commit) (*Patch, error) {
 	fromTree, err := c.Tree()
 	if err != nil {

--- a/plumbing/object/commit_stats_test.go
+++ b/plumbing/object/commit_stats_test.go
@@ -1,6 +1,7 @@
 package object_test
 
 import (
+	"context"
 	"time"
 
 	"gopkg.in/src-d/go-git.v4"
@@ -26,9 +27,25 @@ func (s *CommitStatsSuite) TestStats(c *C) {
 	aCommit, err := r.CommitObject(hash)
 	c.Assert(err, IsNil)
 
+	fileStats, err := aCommit.StatsContext(context.Background())
+	c.Assert(err, IsNil)
+
+	c.Assert(fileStats[0].Name, Equals, "foo")
+	c.Assert(fileStats[0].Addition, Equals, 1)
+	c.Assert(fileStats[0].Deletion, Equals, 0)
+	c.Assert(fileStats[0].String(), Equals, " foo | 1 +\n")
+}
+
+func (s *CommitStatsSuite) TestStats_RootCommit(c *C) {
+	r, hash := s.writeHisotry(c, []byte("foo\n"))
+
+	aCommit, err := r.CommitObject(hash)
+	c.Assert(err, IsNil)
+
 	fileStats, err := aCommit.Stats()
 	c.Assert(err, IsNil)
 
+	c.Assert(fileStats, HasLen, 1)
 	c.Assert(fileStats[0].Name, Equals, "foo")
 	c.Assert(fileStats[0].Addition, Equals, 1)
 	c.Assert(fileStats[0].Deletion, Equals, 0)


### PR DESCRIPTION
This introduce the missing `commit.StatsContext` and also fix a bug when `commit.Stats` its executed over a orphan commit.