### PR TITLE
plumbing: packfile, apply small object reading optimization also for delta objects

### DIFF
--- a/plumbing/format/packfile/packfile.go
+++ b/plumbing/format/packfile/packfile.go
@@ -478,6 +478,7 @@ func (i *objectIter) Next() (plumbing.EncodedObject, error) {
 				}
 			} else if obj, ok := i.p.cacheGet(e.Hash); ok {
 				if obj.Type() != i.typ {
+					i.p.offsetToType[int64(e.Offset)] = obj.Type()
 					continue
 				}
 				return obj, nil
@@ -493,12 +494,14 @@ func (i *objectIter) Next() (plumbing.EncodedObject, error) {
 						return nil, err
 					}
 					if typ != i.typ {
+						i.p.offsetToType[int64(e.Offset)] = typ
 						continue
 					}
 					// getObjectType will seek in the file so we cannot use getNextObject safely
 					return i.p.objectAtOffset(int64(e.Offset), e.Hash)
 				} else {
 					if h.Type != i.typ {
+						i.p.offsetToType[int64(e.Offset)] = h.Type
 						continue
 					}
 					return i.p.getNextObject(h, e.Hash)

--- a/plumbing/format/packfile/packfile.go
+++ b/plumbing/format/packfile/packfile.go
@@ -266,19 +266,6 @@ func (p *Packfile) getNextObject(h *ObjectHeader, hash plumbing.Hash) (plumbing.
 }
 
 func (p *Packfile) getObjectContent(offset int64) (io.ReadCloser, error) {
-	ref, err := p.FindHash(offset)
-	if err == nil {
-		obj, ok := p.cacheGet(ref)
-		if ok {
-			reader, err := obj.Reader()
-			if err != nil {
-				return nil, err
-			}
-
-			return reader, nil
-		}
-	}
-
 	h, err := p.objectHeaderAtOffset(offset)
 	if err != nil {
 		return nil, err

--- a/plumbing/format/packfile/packfile.go
+++ b/plumbing/format/packfile/packfile.go
@@ -490,13 +490,23 @@ func (i *objectIter) Next() (plumbing.EncodedObject, error) {
 					continue
 				}
 			} else {
+				if obj, ok := i.p.cacheGet(e.Hash); ok {
+					if obj.Type() != i.typ {
+						continue
+					}
+					return obj, nil
+				}
+
 				h, err := i.p.objectHeaderAtOffset(int64(e.Offset))
 				if err != nil {
 					return nil, err
 				}
 
 				typ, err := i.p.getObjectType(h)
-				if err == nil && typ != i.typ {
+				if err != nil {
+					return nil, err
+				}
+				if typ != i.typ {
 					continue
 				}
 
@@ -504,7 +514,7 @@ func (i *objectIter) Next() (plumbing.EncodedObject, error) {
 			}
 		}
 
-		obj, err := i.p.GetByOffset(int64(e.Offset))
+		obj, err := i.p.objectAtOffset(int64(e.Offset), e.Hash)
 		if err != nil {
 			return nil, err
 		}

--- a/plumbing/format/packfile/packfile.go
+++ b/plumbing/format/packfile/packfile.go
@@ -184,7 +184,7 @@ func (p *Packfile) getObjectType(h *ObjectHeader) (typ plumbing.ObjectType, err 
 }
 
 func (p *Packfile) objectAtOffset(offset int64, hash plumbing.Hash) (plumbing.EncodedObject, error) {
-	if obj, ok := p.deltaBaseCache.Get(hash); ok {
+	if obj, ok := p.cacheGet(hash); ok {
 		return obj, nil
 	}
 
@@ -237,7 +237,7 @@ func (p *Packfile) getNextObject(h *ObjectHeader, hash plumbing.Hash) (plumbing.
 			} else {
 				err = p.fillOFSDeltaObjectContentWithBuffer(obj, h.OffsetReference, buf)
 			}
-			return obj, nil
+			return obj, err
 		}
 	} else {
 		size, err = p.getObjectSize(h)

--- a/plumbing/format/packfile/packfile.go
+++ b/plumbing/format/packfile/packfile.go
@@ -489,14 +489,12 @@ func (i *objectIter) Next() (plumbing.EncodedObject, error) {
 				if typ != i.typ {
 					continue
 				}
-			} else {
-				if obj, ok := i.p.cacheGet(e.Hash); ok {
-					if obj.Type() != i.typ {
-						continue
-					}
-					return obj, nil
+			} else if obj, ok := i.p.cacheGet(e.Hash); ok {
+				if obj.Type() != i.typ {
+					continue
 				}
-
+				return obj, nil
+			} else {
 				h, err := i.p.objectHeaderAtOffset(int64(e.Offset))
 				if err != nil {
 					return nil, err

--- a/plumbing/format/packfile/packfile.go
+++ b/plumbing/format/packfile/packfile.go
@@ -500,15 +500,19 @@ func (i *objectIter) Next() (plumbing.EncodedObject, error) {
 					return nil, err
 				}
 
-				typ, err := i.p.getObjectType(h)
-				if err != nil {
-					return nil, err
-				}
-				if typ != i.typ {
-					continue
+				if h.Type == plumbing.REFDeltaObject || h.Type == plumbing.OFSDeltaObject {
+					obj, err := i.p.getNextObject(h, e.Hash)
+					if err != nil {
+						return nil, err
+					}
+					if obj.Type() == i.typ {
+						return obj, nil
+					}
+				} else if h.Type == i.typ {
+					return i.p.getNextObject(h, e.Hash)
 				}
 
-				return i.p.getNextObject(h, e.Hash)
+				continue
 			}
 		}
 

--- a/plumbing/format/packfile/packfile.go
+++ b/plumbing/format/packfile/packfile.go
@@ -208,9 +208,9 @@ func (p *Packfile) objectAtOffset(offset int64, hash plumbing.Hash) (plumbing.En
 			return p.getNextObject(h)
 		}
 
-		// For delta objects we read the delta data and create a special object
-		// that will hold them in memory and resolve them lazily to the referenced
-		// object.
+		// For delta objects we read the delta data and apply the small object
+		// optimization only if the expanded version of the object still meets
+		// the small object threshold condition.
 		buf := bufPool.Get().(*bytes.Buffer)
 		buf.Reset()
 		if _, _, err := p.s.NextObject(buf); err != nil {

--- a/plumbing/format/packfile/packfile.go
+++ b/plumbing/format/packfile/packfile.go
@@ -349,7 +349,7 @@ func (p *Packfile) fillREFDeltaObjectContentWithBuffer(obj plumbing.EncodedObjec
 }
 
 func (p *Packfile) fillOFSDeltaObjectContent(obj plumbing.EncodedObject, offset int64) error {
-	buf := bytes.NewBuffer(nil)
+	buf := bufPool.Get().(*bytes.Buffer)
 	buf.Reset()
 	_, _, err := p.s.NextObject(buf)
 	if err != nil {

--- a/plumbing/format/packfile/packfile.go
+++ b/plumbing/format/packfile/packfile.go
@@ -488,18 +488,21 @@ func (i *objectIter) Next() (plumbing.EncodedObject, error) {
 				}
 
 				if h.Type == plumbing.REFDeltaObject || h.Type == plumbing.OFSDeltaObject {
-					obj, err := i.p.getNextObject(h, e.Hash)
+					typ, err := i.p.getObjectType(h)
 					if err != nil {
 						return nil, err
 					}
-					if obj.Type() == i.typ {
-						return obj, nil
+					if typ != i.typ {
+						continue
 					}
-				} else if h.Type == i.typ {
+					// getObjectType will seek in the file so we cannot use getNextObject safely
+					return i.p.objectAtOffset(int64(e.Offset), e.Hash)
+				} else {
+					if h.Type != i.typ {
+						continue
+					}
 					return i.p.getNextObject(h, e.Hash)
 				}
-
-				continue
 			}
 		}
 


### PR DESCRIPTION
In #963 I addressed issue with reading many small objects from a pack file. I originally opted not to apply the optimization to delta objects. It turns out that when traversing a commit history the tree objects are often small and delta encoded. This extends the original optimization to handle this case too. Tested on https://github.com/rails/rails repository and it improves the complete history traversal time by ~20%.