### PR TITLE
plumbing: TreeWalker performance improvement, bufio pool for objects

### DIFF
--- a/plumbing/object/commit.go
+++ b/plumbing/object/commit.go
@@ -171,7 +171,9 @@ func (c *Commit) Decode(o plumbing.EncodedObject) (err error) {
 	}
 	defer ioutil.CheckClose(reader, &err)
 
-	r := bufio.NewReader(reader)
+	r := bufPool.Get().(*bufio.Reader)
+	defer bufPool.Put(r)
+	r.Reset(reader)
 
 	var message bool
 	var pgpsig bool

--- a/plumbing/object/common.go
+++ b/plumbing/object/common.go
@@ -1,0 +1,12 @@
+package object
+
+import (
+	"bufio"
+	"sync"
+)
+
+var bufPool = sync.Pool{
+	New: func() interface{} {
+		return bufio.NewReader(nil)
+	},
+}

--- a/plumbing/object/tag.go
+++ b/plumbing/object/tag.go
@@ -93,7 +93,9 @@ func (t *Tag) Decode(o plumbing.EncodedObject) (err error) {
 	}
 	defer ioutil.CheckClose(reader, &err)
 
-	r := bufio.NewReader(reader)
+	r := bufPool.Get().(*bufio.Reader)
+	defer bufPool.Put(r)
+	r.Reset(reader)
 	for {
 		var line []byte
 		line, err = r.ReadBytes('\n')

--- a/plumbing/object/tree.go
+++ b/plumbing/object/tree.go
@@ -230,7 +230,9 @@ func (t *Tree) Decode(o plumbing.EncodedObject) (err error) {
 	}
 	defer ioutil.CheckClose(reader, &err)
 
-	r := bufio.NewReader(reader)
+	r := bufPool.Get().(*bufio.Reader)
+	defer bufPool.Put(r)
+	r.Reset(reader)
 	for {
 		str, err := r.ReadString(' ')
 		if err != nil {
@@ -383,7 +385,7 @@ func NewTreeWalker(t *Tree, recursive bool, seen map[plumbing.Hash]bool) *TreeWa
 // underlying repository will be skipped automatically. It is possible that this
 // may change in future versions.
 func (w *TreeWalker) Next() (name string, entry TreeEntry, err error) {
-	var obj Object
+	var obj *Tree
 	for {
 		current := len(w.stack) - 1
 		if current < 0 {
@@ -403,7 +405,7 @@ func (w *TreeWalker) Next() (name string, entry TreeEntry, err error) {
 			// Finished with the current tree, move back up to the parent
 			w.stack = w.stack[:current]
 			w.base, _ = path.Split(w.base)
-			w.base = path.Clean(w.base) // Remove trailing slash
+			w.base = strings.TrimSuffix(w.base, "/")
 			continue
 		}
 
@@ -419,7 +421,7 @@ func (w *TreeWalker) Next() (name string, entry TreeEntry, err error) {
 			obj, err = GetTree(w.s, entry.Hash)
 		}
 
-		name = path.Join(w.base, entry.Name)
+		name = simpleJoin(w.base, entry.Name)
 
 		if err != nil {
 			err = io.EOF
@@ -433,9 +435,9 @@ func (w *TreeWalker) Next() (name string, entry TreeEntry, err error) {
 		return
 	}
 
-	if t, ok := obj.(*Tree); ok {
-		w.stack = append(w.stack, &treeEntryIter{t, 0})
-		w.base = path.Join(w.base, entry.Name)
+	if obj != nil {
+		w.stack = append(w.stack, &treeEntryIter{obj, 0})
+		w.base = simpleJoin(w.base, entry.Name)
 	}
 
 	return
@@ -508,4 +510,11 @@ func (iter *TreeIter) ForEach(cb func(*Tree) error) error {
 
 		return cb(t)
 	})
+}
+
+func simpleJoin(parent, child string) string {
+	if len(parent) > 0 {
+		return parent + "/" + child
+	}
+	return child
 }


### PR DESCRIPTION
Removed `path.Clean` and `path.Join`, as they're expensive in comparison to basic string manipulation that can be used here.

Added bufio.Buffer pool to be used by tag, tree and commit objects.