### PR TITLE
plumbing: object/{commit,tag} add EncodeWithoutSignature, Implement #1116

### DIFF
--- a/plumbing/object/commit.go
+++ b/plumbing/object/commit.go
@@ -235,6 +235,11 @@ func (b *Commit) Encode(o plumbing.EncodedObject) error {
 	return b.encode(o, true)
 }
 
+// EncodeWithoutSignature export a Commit into a plumbing.EncodedObject without the signature (correspond to the payload of the PGP signature).
+func (b *Commit) EncodeWithoutSignature(o plumbing.EncodedObject) error {
+	return b.encode(o, false)
+}
+
 func (b *Commit) encode(o plumbing.EncodedObject, includeSig bool) (err error) {
 	o.SetType(plumbing.CommitObject)
 	w, err := o.Writer()
@@ -349,7 +354,7 @@ func (c *Commit) Verify(armoredKeyRing string) (*openpgp.Entity, error) {
 
 	encoded := &plumbing.MemoryObject{}
 	// Encode commit components, excluding signature and get a reader object.
-	if err := c.encode(encoded, false); err != nil {
+	if err := c.EncodeWithoutSignature(encoded); err != nil {
 		return nil, err
 	}
 	er, err := encoded.Reader()

--- a/plumbing/object/commit_test.go
+++ b/plumbing/object/commit_test.go
@@ -4,14 +4,15 @@ import (
 	"bytes"
 	"context"
 	"io"
+	"io/ioutil"
 	"strings"
 	"time"
 
+	fixtures "gopkg.in/src-d/go-git-fixtures.v3"
 	"gopkg.in/src-d/go-git.v4/plumbing"
 	"gopkg.in/src-d/go-git.v4/plumbing/cache"
 
 	. "gopkg.in/check.v1"
-	"gopkg.in/src-d/go-git-fixtures.v3"
 	"gopkg.in/src-d/go-git.v4/storage/filesystem"
 )
 
@@ -494,4 +495,24 @@ func (s *SuiteCommit) TestMalformedHeader(c *C) {
 
 	err = decoded.Decode(encoded)
 	c.Assert(err, IsNil)
+}
+
+func (s *SuiteCommit) TestEncodeWithoutSignature(c *C) {
+	//Similar to TestString since no signature
+	encoded := &plumbing.MemoryObject{}
+	err := s.Commit.EncodeWithoutSignature(encoded)
+	c.Assert(err, IsNil)
+	er, err := encoded.Reader()
+	c.Assert(err, IsNil)
+	payload, err := ioutil.ReadAll(er)
+	c.Assert(err, IsNil)
+
+	c.Assert(string(payload), Equals, ""+
+		"tree eba74343e2f15d62adedfd8c883ee0262b5c8021\n"+
+		"parent 35e85108805c84807bc66a02d91535e1e24b38b9\n"+
+		"parent a5b8b09e2f8fcb0bb99d3ccb0958157b40890d69\n"+
+		"author Máximo Cuadros Ortiz <mcuadros@gmail.com> 1427802494 +0200\n"+
+		"committer Máximo Cuadros Ortiz <mcuadros@gmail.com> 1427802494 +0200\n"+
+		"\n"+
+		"Merge branch 'master' of github.com:tyba/git-fixture\n")
 }

--- a/plumbing/object/tag.go
+++ b/plumbing/object/tag.go
@@ -171,6 +171,11 @@ func (t *Tag) Encode(o plumbing.EncodedObject) error {
 	return t.encode(o, true)
 }
 
+// EncodeWithoutSignature export a Tag into a plumbing.EncodedObject without the signature (correspond to the payload of the PGP signature).
+func (t *Tag) EncodeWithoutSignature(o plumbing.EncodedObject) error {
+	return t.encode(o, false)
+}
+
 func (t *Tag) encode(o plumbing.EncodedObject, includeSig bool) (err error) {
 	o.SetType(plumbing.TagObject)
 	w, err := o.Writer()
@@ -291,7 +296,7 @@ func (t *Tag) Verify(armoredKeyRing string) (*openpgp.Entity, error) {
 
 	encoded := &plumbing.MemoryObject{}
 	// Encode tag components, excluding signature and get a reader object.
-	if err := t.encode(encoded, false); err != nil {
+	if err := t.EncodeWithoutSignature(encoded); err != nil {
 		return nil, err
 	}
 	er, err := encoded.Reader()

--- a/plumbing/object/tag_test.go
+++ b/plumbing/object/tag_test.go
@@ -3,16 +3,17 @@ package object
 import (
 	"fmt"
 	"io"
+	"io/ioutil"
 	"strings"
 	"time"
 
+	fixtures "gopkg.in/src-d/go-git-fixtures.v3"
 	"gopkg.in/src-d/go-git.v4/plumbing"
 	"gopkg.in/src-d/go-git.v4/plumbing/cache"
 	"gopkg.in/src-d/go-git.v4/storage/filesystem"
 	"gopkg.in/src-d/go-git.v4/storage/memory"
 
 	. "gopkg.in/check.v1"
-	"gopkg.in/src-d/go-git-fixtures.v3"
 )
 
 type TagSuite struct {
@@ -446,4 +447,25 @@ HdzbB2ak/HxIeCqmHVlmUqa+WfTMUJcsgOm3/ZFPCSoL6l0bz9Z1XVbiyD03
 
 	_, err = tag.Verify(armoredKeyRing)
 	c.Assert(err, IsNil)
+}
+
+func (s *TagSuite) TestEncodeWithoutSignature(c *C) {
+	//Similar to TestString since no signature
+	encoded := &plumbing.MemoryObject{}
+	tag := s.tag(c, plumbing.NewHash("b742a2a9fa0afcfa9a6fad080980fbc26b007c69"))
+	err := tag.EncodeWithoutSignature(encoded)
+	c.Assert(err, IsNil)
+	er, err := encoded.Reader()
+	c.Assert(err, IsNil)
+	payload, err := ioutil.ReadAll(er)
+	c.Assert(err, IsNil)
+
+	c.Assert(string(payload), Equals, ""+
+		"object f7b877701fbf855b44c0a9e86f3fdce2c298b07f\n"+
+		"type commit\n"+
+		"tag annotated-tag\n"+
+		"tagger Máximo Cuadros <mcuadros@gmail.com> 1474485215 +0200\n"+
+		"\n"+
+		"example annotated tag\n",
+	)
 }


### PR DESCRIPTION
Expose the PGP payload of commits and tags like discussed in #1116.


Signed-off-by: Antoine GIRARD <sapk@sapk.fr>