### PR TITLE
plumbing: format/commitgraph, rename structs/fields to follow the terms used by git more closely

### DIFF
--- a/plumbing/format/commitgraph/commitgraph.go
+++ b/plumbing/format/commitgraph/commitgraph.go
@@ -6,9 +6,9 @@ import (
 	"gopkg.in/src-d/go-git.v4/plumbing"
 )
 
-// Node is a reduced representation of Commit as presented in the commit graph
+// CommitData is a reduced representation of Commit as presented in the commit graph
 // file. It is merely useful as an optimization for walking the commit graphs.
-type Node struct {
+type CommitData struct {
 	// TreeHash is the hash of the root tree of the commit.
 	TreeHash plumbing.Hash
 	// ParentIndexes are the indexes of the parent commits of the commit.
@@ -29,7 +29,7 @@ type Index interface {
 	GetIndexByHash(h plumbing.Hash) (int, error)
 	// GetNodeByIndex gets the commit node from the commit graph using index
 	// obtained from child node, if available
-	GetNodeByIndex(i int) (*Node, error)
+	GetCommitDataByIndex(i int) (*CommitData, error)
 	// Hashes returns all the hashes that are available in the index
 	Hashes() []plumbing.Hash
 }

--- a/plumbing/format/commitgraph/commitgraph_test.go
+++ b/plumbing/format/commitgraph/commitgraph_test.go
@@ -32,40 +32,40 @@ func testDecodeHelper(c *C, path string) {
 	// Root commit
 	nodeIndex, err := index.GetIndexByHash(plumbing.NewHash("347c91919944a68e9413581a1bc15519550a3afe"))
 	c.Assert(err, IsNil)
-	node, err := index.GetNodeByIndex(nodeIndex)
+	commitData, err := index.GetCommitDataByIndex(nodeIndex)
 	c.Assert(err, IsNil)
-	c.Assert(len(node.ParentIndexes), Equals, 0)
-	c.Assert(len(node.ParentHashes), Equals, 0)
+	c.Assert(len(commitData.ParentIndexes), Equals, 0)
+	c.Assert(len(commitData.ParentHashes), Equals, 0)
 
 	// Regular commit
 	nodeIndex, err = index.GetIndexByHash(plumbing.NewHash("e713b52d7e13807e87a002e812041f248db3f643"))
 	c.Assert(err, IsNil)
-	node, err = index.GetNodeByIndex(nodeIndex)
+	commitData, err = index.GetCommitDataByIndex(nodeIndex)
 	c.Assert(err, IsNil)
-	c.Assert(len(node.ParentIndexes), Equals, 1)
-	c.Assert(len(node.ParentHashes), Equals, 1)
-	c.Assert(node.ParentHashes[0].String(), Equals, "347c91919944a68e9413581a1bc15519550a3afe")
+	c.Assert(len(commitData.ParentIndexes), Equals, 1)
+	c.Assert(len(commitData.ParentHashes), Equals, 1)
+	c.Assert(commitData.ParentHashes[0].String(), Equals, "347c91919944a68e9413581a1bc15519550a3afe")
 
 	// Merge commit
 	nodeIndex, err = index.GetIndexByHash(plumbing.NewHash("b29328491a0682c259bcce28741eac71f3499f7d"))
 	c.Assert(err, IsNil)
-	node, err = index.GetNodeByIndex(nodeIndex)
+	commitData, err = index.GetCommitDataByIndex(nodeIndex)
 	c.Assert(err, IsNil)
-	c.Assert(len(node.ParentIndexes), Equals, 2)
-	c.Assert(len(node.ParentHashes), Equals, 2)
-	c.Assert(node.ParentHashes[0].String(), Equals, "e713b52d7e13807e87a002e812041f248db3f643")
-	c.Assert(node.ParentHashes[1].String(), Equals, "03d2c021ff68954cf3ef0a36825e194a4b98f981")
+	c.Assert(len(commitData.ParentIndexes), Equals, 2)
+	c.Assert(len(commitData.ParentHashes), Equals, 2)
+	c.Assert(commitData.ParentHashes[0].String(), Equals, "e713b52d7e13807e87a002e812041f248db3f643")
+	c.Assert(commitData.ParentHashes[1].String(), Equals, "03d2c021ff68954cf3ef0a36825e194a4b98f981")
 
 	// Octopus merge commit
 	nodeIndex, err = index.GetIndexByHash(plumbing.NewHash("6f6c5d2be7852c782be1dd13e36496dd7ad39560"))
 	c.Assert(err, IsNil)
-	node, err = index.GetNodeByIndex(nodeIndex)
+	commitData, err = index.GetCommitDataByIndex(nodeIndex)
 	c.Assert(err, IsNil)
-	c.Assert(len(node.ParentIndexes), Equals, 3)
-	c.Assert(len(node.ParentHashes), Equals, 3)
-	c.Assert(node.ParentHashes[0].String(), Equals, "ce275064ad67d51e99f026084e20827901a8361c")
-	c.Assert(node.ParentHashes[1].String(), Equals, "bb13916df33ed23004c3ce9ed3b8487528e655c1")
-	c.Assert(node.ParentHashes[2].String(), Equals, "a45273fe2d63300e1962a9e26a6b15c276cd7082")
+	c.Assert(len(commitData.ParentIndexes), Equals, 3)
+	c.Assert(len(commitData.ParentHashes), Equals, 3)
+	c.Assert(commitData.ParentHashes[0].String(), Equals, "ce275064ad67d51e99f026084e20827901a8361c")
+	c.Assert(commitData.ParentHashes[1].String(), Equals, "bb13916df33ed23004c3ce9ed3b8487528e655c1")
+	c.Assert(commitData.ParentHashes[2].String(), Equals, "a45273fe2d63300e1962a9e26a6b15c276cd7082")
 
 	// Check all hashes
 	hashes := index.Hashes()
@@ -114,9 +114,9 @@ func (s *CommitgraphSuite) TestReencodeInMemory(c *C) {
 		c.Assert(err, IsNil)
 		memoryIndex := commitgraph.NewMemoryIndex()
 		for i, hash := range index.Hashes() {
-			node, err := index.GetNodeByIndex(i)
+			commitData, err := index.GetCommitDataByIndex(i)
 			c.Assert(err, IsNil)
-			memoryIndex.Add(hash, node)
+			memoryIndex.Add(hash, commitData)
 		}
 		reader.Close()
 

--- a/plumbing/format/commitgraph/commitgraph_test.go
+++ b/plumbing/format/commitgraph/commitgraph_test.go
@@ -116,8 +116,7 @@ func (s *CommitgraphSuite) TestReencodeInMemory(c *C) {
 		for i, hash := range index.Hashes() {
 			node, err := index.GetNodeByIndex(i)
 			c.Assert(err, IsNil)
-			err = memoryIndex.Add(hash, node)
-			c.Assert(err, IsNil)
+			memoryIndex.Add(hash, node)
 		}
 		reader.Close()
 

--- a/plumbing/format/commitgraph/file.go
+++ b/plumbing/format/commitgraph/file.go
@@ -14,11 +14,11 @@ import (
 var (
 	// ErrUnsupportedVersion is returned by OpenFileIndex when the commit graph
 	// file version is not supported.
-	ErrUnsupportedVersion = errors.New("Unsuported version")
+	ErrUnsupportedVersion = errors.New("Unsupported version")
 	// ErrUnsupportedHash is returned by OpenFileIndex when the commit graph
 	// hash function is not supported. Currently only SHA-1 is defined and
 	// supported
-	ErrUnsupportedHash = errors.New("Unsuported hash algorithm")
+	ErrUnsupportedHash = errors.New("Unsupported hash algorithm")
 	// ErrMalformedCommitGraphFile is returned by OpenFileIndex when the commit
 	// graph file is corrupted.
 	ErrMalformedCommitGraphFile = errors.New("Malformed commit graph file")

--- a/plumbing/format/commitgraph/memory.go
+++ b/plumbing/format/commitgraph/memory.go
@@ -60,12 +60,11 @@ func (mi *MemoryIndex) Hashes() []plumbing.Hash {
 }
 
 // Add adds new node to the memory index
-func (mi *MemoryIndex) Add(hash plumbing.Hash, node *Node) error {
+func (mi *MemoryIndex) Add(hash plumbing.Hash, node *Node) {
 	// The parent indexes are calculated lazily in GetNodeByIndex
 	// which allows adding nodes out of order as long as all parents
 	// are eventually resolved
 	node.ParentIndexes = nil
 	mi.indexMap[hash] = len(mi.commitData)
 	mi.commitData = append(mi.commitData, node)
-	return nil
 }

--- a/plumbing/format/commitgraph/memory.go
+++ b/plumbing/format/commitgraph/memory.go
@@ -5,7 +5,7 @@ import (
 )
 
 type MemoryIndex struct {
-	commitData []*Node
+	commitData []*CommitData
 	indexMap   map[plumbing.Hash]int
 }
 
@@ -26,28 +26,28 @@ func (mi *MemoryIndex) GetIndexByHash(h plumbing.Hash) (int, error) {
 	return 0, plumbing.ErrObjectNotFound
 }
 
-// GetNodeByIndex gets the commit node from the commit graph using index
+// GetCommitDataByIndex gets the commit node from the commit graph using index
 // obtained from child node, if available
-func (mi *MemoryIndex) GetNodeByIndex(i int) (*Node, error) {
+func (mi *MemoryIndex) GetCommitDataByIndex(i int) (*CommitData, error) {
 	if int(i) >= len(mi.commitData) {
 		return nil, plumbing.ErrObjectNotFound
 	}
 
-	node := mi.commitData[i]
+	commitData := mi.commitData[i]
 
 	// Map parent hashes to parent indexes
-	if node.ParentIndexes == nil {
-		parentIndexes := make([]int, len(node.ParentHashes))
-		for i, parentHash := range node.ParentHashes {
+	if commitData.ParentIndexes == nil {
+		parentIndexes := make([]int, len(commitData.ParentHashes))
+		for i, parentHash := range commitData.ParentHashes {
 			var err error
 			if parentIndexes[i], err = mi.GetIndexByHash(parentHash); err != nil {
 				return nil, err
 			}
 		}
-		node.ParentIndexes = parentIndexes
+		commitData.ParentIndexes = parentIndexes
 	}
 
-	return node, nil
+	return commitData, nil
 }
 
 // Hashes returns all the hashes that are available in the index
@@ -60,11 +60,11 @@ func (mi *MemoryIndex) Hashes() []plumbing.Hash {
 }
 
 // Add adds new node to the memory index
-func (mi *MemoryIndex) Add(hash plumbing.Hash, node *Node) {
+func (mi *MemoryIndex) Add(hash plumbing.Hash, commitData *CommitData) {
 	// The parent indexes are calculated lazily in GetNodeByIndex
 	// which allows adding nodes out of order as long as all parents
 	// are eventually resolved
-	node.ParentIndexes = nil
+	commitData.ParentIndexes = nil
 	mi.indexMap[hash] = len(mi.commitData)
-	mi.commitData = append(mi.commitData, node)
+	mi.commitData = append(mi.commitData, commitData)
 }


### PR DESCRIPTION
Follows #1128 and #1133 (included now, will rebase). Conflicts with #1132 (will rebase/update depending on whichever one gets in first).

This introduces two changes:
- Renames `Node` to `CommitData`, which is the actual name in the [git documentation](https://github.com/git/git/blob/14c0f8d3ab6c36672189cd2dd217f4617d12ccba/Documentation/technical/commit-graph-format.txt#L73-L85). Since it's anticipated that more data will eventually be added to the format in form of new chunks it seems like a good idea to name the data structures after the chunks.
- Renames all occurrences of `large edges` to `extra edges` to follow [git change](https://github.com/git/git/commit/5af7417bd869d935715a56b2ccdee04d3a79a328). This is restricted purely to the private functions and has no effect on the exported API.

It is anticipated that [commit-graph format v2](https://public-inbox.org/git/pull.112.git.gitgitgadget@gmail.com/) will land in git soon. I'll submit another PR to add support for it (to be merged once the change lands to git).