### PR TITLE
worktree: Set local user config for reproducible testing

### DIFF
--- a/worktree_test.go
+++ b/worktree_test.go
@@ -248,6 +248,8 @@ func (s *RepositorySuite) TestPullAdd(c *C) {
 	ExecuteOnPath(c, path,
 		"touch foo",
 		"git add foo",
+                "git config user.email foo@example.com",
+                "git config user.name foo",
 		"git commit -m foo foo",
 	)
 


### PR DESCRIPTION
The test goes fail with git exit status 128 while committing when git config is not set globally or locally.

This patch sets dummy local git config before committing, for testing.

Fixes #1138