### PR TITLE
Support the 'rebase' config key for branches

### DIFF
--- a/config/branch.go
+++ b/config/branch.go
@@ -8,8 +8,9 @@ import (
 )
 
 var (
-	errBranchEmptyName    = errors.New("branch config: empty name")
-	errBranchInvalidMerge = errors.New("branch config: invalid merge")
+	errBranchEmptyName     = errors.New("branch config: empty name")
+	errBranchInvalidMerge  = errors.New("branch config: invalid merge")
+	errBranchInvalidRebase = errors.New("branch config: rebase must be one of 'true' or 'interactive'")
 )
 
 // Branch contains information on the
@@ -21,6 +22,10 @@ type Branch struct {
 	Remote string
 	// Merge is the local refspec for the branch
 	Merge plumbing.ReferenceName
+	// Rebase instead of merge when pulling. Valid values are
+	// "true" and "interactive".  "false" is undocumented and
+	// typically represented by the non-existence of this field
+	Rebase string
 
 	raw *format.Subsection
 }
@@ -33,6 +38,13 @@ func (b *Branch) Validate() error {
 
 	if b.Merge != "" && !b.Merge.IsBranch() {
 		return errBranchInvalidMerge
+	}
+
+	if b.Rebase != "" &&
+		b.Rebase != "true" &&
+		b.Rebase != "interactive" &&
+		b.Rebase != "false" {
+		return errBranchInvalidRebase
 	}
 
 	return nil
@@ -57,6 +69,12 @@ func (b *Branch) marshal() *format.Subsection {
 		b.raw.SetOption(mergeKey, string(b.Merge))
 	}
 
+	if b.Rebase == "" {
+		b.raw.RemoveOption(rebaseKey)
+	} else {
+		b.raw.SetOption(rebaseKey, string(b.Rebase))
+	}
+
 	return b.raw
 }
 
@@ -66,6 +84,7 @@ func (b *Branch) unmarshal(s *format.Subsection) error {
 	b.Name = b.raw.Name
 	b.Remote = b.raw.Options.Get(remoteSection)
 	b.Merge = plumbing.ReferenceName(b.raw.Options.Get(mergeKey))
+	b.Rebase = b.raw.Options.Get(rebaseKey)
 
 	return b.Validate()
 }

--- a/config/branch_test.go
+++ b/config/branch_test.go
@@ -44,6 +44,7 @@ func (b *BranchSuite) TestMarshall(c *C) {
 [branch "branch-tracking-on-clone"]
 	remote = fork
 	merge = refs/heads/branch-tracking-on-clone
+	rebase = interactive
 `)
 
 	cfg := NewConfig()
@@ -51,6 +52,7 @@ func (b *BranchSuite) TestMarshall(c *C) {
 		Name:   "branch-tracking-on-clone",
 		Remote: "fork",
 		Merge:  plumbing.ReferenceName("refs/heads/branch-tracking-on-clone"),
+		Rebase: "interactive",
 	}
 
 	actual, err := cfg.Marshal()
@@ -64,6 +66,7 @@ func (b *BranchSuite) TestUnmarshall(c *C) {
 [branch "branch-tracking-on-clone"]
 	remote = fork
 	merge = refs/heads/branch-tracking-on-clone
+	rebase = interactive
 `)
 
 	cfg := NewConfig()
@@ -73,4 +76,5 @@ func (b *BranchSuite) TestUnmarshall(c *C) {
 	c.Assert(branch.Name, Equals, "branch-tracking-on-clone")
 	c.Assert(branch.Remote, Equals, "fork")
 	c.Assert(branch.Merge, Equals, plumbing.ReferenceName("refs/heads/branch-tracking-on-clone"))
+	c.Assert(branch.Rebase, Equals, "interactive")
 }

--- a/config/config.go
+++ b/config/config.go
@@ -120,6 +120,7 @@ const (
 	commentCharKey   = "commentChar"
 	windowKey        = "window"
 	mergeKey         = "merge"
+	rebaseKey        = "rebase"
 
 	// DefaultPackWindow holds the number of previous objects used to
 	// generate deltas. The value 10 is the same used by git command.


### PR DESCRIPTION
We are using `go-git` in a command line client that provides some abstractions on top of `git` workspaces to help users manage their reviews.  A key part of workflow management here is correctly pointing upstreams to local or remote branches, and causing pulls to issue rebases rather than merges.

The config value itself is a standard key and `git` itself will set/unset it for you sometimes during relatively normal usage.

This PR just adds support for the key.