### PR TITLE
fix wildcard handling in RefSpec matching

### DIFF
--- a/config/refspec.go
+++ b/config/refspec.go
@@ -99,11 +99,11 @@ func (s RefSpec) matchGlob(n plumbing.ReferenceName) bool {
 
 	var prefix, suffix string
 	prefix = src[0:wildcard]
-	if len(src) < wildcard {
-		suffix = src[wildcard+1 : len(suffix)]
+	if len(src) > wildcard+1 {
+		suffix = src[wildcard+1:]
 	}
 
-	return len(name) > len(prefix)+len(suffix) &&
+	return len(name) >= len(prefix)+len(suffix) &&
 		strings.HasPrefix(name, prefix) &&
 		strings.HasSuffix(name, suffix)
 }


### PR DESCRIPTION
1) The guard logic here was inverted, resulting in an always-false
   branch, which meant that the suffix after the wildcard was
   incorrectly ignored.
2) Wildcards were treated as 1-or-more matches, but git treats them as
   0-or-more. This change aligns go-git with git, but represents a bit
   of a breaking change for go-git.