### PR TITLE
use constant instead of literal string

### DIFF
--- a/worktree.go
+++ b/worktree.go
@@ -722,7 +722,7 @@ func (w *Worktree) Clean(opts *CleanOptions) error {
 
 func (w *Worktree) doClean(status Status, opts *CleanOptions, dir string, files []os.FileInfo) error {
 	for _, fi := range files {
-		if fi.Name() == ".git" {
+		if fi.Name() == GitDirName {
 			continue
 		}
 


### PR DESCRIPTION
I might be completly wrong, but shouldn't GitDirName be used here instead of ".git"? After all if someone one day tries to change this constant and make his own git fork or something, it would still work this way i think