### PR TITLE
feat: improve clone performance and reduce memory usage.

### DIFF
--- a/repository_test.go
+++ b/repository_test.go
@@ -16,6 +16,7 @@ import (
 	"golang.org/x/crypto/openpgp"
 	"golang.org/x/crypto/openpgp/armor"
 	openpgperr "golang.org/x/crypto/openpgp/errors"
+
 	"gopkg.in/src-d/go-git.v4/config"
 	"gopkg.in/src-d/go-git.v4/plumbing"
 	"gopkg.in/src-d/go-git.v4/plumbing/cache"
@@ -2669,5 +2670,24 @@ func BenchmarkObjects(b *testing.B) {
 				iter.Close()
 			}
 		})
+	}
+}
+
+func BenchmarkPlainClone(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		t, err := ioutil.TempDir("", "")
+		if err != nil {
+			b.Fatal(err)
+		}
+		_, err = PlainClone(t, false, &CloneOptions{
+			URL:   "https://github.com/knqyf263/vuln-list",
+			Depth: 1,
+		})
+		if err != nil {
+			b.Error(err)
+		}
+		b.StopTimer()
+		os.RemoveAll(t)
+		b.StartTimer()
 	}
 }

--- a/storage/filesystem/index.go
+++ b/storage/filesystem/index.go
@@ -20,8 +20,14 @@ func (s *IndexStorage) SetIndex(idx *index.Index) (err error) {
 	}
 
 	defer ioutil.CheckClose(f, &err)
+	bw := bufio.NewWriter(f)
+	defer func() {
+		if e := bw.Flush(); err == nil && e != nil {
+			err = e
+		}
+	}()
 
-	e := index.NewEncoder(f)
+	e := index.NewEncoder(bw)
 	err = e.Encode(idx)
 	return err
 }


### PR DESCRIPTION
I tried to clone `github.com/knqyf263/vuln-list`, but `PlainClone` took a too long time.
I improve clone performance and reduce memory usage!

benchstat results
```
name          old time/op    new time/op    delta
PlainClone-4      605s ± 4%      173s ± 5%  -71.42%  (p=0.008 n=5+5)

name          old alloc/op   new alloc/op   delta
PlainClone-4    64.9GB ± 0%    29.8GB ± 0%  -54.12%  (p=0.008 n=5+5)

name          old allocs/op  new allocs/op  delta
PlainClone-4      117M ± 0%      114M ± 0%   -2.50%  (p=0.008 n=5+5)
```

thanks!