### PR TITLE
Added missing error checks in tests

### DIFF
--- a/plumbing/format/packfile/scanner_test.go
+++ b/plumbing/format/packfile/scanner_test.go
@@ -140,6 +140,7 @@ func (s *ScannerSuite) TestReaderReset(c *C) {
 	p := NewScanner(r)
 
 	version, objects, err := p.Header()
+	c.Assert(err, IsNil)
 	c.Assert(version, Equals, VersionSupported)
 	c.Assert(objects, Equals, uint32(31))
 

--- a/plumbing/object/patch_test.go
+++ b/plumbing/object/patch_test.go
@@ -19,6 +19,7 @@ func (s *PatchSuite) TestStatsWithSubmodules(c *C) {
 		fixtures.ByURL("https://github.com/git-fixtures/submodule.git").One().DotGit(), cache.NewObjectLRUDefault())
 
 	commit, err := GetCommit(storer, plumbing.NewHash("b685400c1f9316f350965a5993d350bc746b0bf4"))
+	c.Assert(err, IsNil)
 
 	tree, err := commit.Tree()
 	c.Assert(err, IsNil)

--- a/prune_test.go
+++ b/prune_test.go
@@ -56,6 +56,8 @@ func (s *PruneSuite) testPrune(c *C, deleteTime time.Time) {
 		newCount++
 		return nil
 	})
+	c.Assert(err, IsNil)
+
 	if deleteTime.IsZero() {
 		c.Assert(newCount < count, Equals, true)
 	} else {

--- a/repository_test.go
+++ b/repository_test.go
@@ -335,12 +335,14 @@ func (s *RepositorySuite) TestCreateBranchUnmarshal(c *C) {
 		Merge:  "refs/heads/foo",
 	}
 	err = r.CreateBranch(testBranch1)
-	err = r.CreateBranch(testBranch2)
-
 	c.Assert(err, IsNil)
+	err = r.CreateBranch(testBranch2)
+	c.Assert(err, IsNil)
+
 	cfg, err := r.Config()
 	c.Assert(err, IsNil)
 	marshaled, err := cfg.Marshal()
+	c.Assert(err, IsNil)
 	c.Assert(string(expected), Equals, string(marshaled))
 }
 

--- a/storage/filesystem/dotgit/dotgit_test.go
+++ b/storage/filesystem/dotgit/dotgit_test.go
@@ -226,6 +226,7 @@ func (s *SuiteDotGit) TestRemoveRefFromReferenceFileAndPackedRefs(c *C) {
 		"refs/remotes/origin/branch",
 		"e8d3ffab552895c19b9fcf7aa264d277cde33881",
 	), nil)
+	c.Assert(err, IsNil)
 
 	// Make sure it only appears once in the refs list.
 	refs, err := dir.Refs()

--- a/worktree_commit_test.go
+++ b/worktree_commit_test.go
@@ -210,7 +210,7 @@ func (s *WorktreeSuite) TestCommitTreeSort(c *C) {
 	r, err := Init(st, nil)
 	c.Assert(err, IsNil)
 
-	r, err = Clone(memory.NewStorage(), memfs.New(), &CloneOptions{
+	r, _ = Clone(memory.NewStorage(), memfs.New(), &CloneOptions{
 		URL: path,
 	})
 

--- a/worktree_test.go
+++ b/worktree_test.go
@@ -1675,6 +1675,7 @@ func (s *WorktreeSuite) TestClean(c *C) {
 
 	// Status before cleaning.
 	status, err := wt.Status()
+	c.Assert(err, IsNil)
 	c.Assert(len(status), Equals, 2)
 
 	err = wt.Clean(&CleanOptions{})


### PR DESCRIPTION
When we assign a value to err, make sure to also check for it being nil
afterwards. If those were intentionally unchecked, we should remove the
assignment in the first place. Those checks certainly never harm, but please
review thoroughly and let me know.