### PR TITLE
Don't assign err from ForEach loop

### DIFF
--- a/plumbing/object/merge_base.go
+++ b/plumbing/object/merge_base.go
@@ -32,7 +32,7 @@ func (c *Commit) MergeBase(other *Commit) ([]*Commit, error) {
 	var res []*Commit
 	inNewerHistory := isInIndexCommitFilter(newerHistory)
 	resIter := NewFilterCommitIter(older, &inNewerHistory, &inNewerHistory)
-	err = resIter.ForEach(func(commit *Commit) error {
+	_ = resIter.ForEach(func(commit *Commit) error {
 		res = append(res, commit)
 		return nil
 	})


### PR DESCRIPTION
Since we don't check the value anyway, as it can't possibly be anything but nil.