### PR TITLE
worktree: force convert to int64 to support 32bit os. Fix #1202

### DIFF
--- a/worktree_linux.go
+++ b/worktree_linux.go
@@ -12,7 +12,7 @@ import (
 func init() {
 	fillSystemInfo = func(e *index.Entry, sys interface{}) {
 		if os, ok := sys.(*syscall.Stat_t); ok {
-			e.CreatedAt = time.Unix(os.Ctim.Sec, os.Ctim.Nsec)
+			e.CreatedAt = time.Unix(int64(os.Ctim.Sec), int64(os.Ctim.Nsec))
 			e.Dev = uint32(os.Dev)
 			e.Inode = uint32(os.Ino)
 			e.GID = os.Gid


### PR DESCRIPTION
Fix #1202

~Still WIP, since I am currently setting up things to valid the gitea crossbuild with this fix.~