### PR TITLE
Handle EOF error in commitFileIter.ForEach

### DIFF
--- a/plumbing/object/commit_walker_file.go
+++ b/plumbing/object/commit_walker_file.go
@@ -128,7 +128,9 @@ func isParentHash(hash plumbing.Hash, commit *Commit) bool {
 func (c *commitFileIter) ForEach(cb func(*Commit) error) error {
 	for {
 		commit, nextErr := c.Next()
-		if nextErr != nil {
+		if nextErr == io.EOF {
+			break
+		} else if nextErr != nil {
 			return nextErr
 		}
 		err := cb(commit)
@@ -138,6 +140,7 @@ func (c *commitFileIter) ForEach(cb func(*Commit) error) error {
 			return err
 		}
 	}
+	return nil
 }
 
 func (c *commitFileIter) Close() {

--- a/plumbing/object/commit_walker_file.go
+++ b/plumbing/object/commit_walker_file.go
@@ -130,7 +130,8 @@ func (c *commitFileIter) ForEach(cb func(*Commit) error) error {
 		commit, nextErr := c.Next()
 		if nextErr == io.EOF {
 			break
-		} else if nextErr != nil {
+		}
+		if nextErr != nil {
 			return nextErr
 		}
 		err := cb(commit)

--- a/repository_test.go
+++ b/repository_test.go
@@ -13,7 +13,6 @@ import (
 	"testing"
 	"time"
 
-	fixtures "gopkg.in/src-d/go-git-fixtures.v3"
 
 	"golang.org/x/crypto/openpgp"
 	"golang.org/x/crypto/openpgp/armor"
@@ -33,6 +32,7 @@ import (
 	"gopkg.in/src-d/go-billy.v4/memfs"
 	"gopkg.in/src-d/go-billy.v4/osfs"
 	"gopkg.in/src-d/go-billy.v4/util"
+	"gopkg.in/src-d/go-git-fixtures.v3"
 )
 
 type RepositorySuite struct {

--- a/repository_test.go
+++ b/repository_test.go
@@ -13,6 +13,8 @@ import (
 	"testing"
 	"time"
 
+	fixtures "gopkg.in/src-d/go-git-fixtures.v3"
+
 	"golang.org/x/crypto/openpgp"
 	"golang.org/x/crypto/openpgp/armor"
 	openpgperr "golang.org/x/crypto/openpgp/errors"
@@ -31,7 +33,6 @@ import (
 	"gopkg.in/src-d/go-billy.v4/memfs"
 	"gopkg.in/src-d/go-billy.v4/osfs"
 	"gopkg.in/src-d/go-billy.v4/util"
-	"gopkg.in/src-d/go-git-fixtures.v3"
 )
 
 type RepositorySuite struct {
@@ -1507,12 +1508,13 @@ func (s *RepositorySuite) TestLogFileForEach(c *C) {
 	}
 
 	expectedIndex := 0
-	cIter.ForEach(func(commit *object.Commit) error {
+	err = cIter.ForEach(func(commit *object.Commit) error {
 		expectedCommitHash := commitOrder[expectedIndex]
 		c.Assert(commit.Hash.String(), Equals, expectedCommitHash.String())
 		expectedIndex++
 		return nil
 	})
+	c.Assert(err, IsNil)
 	c.Assert(expectedIndex, Equals, 1)
 }
 
@@ -1551,12 +1553,13 @@ func (s *RepositorySuite) TestLogAllFileForEach(c *C) {
 	}
 
 	expectedIndex := 0
-	cIter.ForEach(func(commit *object.Commit) error {
+	err = cIter.ForEach(func(commit *object.Commit) error {
 		expectedCommitHash := commitOrder[expectedIndex]
 		c.Assert(commit.Hash.String(), Equals, expectedCommitHash.String())
 		expectedIndex++
 		return nil
 	})
+	c.Assert(err, IsNil)
 	c.Assert(expectedIndex, Equals, 1)
 }
 
@@ -1598,12 +1601,13 @@ func (s *RepositorySuite) TestLogFileInitialCommit(c *C) {
 	}
 
 	expectedIndex := 0
-	cIter.ForEach(func(commit *object.Commit) error {
+	err = cIter.ForEach(func(commit *object.Commit) error {
 		expectedCommitHash := commitOrder[expectedIndex]
 		c.Assert(commit.Hash.String(), Equals, expectedCommitHash.String())
 		expectedIndex++
 		return nil
 	})
+	c.Assert(err, IsNil)
 	c.Assert(expectedIndex, Equals, 1)
 }
 


### PR DESCRIPTION
`commitFileIter.ForEach` always returns io.EOF error, so the first commit in this PR fails. 
The second commit fixes this problem by handling io.EOF.