### PR TITLE
Repository.Log: add limiting options to LogOptions

### DIFF
--- a/_examples/log/main.go
+++ b/_examples/log/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"time"
 
 	"gopkg.in/src-d/go-git.v4"
 	. "gopkg.in/src-d/go-git.v4/_examples"
@@ -31,7 +32,9 @@ func main() {
 	CheckIfError(err)
 
 	// ... retrieves the commit history
-	cIter, err := r.Log(&git.LogOptions{From: ref.Hash()})
+	since := time.Date(2019, 1, 1, 0, 0, 0, 0, time.UTC)
+	until := time.Date(2019, 7, 30, 0, 0, 0, 0, time.UTC)
+	cIter, err := r.Log(&git.LogOptions{From: ref.Hash(), Since: &since, Until: &until})
 	CheckIfError(err)
 
 	// ... just iterates over the commits, printing it

--- a/options.go
+++ b/options.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"regexp"
 	"strings"
+	"time"
 
 	"golang.org/x/crypto/openpgp"
 	"gopkg.in/src-d/go-git.v4/config"
@@ -348,6 +349,14 @@ type LogOptions struct {
 	// It is equivalent to running `git log --all`.
 	// If set on true, the From option will be ignored.
 	All bool
+
+	// Show commits more recent than a specific date.
+	// It is equivalent to running `git log --since <date>` or `git log --after <date>`.
+	Since *time.Time
+
+	// Show commits older than a specific date.
+	// It is equivalent to running `git log --until <date>` or `git log --before <date>`.
+	Until *time.Time
 }
 
 var (

--- a/plumbing/object/commit_walker_limit.go
+++ b/plumbing/object/commit_walker_limit.go
@@ -1,0 +1,65 @@
+package object
+
+import (
+	"io"
+	"time"
+
+	"gopkg.in/src-d/go-git.v4/plumbing/storer"
+)
+
+type commitLimitIter struct {
+	sourceIter   CommitIter
+	limitOptions LogLimitOptions
+}
+
+type LogLimitOptions struct {
+	Since *time.Time
+	Until *time.Time
+}
+
+func NewCommitLimitIterFromIter(commitIter CommitIter, limitOptions LogLimitOptions) CommitIter {
+	iterator := new(commitLimitIter)
+	iterator.sourceIter = commitIter
+	iterator.limitOptions = limitOptions
+	return iterator
+}
+
+func (c *commitLimitIter) Next() (*Commit, error) {
+	for {
+		commit, err := c.sourceIter.Next()
+		if err != nil {
+			return nil, err
+		}
+
+		if c.limitOptions.Since != nil && commit.Committer.When.Before(*c.limitOptions.Since) {
+			continue
+		}
+		if c.limitOptions.Until != nil && commit.Committer.When.After(*c.limitOptions.Until) {
+			continue
+		}
+		return commit, nil
+	}
+}
+
+func (c *commitLimitIter) ForEach(cb func(*Commit) error) error {
+	for {
+		commit, nextErr := c.Next()
+		if nextErr == io.EOF {
+			break
+		}
+		if nextErr != nil {
+			return nextErr
+		}
+		err := cb(commit)
+		if err == storer.ErrStop {
+			return nil
+		} else if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (c *commitLimitIter) Close() {
+	c.sourceIter.Close()
+}

--- a/repository.go
+++ b/repository.go
@@ -1068,6 +1068,11 @@ func (r *Repository) Log(o *LogOptions) (object.CommitIter, error) {
 		it = r.logWithFile(*o.FileName, it, o.All)
 	}
 
+	if o.Since != nil || o.Until != nil {
+		limitOptions := object.LogLimitOptions{Since: o.Since, Until: o.Until}
+		it = r.logWithLimit(it, limitOptions)
+	}
+
 	return it, nil
 }
 
@@ -1095,6 +1100,10 @@ func (r *Repository) logAll(commitIterFunc func(*object.Commit) object.CommitIte
 
 func (*Repository) logWithFile(fileName string, commitIter object.CommitIter, checkParent bool) object.CommitIter {
 	return object.NewCommitFileIterFromIter(fileName, commitIter, checkParent)
+}
+
+func (*Repository) logWithLimit(commitIter object.CommitIter, limitOptions object.LogLimitOptions) object.CommitIter {
+	return object.NewCommitLimitIterFromIter(commitIter, limitOptions)
 }
 
 func commitIterFunc(order LogOrder) func(c *object.Commit) object.CommitIter {


### PR DESCRIPTION
Add commit limiting options.
It is equivalent to running `git log --since <date>` or `git log --until <date>`.

In the future, I want to add the other limiting options.
e.g. git log --author <pattern> or git log --merges.