### PR TITLE
Add numeric username support for SSH urls.

### DIFF
--- a/internal/url/url.go
+++ b/internal/url/url.go
@@ -6,7 +6,7 @@ import (
 
 var (
 	isSchemeRegExp   = regexp.MustCompile(`^[^:]+://`)
-	scpLikeUrlRegExp = regexp.MustCompile(`^(?:(?P<user>[^@]+)@)?(?P<host>[^:\s]+):(?:(?P<port>[0-9]{1,5})/)?(?P<path>[^\\].*)$`)
+	scpLikeUrlRegExp = regexp.MustCompile(`^(?:(?P<user>[^@]+)@)?(?P<host>[^:\s]+):(?:(?P<port>[0-9]{1,5})(?:\/|:))?(?P<path>[^\\].*\/[^\\].*)$`)
 )
 
 // MatchesScheme returns true if the given string matches a URL-like

--- a/internal/url/url_test.go
+++ b/internal/url/url_test.go
@@ -1,0 +1,50 @@
+package url
+
+import (
+	"testing"
+)
+
+func TestMatchesScpLike(t *testing.T) {
+	examples := []string{
+		"git@github.com:james/bond",
+		"git@github.com:007/bond",
+		"git@github.com:22:james/bond",
+		"git@github.com:22:007/bond",
+	}
+
+	for _, url := range examples {
+		if !MatchesScpLike(url) {
+			t.Fatalf("repo url %q did not match ScpLike", url)
+		}
+	}
+}
+
+func TestFindScpLikeComponents(t *testing.T) {
+	url := "git@github.com:james/bond"
+	user, host, port, path := FindScpLikeComponents(url)
+
+	if user != "git" || host != "github.com" || port != "" || path != "james/bond" {
+		t.Fatalf("repo url %q did not match properly", user)
+	}
+
+	url = "git@github.com:007/bond"
+	user, host, port, path = FindScpLikeComponents(url)
+
+	if user != "git" || host != "github.com" || port != "" || path != "007/bond" {
+		t.Fatalf("repo url %q did not match properly", user)
+	}
+
+	url = "git@github.com:22:james/bond"
+	user, host, port, path = FindScpLikeComponents(url)
+
+	if user != "git" || host != "github.com" || port != "22" || path != "james/bond" {
+		t.Fatalf("repo url %q did not match properly", user)
+	}
+
+	url = "git@github.com:22:007/bond"
+	user, host, port, path = FindScpLikeComponents(url)
+
+	if user != "git" || host != "github.com" || port != "22" || path != "007/bond" {
+		t.Fatalf("repo url %q did not match properly", user)
+	}
+}

--- a/internal/url/url_test.go
+++ b/internal/url/url_test.go
@@ -2,9 +2,17 @@ package url
 
 import (
 	"testing"
+
+	. "gopkg.in/check.v1"
 )
 
-func TestMatchesScpLike(t *testing.T) {
+func Test(t *testing.T) { TestingT(t) }
+
+type URLSuite struct{}
+
+var _ = Suite(&URLSuite{})
+
+func (s *URLSuite) TestMatchesScpLike(c *C) {
 	examples := []string{
 		"git@github.com:james/bond",
 		"git@github.com:007/bond",
@@ -13,38 +21,40 @@ func TestMatchesScpLike(t *testing.T) {
 	}
 
 	for _, url := range examples {
-		if !MatchesScpLike(url) {
-			t.Fatalf("repo url %q did not match ScpLike", url)
-		}
+		c.Check(MatchesScpLike(url), Equals, true)
 	}
 }
 
-func TestFindScpLikeComponents(t *testing.T) {
+func (s *URLSuite) TestFindScpLikeComponents(c *C) {
 	url := "git@github.com:james/bond"
 	user, host, port, path := FindScpLikeComponents(url)
 
-	if user != "git" || host != "github.com" || port != "" || path != "james/bond" {
-		t.Fatalf("repo url %q did not match properly", user)
-	}
+	c.Check(user, Equals, "git")
+	c.Check(host, Equals, "github.com")
+	c.Check(port, Equals, "")
+	c.Check(path, Equals, "james/bond")
 
 	url = "git@github.com:007/bond"
 	user, host, port, path = FindScpLikeComponents(url)
 
-	if user != "git" || host != "github.com" || port != "" || path != "007/bond" {
-		t.Fatalf("repo url %q did not match properly", user)
-	}
+	c.Check(user, Equals, "git")
+	c.Check(host, Equals, "github.com")
+	c.Check(port, Equals, "")
+	c.Check(path, Equals, "007/bond")
 
 	url = "git@github.com:22:james/bond"
 	user, host, port, path = FindScpLikeComponents(url)
 
-	if user != "git" || host != "github.com" || port != "22" || path != "james/bond" {
-		t.Fatalf("repo url %q did not match properly", user)
-	}
+	c.Check(user, Equals, "git")
+	c.Check(host, Equals, "github.com")
+	c.Check(port, Equals, "22")
+	c.Check(path, Equals, "james/bond")
 
 	url = "git@github.com:22:007/bond"
 	user, host, port, path = FindScpLikeComponents(url)
 
-	if user != "git" || host != "github.com" || port != "22" || path != "007/bond" {
-		t.Fatalf("repo url %q did not match properly", user)
-	}
+	c.Check(user, Equals, "git")
+	c.Check(host, Equals, "github.com")
+	c.Check(port, Equals, "22")
+	c.Check(path, Equals, "007/bond")
 }


### PR DESCRIPTION
In my attempt to use SSH I discovered my username was being **matched as the port** ... this PR modifies the regex to allow for numeric usernames.
```go
git@github.com:117/myrepo // 117 was being matched as the port 
```
This new expression matches the following even when the username in the path is numerical.
```go
git@github.com:james/example // user: git, host: github.com, path: james/example
git@github.com:007/example // user: git, host: github.com, path: 007/example
git@github.com:22:007/example // user: git, host: github.com, port: 22, path: 007/example
git@github.com:22:james/example // user: git, host: github.com, port: 22, path: james/example
```
I tried to leave as much of the old expression as possible.

Signed-off-by: Chief <admin@117.sh>