### PR TITLE
plumbing/object: avoid O(N^2) string building when decoding commit me…

### DIFF
--- a/plumbing/object/commit.go
+++ b/plumbing/object/commit.go
@@ -177,6 +177,7 @@ func (c *Commit) Decode(o plumbing.EncodedObject) (err error) {
 
 	var message bool
 	var pgpsig bool
+	var msgbuf bytes.Buffer
 	for {
 		line, err := r.ReadBytes('\n')
 		if err != nil && err != io.EOF {
@@ -221,13 +222,15 @@ func (c *Commit) Decode(o plumbing.EncodedObject) (err error) {
 				pgpsig = true
 			}
 		} else {
-			c.Message += string(line)
+			msgbuf.Write(line)
 		}
 
 		if err == io.EOF {
-			return nil
+			break
 		}
 	}
+	c.Message = msgbuf.String()
+	return nil
 }
 
 // Encode transforms a Commit into a plumbing.EncodedObject.


### PR DESCRIPTION
…ssage

Most commits have relatively small messages, so this was never
noticeable. However, there are some repositories that have
semi-automated messages that can get very large (e.g.
github.com/riscv/riscv-clang and its riscv-trunk branch), on the order
of 109k lines. Changing from string += to using a bytes.Buffer reduces
the time for Commit.Decode for that specific case from 35s to 74ms.

Signed-off-by: David Symonds <dsymonds@golang.org>