### PR TITLE
add `PathFilter func(string) bool` to LogOptions, #562

### DIFF
--- a/options.go
+++ b/options.go
@@ -343,7 +343,14 @@ type LogOptions struct {
 
 	// Show only those commits in which the specified file was inserted/updated.
 	// It is equivalent to running `git log -- <file-name>`.
+	// this field is kept for compatility, it can be replaced with PathFilter
 	FileName *string
+
+	// Filter commits based on the path of files that are updated
+	// takes file path as argument and should return true if the file is desired
+	// It can be used to implement `git log -- <path>`
+	// either <path> is a file path, or directory path, or a regexp of file/directory path
+	PathFilter func(string) bool
 
 	// Pretend as if all the refs in refs/, along with HEAD, are listed on the command line as <commit>.
 	// It is equivalent to running `git log --all`.

--- a/repository.go
+++ b/repository.go
@@ -1099,7 +1099,13 @@ func (r *Repository) logAll(commitIterFunc func(*object.Commit) object.CommitIte
 }
 
 func (*Repository) logWithFile(fileName string, commitIter object.CommitIter, checkParent bool) object.CommitIter {
-	return object.NewCommitFileIterFromIter(fileName, commitIter, checkParent)
+	return object.NewCommitPathIterFromIter(
+		func(path string) bool {
+			return path == fileName
+		},
+		commitIter,
+		checkParent,
+	)
 }
 
 func (*Repository) logWithLimit(commitIter object.CommitIter, limitOptions object.LogLimitOptions) object.CommitIter {

--- a/repository.go
+++ b/repository.go
@@ -1067,6 +1067,9 @@ func (r *Repository) Log(o *LogOptions) (object.CommitIter, error) {
 		// for `git log --all` also check parent (if the next commit comes from the real parent)
 		it = r.logWithFile(*o.FileName, it, o.All)
 	}
+	if o.PathFilter != nil {
+		it = r.logWithPathFilter(o.PathFilter, it, o.All)
+	}
 
 	if o.Since != nil || o.Until != nil {
 		limitOptions := object.LogLimitOptions{Since: o.Since, Until: o.Until}
@@ -1103,6 +1106,14 @@ func (*Repository) logWithFile(fileName string, commitIter object.CommitIter, ch
 		func(path string) bool {
 			return path == fileName
 		},
+		commitIter,
+		checkParent,
+	)
+}
+
+func (*Repository) logWithPathFilter(pathFilter func(string) bool, commitIter object.CommitIter, checkParent bool) object.CommitIter {
+	return object.NewCommitPathIterFromIter(
+		pathFilter,
 		commitIter,
 		checkParent,
 	)

--- a/repository_test.go
+++ b/repository_test.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"testing"
 	"time"
@@ -1669,6 +1670,20 @@ func (s *RepositorySuite) TestLogFileWithError(c *C) {
 	fileName := "README"
 	pathIter := func(path string) bool {
 		return path == fileName
+	}
+	cIter := object.NewCommitPathIterFromIter(pathIter, &mockErrCommitIter{}, false)
+	defer cIter.Close()
+
+	err := cIter.ForEach(func(commit *object.Commit) error {
+		return nil
+	})
+	c.Assert(err, NotNil)
+}
+
+func (s *RepositorySuite) TestLogPathRegexpWithError(c *C) {
+	pathRE := regexp.MustCompile("R.*E")
+	pathIter := func(path string) bool {
+		return pathRE.MatchString(path)
 	}
 	cIter := object.NewCommitPathIterFromIter(pathIter, &mockErrCommitIter{}, false)
 	defer cIter.Close()

--- a/repository_test.go
+++ b/repository_test.go
@@ -1668,6 +1668,17 @@ func (m *mockErrCommitIter) Close() {}
 
 func (s *RepositorySuite) TestLogFileWithError(c *C) {
 	fileName := "README"
+	cIter := object.NewCommitFileIterFromIter(fileName, &mockErrCommitIter{}, false)
+	defer cIter.Close()
+
+	err := cIter.ForEach(func(commit *object.Commit) error {
+		return nil
+	})
+	c.Assert(err, NotNil)
+}
+
+func (s *RepositorySuite) TestLogPathWithError(c *C) {
+	fileName := "README"
 	pathIter := func(path string) bool {
 		return path == fileName
 	}

--- a/repository_test.go
+++ b/repository_test.go
@@ -1667,7 +1667,10 @@ func (m *mockErrCommitIter) Close() {}
 
 func (s *RepositorySuite) TestLogFileWithError(c *C) {
 	fileName := "README"
-	cIter := object.NewCommitFileIterFromIter(fileName, &mockErrCommitIter{}, false)
+	pathIter := func(path string) bool {
+		return path == fileName
+	}
+	cIter := object.NewCommitPathIterFromIter(pathIter, &mockErrCommitIter{}, false)
 	defer cIter.Close()
 
 	err := cIter.ForEach(func(commit *object.Commit) error {
@@ -2615,9 +2618,9 @@ func (s *RepositorySuite) TestResolveRevisionWithErrors(c *C) {
 	c.Assert(err, IsNil)
 
 	datas := map[string]string{
-		"efs/heads/master~": "reference not found",
-		"HEAD^3":            `Revision invalid : "3" found must be 0, 1 or 2 after "^"`,
-		"HEAD^{/whatever}":  `No commit message match regexp : "whatever"`,
+		"efs/heads/master~":                        "reference not found",
+		"HEAD^3":                                   `Revision invalid : "3" found must be 0, 1 or 2 after "^"`,
+		"HEAD^{/whatever}":                         `No commit message match regexp : "whatever"`,
 		"4e1243bd22c66e76c2ba9eddc1f91394e57f9f83": "reference not found",
 	}
 


### PR DESCRIPTION
This allow filtering commits based on directory path, or regexp on file path.
It should be safe to close #562 with this.

`LogOptions.FileName` and `NewCommitFileIterFromIter` are kept for compatibility.
Let me know if they should be removed.