### PR TITLE
[WIP] Use the user and port specified in the ~/.ssh/config

### DIFF
--- a/plumbing/transport/common.go
+++ b/plumbing/transport/common.go
@@ -232,7 +232,7 @@ func parseSCPLike(endpoint string) (*Endpoint, bool) {
 	user, host, portStr, path := giturl.FindScpLikeComponents(endpoint)
 	port, err := strconv.Atoi(portStr)
 	if err != nil {
-		port = 22
+		port = 0
 	}
 
 	return &Endpoint{

--- a/plumbing/transport/common_test.go
+++ b/plumbing/transport/common_test.go
@@ -90,7 +90,7 @@ func (s *SuiteCommon) TestNewEndpointSCPLike(c *C) {
 	c.Assert(e.User, Equals, "git")
 	c.Assert(e.Password, Equals, "")
 	c.Assert(e.Host, Equals, "github.com")
-	c.Assert(e.Port, Equals, 22)
+	c.Assert(e.Port, Equals, 0)
 	c.Assert(e.Path, Equals, "user/repository.git")
 	c.Assert(e.String(), Equals, "ssh://git@github.com/user/repository.git")
 }


### PR DESCRIPTION
The current implementation disregards of the ~/.ssh/config in most cases in favor for default values etc.
When I was trying this out against the company servers I failed to clone projects from the company server since the cloning address assumed the user and port specified in the ssh config file.

I think these changes will solve my little problem however I'm having great difficulty to use the commit as a package in my other files to try it out.
Would be very happy If anyone would like to try it out/ explain how I should go about using the local project to build my binary so I'm certain that the commit contains the correct behavior.

This is a start regarding: #1220 but I need some more guidance. 

closes #1261 

Best regards,
Signed-off-by: Måns Ansgariusson <mattemagikern@gmail.com>